### PR TITLE
Extend the automation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,9 @@ HEAD
   - add :ckey:`profiles.register_after_run` configuration key to automatically register profiles after collection
   - add :ckey:`execute.pre_run` config key for running commands before execution of matrix
   - add helper function for safely getting config key
+  - add ``--minor-version`` parameter to ``perun collect`` and ``perun run`` to run the collection over different minor version
+  - add ``--crawl-parents`` parameter to allow ``perun collect`` and ``perun run`` to collect the data for both minor version and its predecessors
+  - add checking out of the minor version, and saving the state, to collection of profiles
 
 0.14 (2018-03-27)
 -----------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,7 @@ HEAD
   - remake walk major version to return MajorVersion object, with head and major version name
   - add helper function for loading the profile out of profile info
   - extend the api of the vcs (with storing/restoring the state, checkout and dirty-testing)
+  - add :ckey:`profiles.register_after_run` configuration key to automatically register profiles after collection
 
 0.14 (2018-03-27)
 -----------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,8 @@ HEAD
   - add helper function for loading the profile out of profile info
   - extend the api of the vcs (with storing/restoring the state, checkout and dirty-testing)
   - add :ckey:`profiles.register_after_run` configuration key to automatically register profiles after collection
+  - add :ckey:`execute.pre_run` config key for running commands before execution of matrix
+  - add helper function for safely getting config key
 
 0.14 (2018-03-27)
 -----------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,7 @@ HEAD
   - add ``--minor-version`` parameter to ``perun collect`` and ``perun run`` to run the collection over different minor version
   - add ``--crawl-parents`` parameter to allow ``perun collect`` and ``perun run`` to collect the data for both minor version and its predecessors
   - add checking out of the minor version, and saving the state, to collection of profiles
+  - add :ckey:`degradation.collect_before_check` configuration key for automatically collect profiles before running degradation check
 
 0.14 (2018-03-27)
 -----------------

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -210,6 +210,32 @@ List of Supported Options
 .. currentmodule:: perun.profile.factory
 .. autoattribute:: ProfileInfo.valid_attributes
 
+.. confunit:: execute
+
+   Groups various list of commands, that can be executed before specific phases. Currently this
+   contains only ``pre_run`` phase, which is executed before any collection of the data. This is
+   mainly meant to execute compiling of the binaries and other stuff to ease the development. Note
+   that these commands are executed without shell, but any risks of commands executed by these
+   commands fall entirely into the user hands and we have no responsibility for them.
+
+   All of these list are as follows:
+
+   .. code-block:: yaml
+
+           execute:
+             pre_run:
+               - echo "Running the code again"
+               - make
+               - make install
+
+   The list of commands above first outputs some text into the standard output, then it runs the
+   makefile to compile the collected binary and then installs it.
+
+.. confkey:: execute.pre_run
+
+   ``[local-only]]`` Runs the code before the collection of the data. This is meant to prepare the
+   binaries and other settings for the actual collection of the new data.
+
 .. confunit:: cmds
 
     ``[local-only]`` Refer to :munit:`cmds`.

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -272,6 +272,11 @@ List of Supported Options
    Speficies the list of strategies and how they are applied when checked for degradation in
    methods.
 
+.. confkey:: degradation.collect_before_check
+
+    ``[recursive]`` If set to true, then before checking profiles of two minor versions, we run the
+    collection for job matrix to collect fresh or unexisting profiles.
+
 .. confkey:: degradation.apply
 
     ``[recursive]`` Specifies which strategies are picked for application, if more than one

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -230,6 +230,17 @@ List of Supported Options
 
     ``[local-only]`` Refer to :munit:`postprocessors`
 
+.. confunit:: profiles
+
+   Groups various option specific for profiles, such as strategies for adding or generating
+   profiles:w
+   
+.. confkey:: profiles.register_after_run:
+
+   If the key is set to a true value (can be 1, true, True, yes, etc.), then after newly generated
+   profile (e.g. by running ``perun run matrix``) is automatically registered in the appropriate
+   minor version index.
+
 .. confunit:: degradation
 
    Speficies the list of strategies and how they are applied when checked for degradation in

--- a/docs/jobs.rst
+++ b/docs/jobs.rst
@@ -21,7 +21,9 @@ for profile name generation by setting :ckey:`format.output_profile_template`. N
 annotated with the :preg:`origin` set to the current ``HEAD`` of the wrapped repository. `origin`
 serves as a check during registering profiles in the indexes of minor versions. Profile with
 `origin` different from the target minor version will not be assigned, as it would violate the
-correctness of the performance history of the project.
+correctness of the performance history of the project. If you want to automatically register the
+newly generated profile into the corresponding minor version index, then set
+:ckey:`profiles.register_after_run` key to a true value.
 
 .. image:: /../figs/perun-jobs-flow.*
     :align: center

--- a/docs/jobs.rst
+++ b/docs/jobs.rst
@@ -132,6 +132,10 @@ Note that each phase should return the following tripple: (``status code``, ``st
 ``kwargs``). The ``status code`` is used for checking the success of the called phases and in case
 of error prints the ``status message``.
 
+Before this overall process, one can run a custom set of commands by stating the key
+:ckey:`execute.pre_run` key. This is mostly meant for compiling of new version or preparing other
+necessary requirements before actual collection.
+
 .. image:: /../figs/lifetime-of-profile.*
    :width: 70%
    :align: center

--- a/perun/logic/config.py
+++ b/perun/logic/config.py
@@ -104,6 +104,18 @@ class Config(object):
         if self.path:
             write_config_to(self.path, self.data)
 
+    def safe_get(self, key, default):
+        """Safely returns the value of the key; i.e. in case it is missing default is used
+
+        :param str key: key we are looking up
+        :param object default: default value of the key, which is used if we did not find the value
+        :return: value of the key in the config or default
+        """
+        try:
+            return self.get(key)
+        except exceptions.MissingConfigSectionException:
+            return default
+
     @decorators.validate_arguments(['key'], is_valid_key)
     def get(self, key):
         """Returns the value of the key stored in the config.

--- a/perun/logic/config.py
+++ b/perun/logic/config.py
@@ -78,8 +78,8 @@ class Config(object):
         # Remove the key from the caching
         # ! Note that this is mainly used for the testing, but might be triggered during the future
         # as well.
-        decorators.func_args_cache['lookup_key_recursively'].pop(tuple([key]), None)
-        decorators.func_args_cache['gather_key_recursively'].pop(tuple([key]), None)
+        decorators.remove_from_function_args_cache('lookup_key_recursively')
+        decorators.remove_from_function_args_cache('gather_key_recursively')
 
         *sections, last_section = key.split('.')
         _locate_section_from_query(self.data, sections)[last_section] = value
@@ -402,7 +402,7 @@ def get_hierarchy():
 
 
 @decorators.singleton_with_args
-def lookup_key_recursively(key):
+def lookup_key_recursively(key, default=None):
     """Recursively looks up the key first in the local config and then in the global.
 
     This is used e.g. for formatting strings or editors, where first we have our local configs,
@@ -410,6 +410,7 @@ def lookup_key_recursively(key):
     global config.
 
     :param str key: key we are looking up
+    :param str default: default value, if key is not located in the hierarchy
     """
     # Fixme: this should contain recursive lookup for other instances and also the temporary config
     for config_instance in get_hierarchy():
@@ -417,6 +418,9 @@ def lookup_key_recursively(key):
             return config_instance.get(key)
         except exceptions.MissingConfigSectionException:
             continue
+    # If we have provided default value of the key return this, otherwise we raise an exception
+    if default:
+        return default
     raise exceptions.MissingConfigSectionException
 
 

--- a/perun/logic/runner.py
+++ b/perun/logic/runner.py
@@ -2,7 +2,10 @@
 
 import os
 
+import distutils.util as dutils
+import perun.logic.config as config
 import perun.logic.store as store
+import perun.logic.commands as commands
 import perun.profile.factory as profile
 import perun.utils as utils
 import perun.utils.log as log
@@ -276,10 +279,9 @@ def run_postprocessor(postprocessor, job, prof):
 def store_generated_profile(pcs, prof, job):
     """Stores the generated profile in the pending jobs directory.
 
-    Arguments:
-        pcs(PCS): object with performance control system wrapper
-        prof(dict): profile that we are storing in the repository
-        job(Job): job with additional information about generated profiles
+    :param PCS pcs: object with performance control system wrapper
+    :param dict prof: profile that we are storing in the repository
+    :param Job job: job with additional information about generated profiles
     """
     full_profile = profile.finalize_profile_for_job(pcs, prof, job)
     full_profile_name = profile.generate_profile_name(full_profile)
@@ -287,6 +289,8 @@ def store_generated_profile(pcs, prof, job):
     full_profile_path = os.path.join(profile_directory, full_profile_name)
     profile.store_profile_at(full_profile, full_profile_path)
     log.info("stored profile at: {}".format(os.path.relpath(full_profile_path)))
+    if dutils.strtobool(str(config.lookup_key_recursively("profiles.register_after_run", "false"))):
+        commands.add([full_profile_path], prof['origin'], keep_profile=False)
 
 
 def run_postprocessor_on_profile(prof, postprocessor_name, postprocessor_params):

--- a/perun/logic/runner.py
+++ b/perun/logic/runner.py
@@ -166,7 +166,11 @@ def run_all_phases_for(runner, runner_type, runner_params):
     for phase in ['before', runner_verb, 'after']:
         phase_function = getattr(runner, phase, None)
         if phase_function:
-            ret_val, ret_msg, updated_params = phase_function(**runner_params)
+            try:
+                ret_val, ret_msg, updated_params = phase_function(**runner_params)
+            # We safely catch all of the exceptions
+            except Exception as exc:
+                ret_val, ret_msg, updated_params = error_status, str(exc), {}
             runner_params.update(updated_params or {})
             if not is_status_ok(ret_val, ok_status):
                 return error_status, "error while {}{} phase: {}".format(

--- a/perun/logic/runner.py
+++ b/perun/logic/runner.py
@@ -5,7 +5,6 @@ import subprocess
 
 import distutils.util as dutils
 import perun.vcs as vcs
-import perun.check as check
 import perun.logic.config as config
 import perun.logic.store as store
 import perun.logic.commands as commands
@@ -398,10 +397,11 @@ def run_jobs(pcs, minor_version_list, job_matrix, number_of_jobs):
     """
     with vcs.CleanState(pcs.vcs_type, pcs.vcs_path):
         for minor_version in minor_version_list:
-            check.print_minor_version(minor_version)
+            log.print_minor_version(minor_version)
             vcs.checkout(pcs.vcs_type, pcs.vcs_path, minor_version.checksum)
             run_prephase_commands('pre_run', COLLECT_PHASE_CMD)
             run_jobs_on_current_working_dir(pcs, job_matrix, number_of_jobs)
+
 
 @pass_pcs
 def run_single_job(pcs, cmd, args, workload, collector, postprocessor, minor_version_list, **kwargs):

--- a/perun/utils/decorators.py
+++ b/perun/utils/decorators.py
@@ -91,6 +91,16 @@ def singleton_with_args(func):
 func_args_cache = {}
 
 
+def remove_from_function_args_cache(funcname):
+    """Helper function for clearing the key from func args cache
+
+    :param str funcname: function name that we are removing from the cache
+    :return:
+    """
+    if funcname in func_args_cache.keys():
+        func_args_cache[funcname].clear()
+
+
 def validate_arguments(validated_args, validate, *args, **kwargs):
     """
     Validates the arguments stated by validated_args with validate function.

--- a/perun/utils/log.py
+++ b/perun/utils/log.py
@@ -228,3 +228,22 @@ def failed(ending='\n'):
     print('[', end='')
     cprint("FAILED", 'red', attrs=['bold'])
     print(']', end=ending)
+
+
+def print_minor_version(minor_version):
+    """Helper function for printing minor version to the degradation output
+
+    Currently printed in form of:
+
+    * sha[:6]: desc
+
+    :param MinorVersion minor_version: informations about minor version
+    """
+    print("* ", end='')
+    cprint("{}".format(
+        minor_version.checksum[:6]
+    ), 'yellow', attrs=[])
+    print(": {}".format(
+        minor_version.desc.split("\n")[0].strip()
+    ))
+

--- a/tests/logic/commands/test_cli.py
+++ b/tests/logic/commands/test_cli.py
@@ -824,20 +824,20 @@ def test_run(pcs_full, monkeypatch):
     })
     monkeypatch.setattr("perun.logic.config.local", lambda _: matrix)
     runner = CliRunner()
-    result = runner.invoke(cli.matrix, [])
+    result = runner.invoke(cli.run, ['-c', 'matrix'])
     assert result.exit_code == 0
     assert "ls | grep " in result.output
 
     job_dir = pcs_full.get_job_directory()
     job_profiles = os.listdir(job_dir)
-    assert len(job_profiles) == 2
+    assert len(job_profiles) >= 2
 
     config.runtime().set('profiles.register_after_run', 'true')
     # Try to store the generated crap not in jobs
     jobs_before = len(os.listdir(job_dir))
     # Need to sleep, since in travis this could rewrite the stuff
     time.sleep(1)
-    result = runner.invoke(cli.matrix, [])
+    result = runner.invoke(cli.run, ['matrix'])
     jobs_after = len(os.listdir(job_dir))
     assert result.exit_code == 0
     assert jobs_before == jobs_after
@@ -846,7 +846,8 @@ def test_run(pcs_full, monkeypatch):
     script_dir = os.path.split(__file__)[0]
     source_dir = os.path.join(script_dir, 'collect_complexity')
     job_config_file = os.path.join(source_dir, 'job.yml')
-    result = runner.invoke(cli.job, [
+    result = runner.invoke(cli.run, [
+        'job',
         '--cmd', 'ls',
         '--args', '-al',
         '--workload', '.',
@@ -856,7 +857,7 @@ def test_run(pcs_full, monkeypatch):
     ])
     assert result.exit_code == 0
     job_profiles = os.listdir(job_dir)
-    assert len(job_profiles) == 3
+    assert len(job_profiles) >= 3
 
     # Run the matrix with error in prerun phase
     saved_func = utils.run_safely_external_command
@@ -869,6 +870,6 @@ def test_run(pcs_full, monkeypatch):
 
     monkeypatch.setattr('perun.utils.run_safely_external_command', run_wrapper)
     matrix.data['execute']['pre_run'].append('ls | grep dafad')
-    result = runner.invoke(cli.matrix, [])
+    result = runner.invoke(cli.run, ['matrix'])
     assert result.exit_code == 1
     assert "error in pre_run" in result.output

--- a/tests/logic/commands/test_cli.py
+++ b/tests/logic/commands/test_cli.py
@@ -464,8 +464,7 @@ def test_collect_complexity(monkeypatch, pcs_full, complexity_collect_job):
         'complexity'
     ] + rules + samplings)
     del config.runtime().data['format']
-    decorators.func_args_cache['lookup_key_recursively'].pop(
-        tuple(["format.output_profile_template"]), None)
+    decorators.remove_from_function_args_cache("lookup_key_recursively")
     assert result.exit_code == 0
     assert "info: stored profile at: .perun/jobs/complexity-profile.perf" in result.output
 
@@ -824,6 +823,15 @@ def test_run(pcs_full, monkeypatch):
     job_dir = pcs_full.get_job_directory()
     job_profiles = os.listdir(job_dir)
     assert len(job_profiles) == 2
+
+    config.runtime().set('profiles.register_after_run', 'true')
+    # Try to store the generated crap not in jobs
+    jobs_before = len(os.listdir(job_dir))
+    result = runner.invoke(cli.matrix, [])
+    jobs_after = len(os.listdir(job_dir))
+    assert result.exit_code == 0
+    assert jobs_before == jobs_after
+    config.runtime().set('profiles.register_after_run', 'false')
 
     script_dir = os.path.split(__file__)[0]
     source_dir = os.path.join(script_dir, 'collect_complexity')

--- a/tests/logic/commands/test_collect.py
+++ b/tests/logic/commands/test_collect.py
@@ -124,7 +124,7 @@ def test_collect_memory(capsys, helpers, pcs_full, memory_collect_job, memory_co
     assert 'debug info' in err
 
 
-def test_collect_time(helpers, pcs_full, capsys):
+def test_collect_time(monkeypatch, helpers, pcs_full, capsys):
     """Test collecting the profile using the time collector"""
     # Count the state before running the single job
     before_object_count = helpers.count_contents_on_path(pcs_full.path)[0]
@@ -148,4 +148,13 @@ def test_collect_time(helpers, pcs_full, capsys):
     assert len(profiles) == 1
     assert new_profile.endswith(".perf")
 
-    # Fixme: Add check that the profile was correctly generated
+    # Test running time with error
+    runner.run_single_job(["echo"], "", ["hello"], ["time"], [], [head])
+
+    def collect_raising_exception(**kwargs):
+        raise Exception("Something happened lol!")
+
+    monkeypatch.setattr("perun.collect.time.run.collect", collect_raising_exception)
+    runner.run_single_job(["echo"], "", ["hello"], ["time"], [], [head])
+    _, err = capsys.readouterr()
+    assert 'Something happened lol!' in err

--- a/tests/logic/commands/test_collect.py
+++ b/tests/logic/commands/test_collect.py
@@ -2,6 +2,7 @@
 
 import os
 
+import perun.vcs as vcs
 import perun.logic.runner as runner
 import perun.collect.complexity.run as complexity
 
@@ -21,12 +22,15 @@ def _mocked_stap(**kwargs):
 
 def test_collect_complexity(monkeypatch, helpers, pcs_full, complexity_collect_job):
     """Test collecting the profile using complexity collector"""
+    head = vcs.get_minor_version_info(pcs_full.vcs_type, pcs_full.vcs_path,
+        vcs.get_minor_head(pcs_full.vcs_type, pcs_full.vcs_path)
+    )
     monkeypatch.setattr(complexity, '_call_stap', _mocked_stap)
 
     before_object_count = helpers.count_contents_on_path(pcs_full.path)[0]
 
     cmd, args, work, collectors, posts, config = complexity_collect_job
-    runner.run_single_job(cmd, args, work, collectors, posts, **config)
+    runner.run_single_job(cmd, args, work, collectors, posts, [head], **config)
 
     # Assert that nothing was removed
     after_object_count = helpers.count_contents_on_path(pcs_full.path)[0]
@@ -44,6 +48,9 @@ def test_collect_complexity_fail(monkeypatch, helpers, pcs_full, complexity_coll
     """Test failed collecting using complexity collector"""
     global _mocked_stap_code
     global _mocked_stap_file
+    head = vcs.get_minor_version_info(pcs_full.vcs_type, pcs_full.vcs_path,
+        vcs.get_minor_head(pcs_full.vcs_type, pcs_full.vcs_path)
+    )
 
     monkeypatch.setattr(complexity, '_call_stap', _mocked_stap)
 
@@ -52,7 +59,7 @@ def test_collect_complexity_fail(monkeypatch, helpers, pcs_full, complexity_coll
     # Test malformed file that ends in unexpected way
     _mocked_stap_file = 'record_malformed.txt'
     cmd, args, work, collectors, posts, config = complexity_collect_job
-    runner.run_single_job(cmd, args, work, collectors, posts, **config)
+    runner.run_single_job(cmd, args, work, collectors, posts, [head], **config)
 
     # Assert that nothing was added
     after_object_count = helpers.count_contents_on_path(pcs_full.path)[0]
@@ -60,7 +67,7 @@ def test_collect_complexity_fail(monkeypatch, helpers, pcs_full, complexity_coll
 
     # Test malformed file that ends in another unexpected way
     _mocked_stap_file = 'record_malformed2.txt'
-    runner.run_single_job(cmd, args, work, collectors, posts, **config)
+    runner.run_single_job(cmd, args, work, collectors, posts, [head], **config)
 
     # Assert that nothing was added
     after_object_count = helpers.count_contents_on_path(pcs_full.path)[0]
@@ -68,7 +75,7 @@ def test_collect_complexity_fail(monkeypatch, helpers, pcs_full, complexity_coll
 
     # Simulate the failure of the systemTap
     _mocked_stap_code = 1
-    runner.run_single_job(cmd, args, work, collectors, posts, **config)
+    runner.run_single_job(cmd, args, work, collectors, posts, [head], **config)
 
     # Assert that nothing was added
     after_object_count = helpers.count_contents_on_path(pcs_full.path)[0]
@@ -79,6 +86,10 @@ def test_collect_memory(capsys, helpers, pcs_full, memory_collect_job, memory_co
     """Test collecting the profile using the memory collector"""
     # Fixme: Add check that the profile was correctly generated
     before_object_count = helpers.count_contents_on_path(pcs_full.path)[0]
+    head = vcs.get_minor_version_info(pcs_full.vcs_type, pcs_full.vcs_path,
+        vcs.get_minor_head(pcs_full.vcs_type, pcs_full.vcs_path)
+    )
+    memory_collect_job += ([head], )
 
     runner.run_single_job(*memory_collect_job)
 
@@ -91,8 +102,8 @@ def test_collect_memory(capsys, helpers, pcs_full, memory_collect_job, memory_co
     assert len(profiles) == 1
     assert new_profile.endswith(".perf")
 
-    cmd, args, _, colls, posts = memory_collect_job
-    runner.run_single_job(cmd, args, ["hello"], colls, posts, **{'no_func': 'fun', 'sampling': 0.1})
+    cmd, args, _, colls, posts, _ = memory_collect_job
+    runner.run_single_job(cmd, args, ["hello"], colls, posts, [head], **{'no_func': 'fun', 'sampling': 0.1})
 
     profiles = os.listdir(os.path.join(pcs_full.path, 'jobs'))
     new_smaller_profile = [p for p in profiles if p != new_profile][0]
@@ -105,6 +116,7 @@ def test_collect_memory(capsys, helpers, pcs_full, memory_collect_job, memory_co
 
     # Fixme: Add check that the profile was correctly generated
 
+    memory_collect_no_debug_job += ([head], )
     runner.run_single_job(*memory_collect_no_debug_job)
     last_object_count = helpers.count_contents_on_path(pcs_full.path)[0]
     _, err = capsys.readouterr()
@@ -116,8 +128,11 @@ def test_collect_time(helpers, pcs_full, capsys):
     """Test collecting the profile using the time collector"""
     # Count the state before running the single job
     before_object_count = helpers.count_contents_on_path(pcs_full.path)[0]
+    head = vcs.get_minor_version_info(pcs_full.vcs_type, pcs_full.vcs_path,
+        vcs.get_minor_head(pcs_full.vcs_type, pcs_full.vcs_path)
+    )
 
-    runner.run_single_job(["echo"], "", ["hello"], ["time"], [])
+    runner.run_single_job(["echo"], "", ["hello"], ["time"], [], [head])
 
     # Assert outputs
     out, err = capsys.readouterr()

--- a/tests/logic/commands/test_log.py
+++ b/tests/logic/commands/test_log.py
@@ -51,14 +51,12 @@ def test_log_on_no_vcs(pcs_without_vcs):
 def test_log_short_error(pcs_full, capsys, monkeypatch):
     cfg = config.Config('shared', '', {'format': {'shortlog': '%checksum:6% -> %notexist%'}})
     monkeypatch.setattr("perun.logic.config.shared", lambda: cfg)
-    decorators.func_args_cache['lookup_key_recursively'].pop(
-        tuple(["format.shortlog"]), None)
+    decorators.remove_from_function_args_cache("lookup_key_recursively")
 
     with pytest.raises(SystemExit):
         commands.log(None, short=True)
 
-    decorators.func_args_cache['lookup_key_recursively'].pop(
-        tuple(["format.shortlog"]), None)
+    decorators.remove_from_function_args_cache("lookup_key_recursively")
     out, err = capsys.readouterr()
     assert len(err) != 0
     assert "object does not contain 'notexist' attribute" in err

--- a/tests/logic/commands/test_status.py
+++ b/tests/logic/commands/test_status.py
@@ -322,8 +322,7 @@ def test_status_sort(monkeypatch, helpers, pcs_full, capsys, valid_profile_pool)
     Expecting no errors and long display of the current status of the perun, with all profiles.
     """
     helpers.populate_repo_with_untracked_profiles(pcs_full.path, valid_profile_pool)
-    decorators.func_args_cache['lookup_key_recursively'].pop(
-        tuple(["format.sort_profiles_by"]), None)
+    decorators.remove_from_function_args_cache("lookup_key_recursively")
 
     # Try what happens if we screw the stored profile keys ;)
     cfg = config.Config('shared', '', {
@@ -331,7 +330,7 @@ def test_status_sort(monkeypatch, helpers, pcs_full, capsys, valid_profile_pool)
         'format': {
             'status': '\u2503 %type% \u2503 %collector%  \u2503 (%time%) \u2503 %source% \u2503'
         }
-        })
+    })
     monkeypatch.setattr("perun.logic.config.shared", lambda: cfg)
     commands.status()
 


### PR DESCRIPTION
This pull request extends the automation possibilities, by allowing to run
custom commands before each collection of profiles, to automaticaly register
collected profiles into the current head index, and to collect profiles for all
parents or before each performance change check.

Moreover, this introduces three options:

  1. :ckey:`profiles.register_after_run`: if set to true then, whenever we
collect profile, we assign it to the index.
  2. :ckey:`execute.pre_run`: list of commands executed before each collection phase
  3. :ckey:`degradation.collect_before_check`: if set to true, then before each
check, we collect new profiles

Note that these commands should head towards automatic git hooks.