### PR TITLE
Optimize the performance of CLI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,9 @@ language: python
 python:
     - "3.4"
 
-cache: pip 
+cache: pip
 
 install:
-    - pip install Cython
     - pip install -r requirements.txt
     - pip install -U pytest pytest-cov codecov
     - make install

--- a/perun/cli.py
+++ b/perun/cli.py
@@ -4,7 +4,6 @@ Simple Command Line Interface for the Perun functionality using the Click librar
 calls underlying commands from the commands module.
 """
 
-import logging
 import os
 import pkgutil
 import re
@@ -545,6 +544,7 @@ def init_unit_commands():
     Some of the subunits has to be dynamically initialized according to the registered modules,
     like e.g. show has different forms (raw, graphs, etc.).
     """
+    # Fixme: Refactoring this will yield -0.15s
     for (unit, cli_cmd) in [(perun.view, show), (perun.postprocess, postprocessby),
                             (perun.collect, collect)]:
         for module in pkgutil.walk_packages(unit.__path__, unit.__name__ + '.'):

--- a/perun/collect/memory/parsing.py
+++ b/perun/collect/memory/parsing.py
@@ -7,7 +7,7 @@ import perun.collect.memory.syscalls as syscalls
 
 __author__ = "Radim Podola"
 
-PATTERN_WORD = re.compile(r"\w+")
+PATTERN_WORD = re.compile(r"(\w+|[?])")
 PATTERN_TIME = re.compile(r"\d+([,.]\d*)?|[,.]\d+")
 PATTERN_HEXADECIMAL = re.compile(r"0x[0-9a-fA-F]+")
 PATTERN_INT = re.compile(r"\d+")

--- a/perun/collect/memory/parsing.py
+++ b/perun/collect/memory/parsing.py
@@ -1,7 +1,9 @@
 """This module provides methods for parsing raw memory data"""
+
 import re
+
 from decimal import Decimal
-from perun.collect.memory.syscalls import demangle, address_to_line
+import perun.collect.memory.syscalls as syscalls
 
 __author__ = "Radim Podola"
 
@@ -11,11 +13,10 @@ PATTERN_HEXADECIMAL = re.compile(r"0x[0-9a-fA-F]+")
 PATTERN_INT = re.compile(r"\d+")
 
 
-def parse_stack(stack, cmd):
+def parse_stack(stack):
     """ Parse stack information of one allocation
     Arguments:
         stack(list): list of raw stack data
-        cmd(string): profiled binary
 
     Returns:
         list: list of formatted structures representing
@@ -29,7 +30,7 @@ def parse_stack(stack, cmd):
         # it's the first word in the call record
         func = PATTERN_WORD.search(call).group()
         # demangling name of function
-        func = demangle(func)
+        func = syscalls.demangle(func)
         call_data.update({'function': func})
 
         # parsing instruction pointer,
@@ -38,7 +39,7 @@ def parse_stack(stack, cmd):
 
         # getting information of instruction pointer,
         # the source file and line number in the source file
-        ip_info = address_to_line(ip, cmd)
+        ip_info = syscalls.address_to_line(ip)
         if ip_info[0] in ["?", "??"]:
             ip_info[0] = "unreachable"
         if ip_info[1] in ["?", "??"]:
@@ -73,11 +74,10 @@ def parse_allocation_location(trace):
     return {}
 
 
-def parse_resources(allocation, cmd):
+def parse_resources(allocation):
     """ Parse resources of one allocation
     Arguments:
         allocation(list): list of raw allocation data
-        cmd(string): profiled binary
 
     Returns:
         structure: formatted structure representing
@@ -102,7 +102,7 @@ def parse_resources(allocation, cmd):
 
     # parsing stack in the moment of allocation
     # to getting trace of it
-    trace = parse_stack(allocation[2:], cmd)
+    trace = parse_stack(allocation[2:])
     data.update({'trace': trace})
 
     # parsed data is memory type
@@ -117,6 +117,7 @@ def parse_resources(allocation, cmd):
 
 def parse_log(filename, cmd, snapshots_interval):
     """ Parse raw data in the log file
+
     Arguments:
         filename(string): name of the log file
         cmd(string): profiled binary
@@ -146,6 +147,18 @@ def parse_log(filename, cmd, snapshots_interval):
     for item in log:
         allocations.append(item.splitlines())
 
+    # Collect names and addresses for demangling and addr2line collective call
+    names, ips = set(), set()
+    for allocation in allocations:
+        for resource in allocation[2:]:
+            name, ip = resource.split(' ')
+            names.add(name)
+            ips.add(ip)
+
+    # Build caches for demangle and addr2line for further calls
+    syscalls.build_demangle_cache(names)
+    syscalls.build_address_to_line_cache(ips, cmd)
+
     snapshots = []
     data = {}
     data.update({'time': '{0:f}'.format(interval)})
@@ -173,7 +186,7 @@ def parse_log(filename, cmd, snapshots_interval):
 
         # using parse_resources()
         # parsing resources,
-        data['resources'].append(parse_resources(allocation, cmd))
+        data['resources'].append(parse_resources(allocation))
 
     if data:
         snapshots.append(data)

--- a/perun/collect/memory/syscalls.py
+++ b/perun/collect/memory/syscalls.py
@@ -26,7 +26,7 @@ def build_demangle_cache(names):
     global demangle_cache
 
     list_of_names = list(names)
-    if not all(map(lambda name: PATTERN_WORD.match(name), list_of_names)):
+    if not all(map(PATTERN_WORD.match, list_of_names)):
         log.error("incorrect values in demangled names")
     else:
         sys_call = ['c++filt'] + list_of_names
@@ -58,7 +58,7 @@ def build_address_to_line_cache(addresses, binary_name):
     global address_to_line_cache
 
     list_of_addresses = list(addresses)
-    if not all(map(lambda addr: PATTERN_HEXADECIMAL.match(addr), list_of_addresses)):
+    if not all(map(PATTERN_HEXADECIMAL.match, list_of_addresses)):
         log.error("incorrect values in address translations")
     else:
         sys_call = ['addr2line', '-e', binary_name] + list_of_addresses

--- a/perun/profile/converters.py
+++ b/perun/profile/converters.py
@@ -1,10 +1,12 @@
 """This module implements translation of the profile to other formats """
 import copy
 
-import numpy
-import pandas
-
 import perun.profile.query as query
+
+import demandimport
+with demandimport.enabled():
+    import numpy
+    import pandas
 
 __author__ = 'Radim Podola'
 

--- a/perun/utils/__init__.py
+++ b/perun/utils/__init__.py
@@ -104,6 +104,7 @@ def get_supported_module_names(package, function_name):
     Returns:
         list: list of names of supported version control systems
     """
+    # Fixme: refactoring this will yield -0.1s
     module_list = []
     for (_, module_name, _) in pkgutil.iter_modules(package.__path__, package.__name__ + '.'):
         module = get_module(module_name)

--- a/perun/utils/bokeh_helpers.py
+++ b/perun/utils/bokeh_helpers.py
@@ -1,10 +1,12 @@
 """Collection of helper functions for working with bokeh graphs"""
 
-import bokeh.layouts as layouts
-import bokeh.palettes as palettes
-import bokeh.plotting as plotting
-
 import perun.utils.log as log
+
+import demandimport
+with demandimport.enabled():
+    import bokeh.layouts as layouts
+    import bokeh.palettes as palettes
+    import bokeh.plotting as plotting
 
 __author__ = 'Tomas Fiedor'
 

--- a/perun/view/bars/factory.py
+++ b/perun/view/bars/factory.py
@@ -1,11 +1,14 @@
 """This module contains the BAR graphs creating functions"""
 
-import bkcharts as charts
 import perun.profile.factory as profiles
 
 import perun.profile.converters as converters
 import perun.utils.bokeh_helpers as bokeh_helpers
 import perun.utils.log as log
+
+import demandimport
+with demandimport.enabled():
+    import bkcharts as charts
 
 __author__ = 'Radim Podola'
 __coauthored__ = 'Tomas Fiedor'

--- a/perun/view/bars/run.py
+++ b/perun/view/bars/run.py
@@ -1,6 +1,5 @@
 """Bar's graphs interpretation of the profiles."""
 
-import bokeh.core.enums as enums
 import click
 
 import perun.view.bars.factory as bars_factory
@@ -10,6 +9,10 @@ import perun.utils.bokeh_helpers as bokeh_helpers
 
 from perun.utils.helpers import pass_profile
 from perun.utils.exceptions import InvalidParameterException
+
+import demandimport
+with demandimport.enabled():
+    import bokeh.core.enums as enums
 
 __author__ = 'Radim Podola'
 __coauthored__ = 'Tomas Fiedor'

--- a/perun/view/flow/bokeh_factory.py
+++ b/perun/view/flow/bokeh_factory.py
@@ -1,13 +1,16 @@
 """This module contains the Flow usage graph creating functions"""
 
-import bkcharts as charts
-import bokeh.models as models
-import pandas
 import perun.profile.factory as profiles
 
 import perun.profile.converters as converters
 import perun.utils.bokeh_helpers as bokeh_helpers
 import perun.utils.log as log
+
+import demandimport
+with demandimport.enabled():
+    import bkcharts as charts
+    import bokeh.models as models
+    import pandas
 
 __author__ = 'Radim Podola'
 __coauthored__ = 'Tomas Fiedor'

--- a/perun/view/flow/run.py
+++ b/perun/view/flow/run.py
@@ -1,6 +1,5 @@
 """Flow graphs visualization of the profiles."""
 
-import bokeh.core.enums as enums
 import click
 
 import perun.profile.converters as converters
@@ -11,6 +10,10 @@ import perun.view.flow.bokeh_factory as flow_factory
 import perun.view.flow.ncurses_factory as curses_graphs
 from perun.utils.exceptions import InvalidParameterException
 from perun.utils.helpers import pass_profile
+
+import demandimport
+with demandimport.enabled():
+    import bokeh.core.enums as enums
 
 __author__ = 'Radim Podola'
 __coauthored__ = 'Tomas Fiedor'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 click==6.7
 termcolor==1.1.0
 colorama==0.3.7
-kivy==1.9.1
 ruamel.yaml==0.15.6
 pandas==0.20.2
 bokeh==0.12.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ kivy==1.9.1
 ruamel.yaml==0.15.6
 pandas==0.20.2
 bokeh==0.12.6
+demandimport==0.3.4

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,8 @@ setup(
         'collect/complexity/cpp_sources/workload/*.{h,cpp,conf}'
     ]},
     install_requires=[
-        'click', 'termcolor', 'colorama', 'kivy', 'ruamel.yaml', 'GitPython', 'bokeh', 'pandas'
+        'click', 'termcolor', 'colorama', 'ruamel.yaml', 'GitPython', 'bokeh', 'pandas',
+        'demandimport'
     ],
 
     entry_points='''

--- a/tests/logic/commands/conftest.py
+++ b/tests/logic/commands/conftest.py
@@ -319,11 +319,10 @@ def pcs_full():
 
     # Populate PCS with profiles
     root_profile = Helpers.prepare_profile(pcs_obj, profiles[0], str(root))
-    commands.add(root_profile, str(root))
+    commands.add([root_profile], str(root))
     chead_profile1 = Helpers.prepare_profile(pcs_obj, profiles[1], str(current_head))
     chead_profile2 = Helpers.prepare_profile(pcs_obj, profiles[2], str(current_head))
-    commands.add(chead_profile1, str(current_head))
-    commands.add(chead_profile2, str(current_head))
+    commands.add([chead_profile1, chead_profile2], str(current_head))
 
     # Assert that we have five blobs: 2 for commits and 3 for profiles
     pcs_object_dir = os.path.join(pcs_path, ".perun", "objects")

--- a/tests/logic/commands/test_add.py
+++ b/tests/logic/commands/test_add.py
@@ -111,7 +111,7 @@ def test_add_on_empty_repo(helpers, pcs_with_empty_git, valid_profile_pool, caps
 
     # Assert that the program ends
     with pytest.raises(SystemExit):
-        commands.add(valid_profile_pool[0], None, keep_profile=True)
+        commands.add([valid_profile_pool[0]], None, keep_profile=True)
 
     # Assert that nothing was added (rather weak, but should be enough)
     after_count = helpers.count_contents_on_path(pcs_with_empty_git.path)
@@ -133,7 +133,7 @@ def test_add_on_no_vcs(helpers, pcs_without_vcs, valid_profile_pool):
     before_count = helpers.count_contents_on_path(pcs_without_vcs.path)
     assert pcs_without_vcs.vcs_type == 'pvcs'
     with pytest.raises(UnsupportedModuleException):
-        commands.add(valid_profile_pool[0], None, keep_profile=True)
+        commands.add([valid_profile_pool[0]], None, keep_profile=True)
 
     # Assert that nothing was added (rather weak, but should be enough)
     after_count = helpers.count_contents_on_path(pcs_without_vcs.path)
@@ -159,7 +159,7 @@ def test_add(helpers, pcs_full, valid_profile_pool):
         before_entries_count = assert_before_add(helpers, obj_path, current_head, valid_profile)
 
         # Add the profile to timestamp
-        commands.add(valid_profile, current_head, keep_profile=True)
+        commands.add([valid_profile], current_head, keep_profile=True)
 
         # Now check, that the profile was successfully added to index, and its entry is valid
         after_entries_count = assert_after_valid_add(helpers, obj_path, current_head, valid_profile)
@@ -188,7 +188,7 @@ def test_add_no_minor(helpers, pcs_full, valid_profile_pool):
         # Check that the profile was NOT in the index before
         before_entries_count = assert_before_add(helpers, obj_path, head, valid_profile)
 
-        commands.add(valid_profile, None, keep_profile=True)
+        commands.add([valid_profile], None, keep_profile=True)
 
         # Now check, that the profile was successfully added to index, and its entry is valid
         after_entries_count = assert_after_valid_add(helpers, obj_path, head, valid_profile)
@@ -213,7 +213,7 @@ def test_add_wrong_minor(helpers, pcs_full, valid_profile_pool):
     before_count = helpers.count_contents_on_path(pcs_full.path)
 
     with pytest.raises(VersionControlSystemException):
-        commands.add(valid_profile_pool[0], wrong_commit, keep_profile=True)
+        commands.add([valid_profile_pool[0]], wrong_commit, keep_profile=True)
 
     # Assert that nothing was added (rather weak, but should be enough)
     after_count = helpers.count_contents_on_path(pcs_full.path)
@@ -232,7 +232,7 @@ def test_add_wrong_profile(helpers, pcs_full, error_profile_pool):
     for error_profile in error_profile_pool:
         before_entries_count = assert_before_add(helpers, pcs_full.path, head, error_profile)
         with pytest.raises(IncorrectProfileFormatException):
-            commands.add(error_profile, None, keep_profile=True)
+            commands.add([error_profile], None, keep_profile=True)
 
         # Assert that the profile was not added into the index
         after_entries_count = assert_after_invalid_add(helpers, pcs_full.path, head, error_profile)
@@ -261,13 +261,13 @@ def test_add_existing(helpers, pcs_full, valid_profile_pool, capsys):
         # Check that the profile was NOT in the index before
         before_entries_count = assert_before_add(helpers, obj_path, head, valid_profile)
 
-        commands.add(valid_profile, None, keep_profile=True)
+        commands.add([valid_profile], None, keep_profile=True)
 
         # Assert that the profile was successfully added to the index
         middle_entries_count = assert_after_valid_add(helpers, obj_path, head, valid_profile)
         assert before_entries_count == (middle_entries_count - 1)
 
-        commands.add(valid_profile, None, keep_profile=True)
+        commands.add([valid_profile], None, keep_profile=True)
 
         # Assert that nothing was added to the index
         after_entries_count = assert_after_valid_add(helpers, obj_path, head, valid_profile)
@@ -291,4 +291,4 @@ def test_add_outside_pcs(valid_profile_pool):
     and thus should not do anything, should be caught on the CLI/UI level
     """
     with pytest.raises(NotPerunRepositoryException):
-        commands.add(valid_profile_pool[0], None, keep_profile=True)
+        commands.add([valid_profile_pool[0]], None, keep_profile=True)

--- a/tests/logic/commands/test_cli.py
+++ b/tests/logic/commands/test_cli.py
@@ -111,21 +111,21 @@ def test_add_massaged_head(helpers, pcs_full, valid_profile_pool):
     first_tagged = os.path.relpath(helpers.prepare_profile(pcs_full, valid_profile_pool[0], head))
 
     runner = CliRunner()
-    result = runner.invoke(cli.add, ['0@p', 'HEAD'])
+    result = runner.invoke(cli.add, ['0@p', '--minor=HEAD'])
     assert result.exit_code == 0
     assert "'{}' successfully registered".format(first_tagged) in result.output
 
     runner = CliRunner()
-    result = runner.invoke(cli.add, ['0@p', r"HEAD^{d"])
+    result = runner.invoke(cli.add, ['0@p', r"--minor=HEAD^{d"])
     assert result.exit_code == 2
     assert "Missing closing brace"
 
     runner = CliRunner()
-    result = runner.invoke(cli.add, ['0@p', r"HEAD^}"])
+    result = runner.invoke(cli.add, ['0@p', r"--minor=HEAD^}"])
     assert result.exit_code == 2
 
     runner = CliRunner()
-    result = runner.invoke(cli.add, ['0@p', 'tag2'])
+    result = runner.invoke(cli.add, ['0@p', '--minor=tag2'])
     assert result.exit_code == 2
     assert "Ref 'tag2' did not resolve to object"
 

--- a/tests/logic/commands/test_remove.py
+++ b/tests/logic/commands/test_remove.py
@@ -25,13 +25,13 @@ def test_rm_outside_pcs(stored_profile_pool):
     """
     with pytest.raises(NotPerunRepositoryException):
         # Remove first profile from the head
-        commands.remove(stored_profile_pool[0], None)
+        commands.remove([stored_profile_pool[0]], None)
 
 
 def test_rm_on_empty_repo(pcs_with_empty_git, stored_profile_pool, capsys):
     """Test calling 'perun rm', when the wrapped VCS is empty"""
     with pytest.raises(SystemExit):
-        commands.remove(stored_profile_pool[0], None)
+        commands.remove([stored_profile_pool[0]], None)
 
     # Test that nothing is printed on out and something is printed on err
     out, err = capsys.readouterr()
@@ -53,7 +53,7 @@ def test_rm_no_profiles(helpers, pcs_full, capsys):
     git_repo.index.commit("new commit")
 
     with pytest.raises(EntryNotFoundException):
-        commands.remove('nonexistent.perf', None)
+        commands.remove(['nonexistent.perf'], None)
 
     out, _ = capsys.readouterr()
     assert out == ''
@@ -70,7 +70,7 @@ def test_rm_nonexistent(helpers, pcs_full, capsys):
     """
     before_count = helpers.count_contents_on_path(pcs_full.path)
     with pytest.raises(EntryNotFoundException):
-        commands.remove('nonexistent.perf', None)
+        commands.remove(['nonexistent.perf'], None)
 
     out, _ = capsys.readouterr()
     assert out == ''
@@ -101,7 +101,7 @@ def test_rm(helpers, pcs_full, stored_profile_pool, capsys):
     with helpers.open_index(pcs_full.path, head) as index_handle:
         assert helpers.exists_profile_in_index_such_that(index_handle, entry_contains_profile)
 
-    commands.remove(deleted_profile, None)
+    commands.remove([deleted_profile], None)
 
     with helpers.open_index(pcs_full.path, head) as index_handle:
         assert not helpers.exists_profile_in_index_such_that(index_handle, entry_contains_profile)


### PR DESCRIPTION
This pull request contains collection of commits, that will optimize the
performance of Perun within the command line interface.

It contains (a) optimization of imports, by introducing the on demand import of
big modules (like e.g. bkcharts) and (b) optimization of memory collector that
had the biggest overhead, by numerous subprocess calls.
