### PR TITLE
Rehaul the notion of workloads.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,8 @@ HEAD
   - add ``pending tag range`` to ``perun add`` command to add more profiles at once
   - add ``index tag rage`` to ``perun rm`` command to remove more profiles at once
   - fix the issue with wrong sort order and tags (now :ckey:`format.sort_profiles_by` sets the option in local)
+  - add support for workload generators
+  - implement integer workload generator that generates workload from the integer interval
 
 0.15 (2018-06-20)
 -----------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ HEAD
   - fix the issue with wrong sort order and tags (now :ckey:`format.sort_profiles_by` sets the option in local)
   - add support for workload generators
   - implement integer workload generator that generates workload from the integer interval
+  - add :ckey:`generators.workload` for specification of workload generators in config
 
 0.15 (2018-06-20)
 -----------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ HEAD
   - implement integer workload generator that generates workload from the integer interval
   - implement singleton workload generator that generates single workload
   - add :ckey:`generators.workload` for specification of workload generators in config
+  - remodel the notion of workloads to accept the workload generators to allow other style of workloads
 
 0.15 (2018-06-20)
 -----------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ HEAD
   - fix the issue with wrong sort order and tags (now :ckey:`format.sort_profiles_by` sets the option in local)
   - add support for workload generators
   - implement integer workload generator that generates workload from the integer interval
+  - implement singleton workload generator that generates single workload
   - add :ckey:`generators.workload` for specification of workload generators in config
 
 0.15 (2018-06-20)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,8 @@ HEAD
   - implement file workload generator that generates random text files
   - add :ckey:`generators.workload` for specification of workload generators in config
   - remodel the notion of workloads to accept the workload generators to allow other style of workloads
+  - add two modes of workload generation (one that merges the profiles into one; and one which gradually generates profiles)
+  - add default workload generators to shared configuration
 
 0.15 (2018-06-20)
 -----------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ HEAD
   - add support for workload generators
   - implement integer workload generator that generates workload from the integer interval
   - implement singleton workload generator that generates single workload
+  - implement string workload generator that generates random strings
   - add :ckey:`generators.workload` for specification of workload generators in config
   - remodel the notion of workloads to accept the workload generators to allow other style of workloads
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ HEAD
   - implement integer workload generator that generates workload from the integer interval
   - implement singleton workload generator that generates single workload
   - implement string workload generator that generates random strings
+  - implement file workload generator that generates random text files
   - add :ckey:`generators.workload` for specification of workload generators in config
   - remodel the notion of workloads to accept the workload generators to allow other style of workloads
 

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -327,14 +327,21 @@ List of Supported Options
           workload:
             - id: gen1
               type: integer
+              profile_for_each_workload: True
             - id: gen2
               type: integer
               min_range: 10
               max_range: 100
               step: 10
 
-    This specifies two integer workload generators ``gen1`` and ``gen2``. The first uses the default
-    range, while the latter specifies the range 10, 20, ..., 100.
+    This specifies two integer workload generators ``gen1`` and ``gen2``. The first uses the
+    default range, while the latter specifies the range 10, 20, ..., 100. If
+    ``profile_for_each_workload`` is set to true value (true, yes, etc.), then isolate profile will
+    be generated for each collected workload. Otherwise the resulting profiles are merged into the
+    one profile, and each resources has additional key called "workload", that allows using
+    :ref:`_postprocessors-regression-analysis` of amount depending on the workload.
+
+    For more details about supported generators refer to :ref:`jobs-workload-generators`.
 
 .. _config-templates:
 

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -313,6 +313,29 @@ List of Supported Options
               method: bmoe
             - method: aat
 
+.. confkey:: generators.workload
+
+    ``[gathered]`` Specifies generators of the workload. Each workload has to be specified by its
+    ``id`` and ``type``, which corresponds to the name of the generator (currently we support only
+    Integer generator, that generates the range of values). Further you can specify rest of the
+    params, where each workload generator has different parameters. The specification can be as
+    follows:
+
+    .. code-block:: yaml
+
+        generators:
+          workload:
+            - id: gen1
+              type: integer
+            - id: gen2
+              type: integer
+              min_range: 10
+              max_range: 100
+              step: 10
+
+    This specifies two integer workload generators ``gen1`` and ``gen2``. The first uses the default
+    range, while the latter specifies the range 10, 20, ..., 100.
+
 .. _config-templates:
 
 Predefined Configuration Templates

--- a/docs/jobs.rst
+++ b/docs/jobs.rst
@@ -236,6 +236,11 @@ can be set in the configuration:
               - /usr/share
               - << "Hello world!"
 
+   From version 15.1. you can use the workload generators instead. See
+   :ref:`jobs-workload-generators` for more information about supported workload generators and
+   :ckey:`generators.workload` for more information how to specify the workload generators in the
+   configuration files.
+
 .. matrixunit:: collectors
 
    List of collectors used to collect data for the given configuration of application represented
@@ -268,3 +273,34 @@ can be set in the configuration:
                  - method: full
                  - steps: 10
 
+.. _jobs-workload-generators:
+
+List of Supported Workload Generators
+-------------------------------------
+
+.. automodule:: perun.workload
+
+Generic settings
+^^^^^^^^^^^^^^^^
+
+.. automodule:: perun.workload.generator
+
+Singleton Generator
+^^^^^^^^^^^^^^^^^^^
+
+.. automodule:: perun.workload.singleton_generator
+
+Integer Generator
+^^^^^^^^^^^^^^^^^
+
+.. automodule:: perun.workload.integer_generator
+
+String Generator
+^^^^^^^^^^^^^^^^
+
+.. automodule:: perun.workload.string_generator
+
+Text File Generator
+^^^^^^^^^^^^^^^^^^^
+
+.. automodule:: perun.workload.textfile_generator

--- a/perun/cli.py
+++ b/perun/cli.py
@@ -699,7 +699,7 @@ def postprocessby(ctx, profile, **_):
 @click.option('--minor-version', '-m', 'minor_version_list', nargs=1, multiple=True,
               callback=cli_helpers.minor_version_list_callback, default=['HEAD'],
               help='Specifies the head minor version, for which the profiles will be collected.')
-@click.option('--crawl-parents', '-c', is_flag=True, default=False, is_eager=True,
+@click.option('--crawl-parents', '-cp', is_flag=True, default=False, is_eager=True,
               help='If set to true, then for each specified minor versions, profiles for parents'
                    ' will be collected as well')
 @click.option('--cmd', '-c', nargs=1, required=False, multiple=True, default=[''],

--- a/perun/collect/memory/filter.py
+++ b/perun/collect/memory/filter.py
@@ -51,7 +51,7 @@ def set_global_region(profile):
     """
     :param dict profile: partially computed profile
     """
-    profile['global']['resources'] = {}
+    profile['global'] = {}
 
 
 def allocation_filter(profile, function, source):

--- a/perun/collect/memory/parsing.py
+++ b/perun/collect/memory/parsing.py
@@ -72,13 +72,13 @@ def parse_allocation_location(trace):
     return {}
 
 
-def parse_resources(allocation):
+def parse_resources(allocation, workload):
     """ Parse resources of one allocation
 
     :param list allocation: list of raw allocation data
     :returns structure: formatted structure representing resources of one allocation
     """
-    data = {}
+    data = {'workload': workload}
 
     # parsing amount of allocated memory,
     # it's the first number on the second line
@@ -115,7 +115,7 @@ def parse_resources(allocation):
     return data
 
 
-def parse_log(filename, cmd, snapshots_interval):
+def parse_log(filename, cmd, snapshots_interval, workload):
     """ Parse raw data in the log file
 
     :param string filename: name of the log file
@@ -182,13 +182,10 @@ def parse_log(filename, cmd, snapshots_interval):
 
         # using parse_resources()
         # parsing resources,
-        data['resources'].append(parse_resources(allocation))
+        data['resources'].append(parse_resources(allocation, workload))
 
     if data:
         snapshots.append(data)
-
-    # WTF IS THIS?
-    #glob[0].update({'resources': [snapshots[-1]['resources'][-1]]})
 
     return {'snapshots': snapshots, 'global': {'resources': []}}
 

--- a/perun/collect/memory/run.py
+++ b/perun/collect/memory/run.py
@@ -70,12 +70,13 @@ def collect(cmd, args, workload, **_):
     return CollectStatus.OK, '', {}
 
 
-def after(cmd, sampling=DEFAULT_SAMPLING, **kwargs):
+def after(cmd, workload, sampling=DEFAULT_SAMPLING, **kwargs):
     """ Phase after the collection for minor postprocessing
         that needs to be done after collect
 
     :param string cmd: binary file to profile
     :param int sampling: sampling of the collection of the data
+    :param str workload: workload for which we are collecting the data
     :param dict kwargs: profile's header
     :returns tuple: (return code, message, updated kwargs)
 
@@ -101,7 +102,7 @@ def after(cmd, sampling=DEFAULT_SAMPLING, **kwargs):
 
     print("Generating profile: ", end='')
     try:
-        profile = parser.parse_log(_tmp_log_filename, cmd, sampling)
+        profile = parser.parse_log(_tmp_log_filename, cmd, sampling, workload)
     except IndexError as i_err:
         log.failed()
         return CollectStatus.ERROR, 'Info missing in log file: {}'.format(str(i_err)), {}

--- a/perun/collect/time/run.py
+++ b/perun/collect/time/run.py
@@ -64,7 +64,8 @@ def collect(repeat=10, warmup=3, **kwargs):
                     "uid": kwargs['cmd'],
                     "order": order,
                     "subtype": key,
-                    "type": "time"
+                    "type": "time",
+                    "workload": kwargs['workload']
                 } for (order, key, timing) in times
             ]
         }

--- a/perun/logic/config.py
+++ b/perun/logic/config.py
@@ -184,6 +184,24 @@ degradation:
     apply: all
     strategies:
       - method: average_amount_threshold
+
+generators:
+    workload:
+      - id: basic_strings
+        type: string
+        min_len: 8
+        max_len: 128
+        step: 8
+      - id: basic_integers
+        type: integer
+        min_range: 100
+        max_range: 10000
+        step: 200
+      - id: basic_files
+        type: textfile
+        min_lines: 10
+        max_lines: 10000
+        step: 1000
     """)
 
     write_config_to(path, shared_config)

--- a/perun/profile/factory.py
+++ b/perun/profile/factory.py
@@ -421,6 +421,30 @@ def sort_profiles(profile_list, reverse_profiles=True):
     profile_list.sort(key=operator.attrgetter(sort_order), reverse=reverse_profiles)
 
 
+def merge_resources_of(lhs, rhs):
+    """Merges the resources of lhs and rhs profiles
+
+    :param dict lhs: left operator of the profile merge
+    :param dict rhs: right operator of the profile merge
+    :return: profile with merged resources
+    """
+    # Return lhs/rhs if rhs/lhs is empty
+    if not rhs:
+        return lhs
+    if not lhs:
+        return rhs
+
+    # Note that we assume  that lhs and rhs are the same type ;)
+    if 'global' in lhs.keys() and lhs['global']:
+        lhs['global']['resources'].extend(rhs['global']['resources'])
+        lhs['global']['timestamp'] += rhs['global']['timestamp']
+
+    if 'snapshots' in lhs.keys():
+        lhs['snapshots'].extend(rhs['snapshots'])
+
+    return lhs
+
+
 class ProfileInfo(object):
     """Structure for storing information about profiles.
 

--- a/perun/utils/helpers.py
+++ b/perun/utils/helpers.py
@@ -3,6 +3,8 @@
 import re
 import operator
 import collections
+import namedlist
+
 from enum import Enum
 from perun.utils.structs import PerformanceChange
 
@@ -64,7 +66,7 @@ RAW_ITEM_COLOUR = 'yellow'
 RAW_ATTRS = []
 
 # Job specific
-Job = collections.namedtuple("Job", "collector postprocessors cmd workload args")
+Job = namedlist.namedlist("Job", "collector postprocessors cmd workload args")
 Unit = collections.namedtuple("Unit", "name params")
 
 COLLECT_PHASE_CMD = 'blue'

--- a/perun/utils/structs.py
+++ b/perun/utils/structs.py
@@ -1,8 +1,12 @@
 """List of helper and globally used structures and named tuples"""
 
+import collections
+
 from enum import Enum
 
 __author__ = 'Tomas Fiedor'
+
+GeneratorSpec = collections.namedtuple('GeneratorSpec', 'constructor params')
 
 PerformanceChange = Enum(
     'PerformanceChange',

--- a/perun/workload/__init__.py
+++ b/perun/workload/__init__.py
@@ -1,4 +1,4 @@
-"""From version 15.1, Perun supports the specification of workload generators, instead of raw
+"""From version 0.15.1, Perun supports the specification of workload generators, instead of raw
 workload values specified in :munit:`workloads`. These generators continuously generates workloads
 and internally Perun either merges the resources into one single profile or gradually generates
 profile for each workload.

--- a/perun/workload/__init__.py
+++ b/perun/workload/__init__.py
@@ -7,4 +7,46 @@ also serve as missing independent variable.
 This package contains the general generator object and the concrete generators of workload, such
 as the string workload, integer workload, etc.
 """
+
+import collections
+
+import perun.logic.config as config
+import perun.utils.log as log
+import perun.utils as utils
+
 __author__ = 'Tomas Fiedor'
+
+GeneratorSpec = collections.namedtuple('GeneratorSpec', 'constructor params')
+
+
+def load_generator_specifications():
+    """Collects from configuration file all of the workload specifications and constructs a mapping
+    of 'id' -> GeneratorSpec, which contains the constructor and parameters used for construction.
+
+    The specifications are specified by :ckey:`generators.workload` as follows:
+
+    generators:
+      workload:
+        - id: name_of_generator
+          type: integer
+          min_range: 10
+          max_range: 20
+
+    :return: map of ids to generator specifications
+    """
+    specifications_from_config = config.gather_key_recursively('generators.workload')
+    spec_map = {}
+    for spec in specifications_from_config:
+        if 'id' not in spec.keys() or 'type' not in spec.keys():
+            log.warn("incorrect workload specification: missing 'id' or 'type'")
+            continue
+        generator_module = "perun.workload.{}_generator".format(spec['type'].lower())
+        constructor_name = "{}Generator".format(spec['type'].title())
+        try:
+            constructor = getattr(utils.get_module(generator_module), constructor_name)
+            spec_map[spec['id']] = GeneratorSpec(constructor, spec)
+        except (ImportError, AttributeError):
+            log.warn("incorrect workload generator '{}': '{}' is not valid workload type".format(
+                spec['id'], spec['type']
+            ))
+    return spec_map

--- a/perun/workload/__init__.py
+++ b/perun/workload/__init__.py
@@ -5,6 +5,12 @@ profile for each workload.
 
 The generators are specified by :ckey:`generators.workload` section. These specifications are
 collected through all of the configurations in the hierarchy.
+
+You can use some basic generators specified in shared configurations called ``basic_strings``
+(which generates strings of lengths from interval (8, 128) with increment of 8), ``basic_integers``
+(which generates integers from interval (100, 10000), with increment of 200) or ``basic_files``
+(which generates text files with number of lines from interval (10, 10000), with increment of
+1000).
 """
 
 import perun.logic.config as config

--- a/perun/workload/__init__.py
+++ b/perun/workload/__init__.py
@@ -1,11 +1,10 @@
-"""Package containing generators of workloads.
+"""From version 15.1, Perun supports the specification of workload generators, instead of raw
+workload values specified in :munit:`workloads`. These generators continuously generates workloads
+and internally Perun either merges the resources into one single profile or gradually generates
+profile for each workload.
 
-In previous Perun version, the workloads were considered to be string supplied by the user.
-Now, this has been changed to a set of generators, that can generate a wider range of values and
-also serve as missing independent variable.
-
-This package contains the general generator object and the concrete generators of workload, such
-as the string workload, integer workload, etc.
+The generators are specified by :ckey:`generators.workload` section. These specifications are
+collected through all of the configurations in the hierarchy.
 """
 
 import perun.logic.config as config

--- a/perun/workload/__init__.py
+++ b/perun/workload/__init__.py
@@ -1,0 +1,10 @@
+"""Package containing generators of workloads.
+
+In previous Perun version, the workloads were considered to be string supplied by the user.
+Now, this has been changed to a set of generators, that can generate a wider range of values and
+also serve as missing independent variable.
+
+This package contains the general generator object and the concrete generators of workload, such
+as the string workload, integer workload, etc.
+"""
+__author__ = 'Tomas Fiedor'

--- a/perun/workload/generator.py
+++ b/perun/workload/generator.py
@@ -1,5 +1,13 @@
-"""Generic object to be inherited from. Contains the basic method and API"""
+"""All generators can be configured using the following generic settings:
 
+  * ``profile_for_each_workload``: by default this option is set to false, and then when one uses
+    the generator to generate the workload, the collected resources will be merged into one single
+    profile. If otherwise this option is set to true value (true, 1, yes, etc.) then Perun will
+    generate profile for each of the generated workload.
+
+"""
+
+import distutils.util as dutils
 import perun.utils.log as log
 import perun.profile.factory as profile
 
@@ -9,10 +17,10 @@ __author__ = 'Tomas Fiedor'
 
 
 class Generator(object):
-    """Base object for generation of the workloads
+    """Generator is a base object of all generators and contains generic options for all generators.
 
-    :ivar Job job: job for which we are collecting the data
-    :ivar str generator_name: name of the workload generator
+    :ivar bool profile_for_each_workload: if set to true, then we will generate one profile
+        for each workload, otherwise the workload will be merged into one single profile
     """
     def __init__(self, job, profile_for_each_workload=False, **_):
         """Initializes the job of the generator
@@ -24,12 +32,10 @@ class Generator(object):
         """
         self.job = job
         self.generator_name = self.job.workload
-        self.for_each = profile_for_each_workload
+        self.for_each = dutils.strtobool(str(profile_for_each_workload))
 
     def generate(self, collect_function):
         """Collects the data for the generated workload
-
-        TODO: Merge the workload stuff
 
         :return: tuple of collection status and collected profile
         """

--- a/perun/workload/generator.py
+++ b/perun/workload/generator.py
@@ -1,7 +1,6 @@
 """Generic object to be inherited from. Contains the basic method and API"""
 
 import perun.utils.log as log
-import perun.logic.runner as runner
 
 __author__ = 'Tomas Fiedor'
 
@@ -18,7 +17,7 @@ class Generator(object):
         """
         self.job = job
 
-    def generate(self):
+    def generate(self, collect_function):
         """Collects the data for the generated workload
 
         TODO: Merge the workload stuff
@@ -27,7 +26,7 @@ class Generator(object):
         """
         for workload in self._generate_next_workload():
             self.job.collector.params['workload'] = str(workload)
-            c_status, prof = runner.run_collector(self.job.collector, self.job)
+            c_status, prof = collect_function(self.job.collector, self.job)
             yield c_status, prof
 
     def _generate_next_workload(self):

--- a/perun/workload/generator.py
+++ b/perun/workload/generator.py
@@ -9,13 +9,16 @@ class Generator(object):
     """Base object for generation of the workloads
 
     :ivar Job job: job for which we are collecting the data
+    :ivar str generator_name: name of the workload generator
     """
-    def __init__(self, job):
+    def __init__(self, job, **_):
         """Initializes the job of the generator
 
         :param Job job: job for which we will initialize the generator
+        :param dict _: additional keyword arguments
         """
         self.job = job
+        self.generator_name = self.job.workload
 
     def generate(self, collect_function):
         """Collects the data for the generated workload
@@ -26,6 +29,7 @@ class Generator(object):
         """
         for workload in self._generate_next_workload():
             self.job.collector.params['workload'] = str(workload)
+            self.job.workload = "{}_{}".format(self.generator_name, str(workload))
             c_status, prof = collect_function(self.job.collector, self.job)
             yield c_status, prof
 

--- a/perun/workload/generator.py
+++ b/perun/workload/generator.py
@@ -1,0 +1,35 @@
+"""Generic object to be inherited from. Contains the basic method and API"""
+
+import perun.utils.log as log
+import perun.logic.runner as runner
+
+__author__ = 'Tomas Fiedor'
+
+
+class Generator(object):
+    """Base object for generation of the workloads
+
+    :ivar Job job: job for which we are collecting the data
+    """
+    def __init__(self, job):
+        """Initializes the job of the generator
+
+        :param Job job: job for which we will initialize the generator
+        """
+        self.job = job
+
+    def generate(self):
+        """Collects the data for the generated workload
+
+        TODO: Merge the workload stuff
+
+        :return: tuple of collection status and collected profile
+        """
+        for workload in self._generate_next_workload():
+            self.job.collector.params['workload'] = str(workload)
+            c_status, prof = runner.run_collector(self.job.collector, self.job)
+            yield c_status, prof
+
+    def _generate_next_workload(self):
+        """Logs error, since each generator should generate the workloads in different ways"""
+        log.error("using invalid generator: does not implement _generate_next_workload function!")

--- a/perun/workload/generator.py
+++ b/perun/workload/generator.py
@@ -1,6 +1,9 @@
 """Generic object to be inherited from. Contains the basic method and API"""
 
 import perun.utils.log as log
+import perun.profile.factory as profile
+
+from perun.utils.helpers import CollectStatus
 
 __author__ = 'Tomas Fiedor'
 
@@ -11,14 +14,17 @@ class Generator(object):
     :ivar Job job: job for which we are collecting the data
     :ivar str generator_name: name of the workload generator
     """
-    def __init__(self, job, **_):
+    def __init__(self, job, profile_for_each_workload=False, **_):
         """Initializes the job of the generator
 
         :param Job job: job for which we will initialize the generator
+        :param bool profile_for_each_workload: if set to true, then we will generate one profile
+            for each workload, otherwise the workload will be merged into one single profile
         :param dict _: additional keyword arguments
         """
         self.job = job
         self.generator_name = self.job.workload
+        self.for_each = profile_for_each_workload
 
     def generate(self, collect_function):
         """Collects the data for the generated workload
@@ -27,11 +33,22 @@ class Generator(object):
 
         :return: tuple of collection status and collected profile
         """
+        collective_profile, collective_status = {}, CollectStatus.OK
+
         for workload in self._generate_next_workload():
             self.job.collector.params['workload'] = str(workload)
-            self.job.workload = "{}_{}".format(self.generator_name, str(workload))
+            self.job.workload = "{}_{}".format(self.generator_name, str(workload)) \
+                if self.for_each else self.generator_name
             c_status, prof = collect_function(self.job.collector, self.job)
-            yield c_status, prof
+            if self.for_each:
+                yield c_status, prof
+            else:
+                collective_status = \
+                    CollectStatus.ERROR if collective_status == CollectStatus.ERROR else c_status
+                collective_profile = profile.merge_resources_of(collective_profile, prof)
+
+        if collective_profile:
+            yield collective_status, collective_profile
 
     def _generate_next_workload(self):
         """Logs error, since each generator should generate the workloads in different ways"""

--- a/perun/workload/integer_generator.py
+++ b/perun/workload/integer_generator.py
@@ -12,16 +12,16 @@ class IntegerGenerator(Generator):
     :ivar int max_range: the maximal value that should be generated
     :ivar int step: the step of the integer generation
     """
-    def __init__(self, job, min_range, max_range, step=1, **_):
+    def __init__(self, job, min_range, max_range, step=1, **kwargs):
         """Initializes the generator of integer workload
 
         :param Job job: job for which we are generating the workloads
         :param int min_range: the minimal value that should be generated
         :param int max_range: the maximal value that should be generated
         :param int step: step of the integer generator
-        :param dict _: additional keyword arguments
+        :param dict kwargs: additional keyword arguments
         """
-        super().__init__(job)
+        super().__init__(job, **kwargs)
 
         self.min_range = int(min_range)
         self.max_range = int(max_range)

--- a/perun/workload/integer_generator.py
+++ b/perun/workload/integer_generator.py
@@ -1,0 +1,35 @@
+"""Simple generator that generates integer values from given interval"""
+
+from perun.workload.generator import Generator
+
+__author__ = 'Tomas Fiedor'
+
+
+class IntegerGenerator(Generator):
+    """Generator of integer values
+
+    :ivar int min_range: the minimal value that should be generated
+    :ivar int max_range: the maximal value that should be generated
+    :ivar int step: the step of the integer generation
+    """
+    def __init__(self, job, min_range, max_range, step=1):
+        """Initializes the generator of integer workload
+
+        :param Job job: job for which we are generating the workloads
+        :param int min_range: the minimal value that should be generated
+        :param int max_range: the maximal value that should be generated
+        :param int step: step of the integer generator
+        """
+        super().__init__(job)
+
+        self.min_range = min_range
+        self.max_range = max_range
+        self.step = step
+
+    def _generate_next_workload(self):
+        """Generates the next integer as the workload
+
+        :return: integer number from the given range and after given step
+        """
+        for integer in range(self.min_range, self.max_range+1, self.step):
+            yield integer

--- a/perun/workload/integer_generator.py
+++ b/perun/workload/integer_generator.py
@@ -1,4 +1,27 @@
-"""Simple generator that generates integer values from given interval"""
+"""Integer Generator generates the range of the integers.
+
+The Integer Generator starts from the ``min_range`` workload, and continuously increments this
+value by ``step`` (by default equal to 1) until it reaches max_range (including).
+
+The following shows the example of integer generator, which continuously generates workloads
+10, 20, ..., 90, 100:
+
+  .. code-block:: yaml
+
+      generators:
+        workload:
+          - id: integer_generator
+            type: integer
+            min_range: 10
+            max_range: 100
+            step: 10
+
+The Integer Generator can be configured by following options:
+
+  * ``min_range``: the minimal integer value that shall be generated.
+  * ``max_range``: the maximal integer value that shall be generated.
+  * ``step``: the step (or increment) of the range.
+"""
 
 from perun.workload.generator import Generator
 

--- a/perun/workload/integer_generator.py
+++ b/perun/workload/integer_generator.py
@@ -12,19 +12,20 @@ class IntegerGenerator(Generator):
     :ivar int max_range: the maximal value that should be generated
     :ivar int step: the step of the integer generation
     """
-    def __init__(self, job, min_range, max_range, step=1):
+    def __init__(self, job, min_range, max_range, step=1, **_):
         """Initializes the generator of integer workload
 
         :param Job job: job for which we are generating the workloads
         :param int min_range: the minimal value that should be generated
         :param int max_range: the maximal value that should be generated
         :param int step: step of the integer generator
+        :param dict _: additional keyword arguments
         """
         super().__init__(job)
 
-        self.min_range = min_range
-        self.max_range = max_range
-        self.step = step
+        self.min_range = int(min_range)
+        self.max_range = int(max_range)
+        self.step = int(step)
 
     def _generate_next_workload(self):
         """Generates the next integer as the workload

--- a/perun/workload/singleton_generator.py
+++ b/perun/workload/singleton_generator.py
@@ -1,4 +1,14 @@
-"""Simple generator that generates single value"""
+"""Singleton Generator generates only one single value. This generator corresponds to the default
+behaviour of Perun, i.e. when each specified workload in :munit:`workloads` was passed to profiled
+program as string.
+
+Currently be default, any string specified in :munit:`workloads`, that does not correspond to some
+generator specified in :ckey:`generators.workload`, is converted to Singleton Generator.
+
+The Singleton Generator can be configured by following options:
+
+  * ``value``: singleton value that is passed as workload.
+"""
 
 from perun.workload.generator import Generator
 

--- a/perun/workload/singleton_generator.py
+++ b/perun/workload/singleton_generator.py
@@ -10,13 +10,13 @@ class SingletonGenerator(Generator):
 
     :ivar object value: singleton value used as workload
     """
-    def __init__(self, job, value):
+    def __init__(self, job, value, **kwargs):
         """Initializes the generator of singleton workload
 
         :param Job job: job for which we are generating the workloads
         :param value: singleton value that is used as workload
         """
-        super().__init__(job)
+        super().__init__(job, **kwargs)
 
         self.value = value
 

--- a/perun/workload/singleton_generator.py
+++ b/perun/workload/singleton_generator.py
@@ -26,4 +26,3 @@ class SingletonGenerator(Generator):
         :return: single value
         """
         yield self.value
-

--- a/perun/workload/singleton_generator.py
+++ b/perun/workload/singleton_generator.py
@@ -1,4 +1,4 @@
-""""""
+"""Simple generator that generates single value"""
 
 from perun.workload.generator import Generator
 

--- a/perun/workload/singleton_generator.py
+++ b/perun/workload/singleton_generator.py
@@ -1,0 +1,29 @@
+""""""
+
+from perun.workload.generator import Generator
+
+__author__ = 'Tomas Fiedor'
+
+
+class SingletonGenerator(Generator):
+    """Generator of singleton values
+
+    :ivar object value: singleton value used as workload
+    """
+    def __init__(self, job, value):
+        """Initializes the generator of singleton workload
+
+        :param Job job: job for which we are generating the workloads
+        :param value: singleton value that is used as workload
+        """
+        super().__init__(job)
+
+        self.value = value
+
+    def _generate_next_workload(self):
+        """Generates the next integer as the workload
+
+        :return: single value
+        """
+        yield self.value
+

--- a/perun/workload/string_generator.py
+++ b/perun/workload/string_generator.py
@@ -1,4 +1,28 @@
-"""Generator of random strings"""
+"""String Generator generates strings of changing length.
+
+The String Generators starts generating random strings starting from the ``min_len``, and
+continuously increments this length by ``step_len`` (by default equal to 1), until it reaches
+the ``max_len`` (including).
+
+The following shows the example of integer generator, which continuously generates workload strings
+of length 1, 2, ..., 9, 10:
+
+  .. code-block:: yaml
+
+      generators:
+        workload:
+          - id: string_generator
+            type: string
+            min_len: 1
+            max_len: 10
+            step_len: 1
+
+The String Generator can be configured by following options:
+
+  * ``min_len``: the minimal length of the string that shall be generated.
+  * ``max_len``: the maximal length of the string that shall be generated.
+  * ``step_len``: the step (or increment) of the lengths.
+"""
 
 import random
 import string
@@ -15,20 +39,20 @@ class StringGenerator(Generator):
     :ivar int max_len: maximal length of generated strings
     :ivar int step_len: increment of the lengths
     """
-    def __init__(self, job, min_len, max_len, step=1, **kwargs):
+    def __init__(self, job, min_len, max_len, step_len=1, **kwargs):
         """Initializes the generator of string workloads
 
         :param Job job: job for which we are generating the workloads
         :param int min_len: minimal length of the generated string
         :param int max_len: maximal length of the generated string
-        :param int step: step for generating the strings
+        :param int step_len: step for generating the strings
         :param dict kwargs: additional keyword arguments
         """
         super().__init__(job, **kwargs)
 
         self.min_len = int(min_len)
         self.max_len = int(max_len)
-        self.step_len = int(step)
+        self.step_len = int(step_len)
 
     def _generate_next_workload(self):
         """Generates the next random string with increased length

--- a/perun/workload/string_generator.py
+++ b/perun/workload/string_generator.py
@@ -15,15 +15,16 @@ class StringGenerator(Generator):
     :ivar int max_len: maximal length of generated strings
     :ivar int step_len: increment of the lengths
     """
-    def __init__(self, job, min_len, max_len, step=1):
+    def __init__(self, job, min_len, max_len, step=1, **kwargs):
         """Initializes the generator of string workloads
 
-        :param job:
-        :param min_len:
-        :param max_len:
-        :param step:
+        :param Job job: job for which we are generating the workloads
+        :param int min_len: minimal length of the generated string
+        :param int max_len: maximal length of the generated string
+        :param int step: step for generating the strings
+        :param dict kwargs: additional keyword arguments
         """
-        super().__init__(job)
+        super().__init__(job, **kwargs)
 
         self.min_len = int(min_len)
         self.max_len = int(max_len)

--- a/perun/workload/string_generator.py
+++ b/perun/workload/string_generator.py
@@ -36,6 +36,6 @@ class StringGenerator(Generator):
         """
         for str_len in range(self.min_len, self.max_len+1, self.step_len):
             yield "".join(
-                random.choice(string.ascii_letters + string.digits + string.whitespace)
+                random.choice(string.ascii_letters + string.digits)
                 for _ in range(str_len)
             )

--- a/perun/workload/string_generator.py
+++ b/perun/workload/string_generator.py
@@ -1,0 +1,41 @@
+"""Generator of random strings"""
+
+import random
+import string
+
+from perun.workload.generator import Generator
+
+__author__ = 'Tomas Fiedor'
+
+
+class StringGenerator(Generator):
+    """Generator of random strings
+
+    :ivar int min_len: minimal length of generated strings
+    :ivar int max_len: maximal length of generated strings
+    :ivar int step_len: increment of the lengths
+    """
+    def __init__(self, job, min_len, max_len, step=1):
+        """Initializes the generator of string workloads
+
+        :param job:
+        :param min_len:
+        :param max_len:
+        :param step:
+        """
+        super().__init__(job)
+
+        self.min_len = int(min_len)
+        self.max_len = int(max_len)
+        self.step_len = int(step)
+
+    def _generate_next_workload(self):
+        """Generates the next random string with increased length
+
+        :return: random string of length in interval (min, max)
+        """
+        for str_len in range(self.min_len, self.max_len+1, self.step_len):
+            yield "".join(
+                random.choice(string.ascii_letters + string.digits + string.whitespace)
+                for _ in range(str_len)
+            )

--- a/perun/workload/textfile_generator.py
+++ b/perun/workload/textfile_generator.py
@@ -1,0 +1,85 @@
+"""Generator of random text files"""
+
+import os
+import tempfile
+import random
+import faker
+
+from perun.workload.generator import Generator
+
+__author__ = 'Tomas Fiedor'
+
+
+class TextfileGenerator(Generator):
+    """Generator of random text files
+
+    :ivar int min_lines: minimal number of lines in generated text file
+    :ivar int max_lines: maximal number of lines in generated text file
+    :ivar int step: step for lines in generated text file
+    :ivar int min_chars_in_row: minimal number of rows/chars on one line in the text file
+    :ivar int max_chars_in_row: maximal number of rows/chars on one line in the text file
+    :ivar bool randomize_rows: if set to true, then the lines in the file will be
+        randomized. Otherwise they will always be maximal.
+    :ivar Faker faker: faker of the data
+    """
+    def __init__(self, job, min_lines, max_lines, step=1, min_rows=5, max_rows=80,
+                 randomize_rows=True):
+        """Initializes the generator of random text files
+
+        :param Job job: job for which we are generating workloads
+        :param int min_lines: minimal number of lines in generated text file
+        :param int max_lines: maximal number of lines in generated text file
+        :param int step: step for lines in generated text file
+        :param int min_rows: minimal number of rows/chars on one line in the text file
+        :param int max_rows: maximal number of rows/chars on one line in the text file
+        :param bool randomize_rows: if set to true, then the lines in the file will be
+            randomized. Otherwise they will always be maximal.
+        """
+        super().__init__(job)
+
+        # Line specific attributes
+        self.min_lines = min_lines
+        self.max_lines = max_lines
+        self.step = step
+
+        # Row / Character specific
+        # Note that faker has a lower limit on generated text.
+        self.min_chars_in_row = max(min_rows, 5)
+        self.max_chars_in_row = max_rows
+        self.randomize_rows = randomize_rows
+
+        self.faker = faker.Faker()
+
+    def _get_line(self):
+        """Generates text of given length
+
+        :return: one random line of lorem ipsum dolor text
+        """
+        line_len = random.randint(self.min_chars_in_row, self.max_chars_in_row + 1) \
+            if self.randomize_rows else self.max_chars_in_row
+        return self.faker.text(max_nb_chars=line_len).replace('\n', ' ')
+
+    def _get_file_content(self, file_len):
+        """Generates text file content for the file of given length
+
+        :param int file_len: length of the generated file contents
+        :return: content to be used in randomly generated file
+        """
+        return "\n".join(
+            self._get_line() for _ in range(file_len)
+        )
+
+    def _generate_next_workload(self):
+        """Generates next file workload
+
+        :return: path to a file
+        """
+        for file_len in range(self.min_lines, self.max_lines + 1):
+            fd, path = tempfile.mkstemp()
+            try:
+                print("Generating {}".format(path))
+                with os.fdopen(fd, 'w') as tmpfile:
+                    tmpfile.write(self._get_file_content(file_len))
+                yield path
+            finally:
+                os.remove(path)

--- a/perun/workload/textfile_generator.py
+++ b/perun/workload/textfile_generator.py
@@ -23,7 +23,7 @@ class TextfileGenerator(Generator):
     :ivar Faker faker: faker of the data
     """
     def __init__(self, job, min_lines, max_lines, step=1, min_rows=5, max_rows=80,
-                 randomize_rows=True):
+                 randomize_rows=True, **kwargs):
         """Initializes the generator of random text files
 
         :param Job job: job for which we are generating workloads
@@ -34,18 +34,19 @@ class TextfileGenerator(Generator):
         :param int max_rows: maximal number of rows/chars on one line in the text file
         :param bool randomize_rows: if set to true, then the lines in the file will be
             randomized. Otherwise they will always be maximal.
+        :param dict kwargs: additional keyword arguments
         """
-        super().__init__(job)
+        super().__init__(job, **kwargs)
 
         # Line specific attributes
-        self.min_lines = min_lines
-        self.max_lines = max_lines
-        self.step = step
+        self.min_lines = int(min_lines)
+        self.max_lines = int(max_lines)
+        self.step = int(step)
 
         # Row / Character specific
         # Note that faker has a lower limit on generated text.
-        self.min_chars_in_row = max(min_rows, 5)
-        self.max_chars_in_row = max_rows
+        self.min_chars_in_row = max(int(min_rows), 5)
+        self.max_chars_in_row = int(max_rows)
         self.randomize_rows = randomize_rows
 
         self.faker = faker.Faker()

--- a/perun/workload/textfile_generator.py
+++ b/perun/workload/textfile_generator.py
@@ -1,5 +1,37 @@
-"""Generator of random text files"""
+"""Text File Generator generates the range of random files.
 
+The TextFile Generator generates files with random contents (lorem ipsum) starting from
+``min_lines``, and continuously increments this value by ``step`` until the number of lines in
+the generated file reaches ``max_lines``. Each row will then either have maximal length of
+``max_chars`` (if ``randomize_rows`` is set to false value), otherwise the length is randomized
+from the interval (``min_lines``, ``max_lines``).
+
+The following shows the example of integer generator, which continuously generates workloads
+10, 20, ..., 90, 100:
+
+  .. code-block:: yaml
+
+      generators:
+        workload:
+          - id: textfile_generator
+            type: textfile
+            min_lines: 10
+            max_lines: 100
+            step: 10
+
+The TextFile Generator can be configured by following options:
+
+  * ``min_lines``: the minimal number of lines in the file that shall be generated.
+  * ``max_lines``: the maximal number of lines in the file that shall be generated.
+  * ``step``: the step (or increment) of the range. By default set to 1.
+  * ``min_chars``: the minimal number of characters on one line. By default set to 5.
+  * ``max_chars``: the maximal number of characters on one line. By default set to 80.
+  * ``randomize_rows``: by default set to True, the rows in the file have then randomized length
+    from interval (``min_chars``, ``max_chars``). Otherwise (if set to false), the lines will always
+    be of maximal length (``max_chars``).
+"""
+
+import distutils.util as dutils
 import os
 import tempfile
 import random
@@ -16,11 +48,10 @@ class TextfileGenerator(Generator):
     :ivar int min_lines: minimal number of lines in generated text file
     :ivar int max_lines: maximal number of lines in generated text file
     :ivar int step: step for lines in generated text file
-    :ivar int min_chars_in_row: minimal number of rows/chars on one line in the text file
-    :ivar int max_chars_in_row: maximal number of rows/chars on one line in the text file
+    :ivar int min_chars: minimal number of rows/chars on one line in the text file
+    :ivar int max_chars: maximal number of rows/chars on one line in the text file
     :ivar bool randomize_rows: if set to true, then the lines in the file will be
         randomized. Otherwise they will always be maximal.
-    :ivar Faker faker: faker of the data
     """
     def __init__(self, job, min_lines, max_lines, step=1, min_rows=5, max_rows=80,
                  randomize_rows=True, **kwargs):
@@ -45,9 +76,9 @@ class TextfileGenerator(Generator):
 
         # Row / Character specific
         # Note that faker has a lower limit on generated text.
-        self.min_chars_in_row = max(int(min_rows), 5)
-        self.max_chars_in_row = int(max_rows)
-        self.randomize_rows = randomize_rows
+        self.min_chars = max(int(min_rows), 5)
+        self.max_chars = int(max_rows)
+        self.randomize_rows = dutils.strtobool(str(randomize_rows))
 
         self.faker = faker.Faker()
 
@@ -56,8 +87,8 @@ class TextfileGenerator(Generator):
 
         :return: one random line of lorem ipsum dolor text
         """
-        line_len = random.randint(self.min_chars_in_row, self.max_chars_in_row + 1) \
-            if self.randomize_rows else self.max_chars_in_row
+        line_len = random.randint(self.min_chars, self.max_chars + 1) \
+            if self.randomize_rows else self.max_chars
         return self.faker.text(max_nb_chars=line_len).replace('\n', ' ')
 
     def _get_file_content(self, file_len):

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ sphinx-click==1.0.3
 Jinja2==2.9.6
 python-magic>=0.4
 scipy>=0.19.1
+Faker>=0.8.16

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ Jinja2==2.9.6
 python-magic>=0.4
 scipy>=0.19.1
 Faker>=0.8.16
+namedlist>=1.7

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,8 @@ setup(
     ]},
     install_requires=[
         'click', 'termcolor', 'colorama', 'ruamel.yaml', 'GitPython', 'bokeh', 'pandas',
-        'demandimport', 'Sphinx', 'sphinx-click', 'Jinja2', 'python-magic', 'scipy', 'faker'
+        'demandimport', 'Sphinx', 'sphinx-click', 'Jinja2', 'python-magic', 'scipy', 'faker',
+        'namedlist'
     ],
 
     entry_points='''

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     ]},
     install_requires=[
         'click', 'termcolor', 'colorama', 'ruamel.yaml', 'GitPython', 'bokeh', 'pandas',
-        'demandimport', 'Sphinx', 'sphinx-click', 'Jinja2', 'python-magic', 'scipy'
+        'demandimport', 'Sphinx', 'sphinx-click', 'Jinja2', 'python-magic', 'scipy', 'faker'
     ],
 
     entry_points='''

--- a/tests/collect_memory/memory_collect_test.c
+++ b/tests/collect_memory/memory_collect_test.c
@@ -6,7 +6,6 @@
  * Author:      Podola Radim, xpodol06@stud.fit.vutbr.cz
  * Description: Testing file for injected malloc.so library.
 
-TODO: Test for all allocation functions, use assert?
  */
 #include <stdio.h>
 #include <stdlib.h>
@@ -21,16 +20,23 @@ void fun() {
 }
 
 
-int main(){
+int main(int argc, char** argv){
 
 	int *n, *m, res;
+
+	int repeats = 1;
+	if (argc == 2) {
+        repeats = atoi(argv[1]);
+	}
 
 	n = (int*)malloc(sizeof(int));
 	*n = 5;
 	free(n);
 
-	for (int i = 0; i < 1000000; ++i);
-	fun();
+    while(repeats--) {
+        for (int i = 0; i < 1000000; ++i);
+        fun();
+	}
 
 	m = (int*)malloc(sizeof(int));
 	*m = 5;

--- a/tests/test_collect.py
+++ b/tests/test_collect.py
@@ -8,6 +8,7 @@ import perun.profile.query as query
 import perun.collect.complexity.run as complexity
 
 from perun.utils.helpers import Unit, Job
+from perun.workload.integer_generator import IntegerGenerator
 
 __author__ = 'Tomas Fiedor'
 
@@ -138,6 +139,16 @@ def test_collect_memory(capsys, helpers, pcs_full, memory_collect_job, memory_co
     _, prof = runner.run_collector(collector_unit, job)
 
     assert len(list(query.all_resources_of(prof))) == 0
+
+
+def test_collect_memory_with_generator(pcs_full, memory_collect_job):
+    """Tries to collect the memory with integer generators"""
+    cmd = memory_collect_job[0][0]
+    collector = Unit('memory', {})
+    integer_job = Job(collector, [], cmd, '', '')
+    integer_generator = IntegerGenerator(integer_job, 1, 3, 1)
+    memory_profiles = list(integer_generator.generate(runner.run_collector))
+    assert len(memory_profiles) == 1
 
 
 def test_collect_time(monkeypatch, helpers, pcs_full, capsys):

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -9,6 +9,7 @@ import perun.logic.runner as runner
 from perun.utils.helpers import Job, CollectStatus, Unit
 from perun.workload.integer_generator import IntegerGenerator
 from perun.workload.singleton_generator import SingletonGenerator
+from perun.workload.string_generator import StringGenerator
 from perun.workload.generator import Generator
 
 
@@ -102,3 +103,15 @@ def test_singleton():
         assert len(profile['global']['resources']) > 0
         job_count += 1
     assert job_count == 1
+
+
+def test_string_generator():
+    """Tests string generator"""
+    collector = Unit('time', {})
+    string_job = Job(collector, [], 'expr', 'length', '')
+    string_generator = StringGenerator(string_job, 10, 20, 1)
+
+    for c_status, profile in string_generator.generate(runner.run_collector):
+        assert c_status == CollectStatus.OK
+        assert profile
+        assert len(profile['global']['resources']) > 0

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -34,6 +34,26 @@ def test_integer_generator():
         _ = list(pure_generator.generate(runner.run_collector))
 
 
+def test_integer_generator_for_each():
+    """Tests the profile_for_each_workload option"""
+    # When profile_for_each_workload is not set, we yield profiles for each workload
+    collector = Unit('time', {})
+    integer_job = Job(collector, [], 'factor', '', '')
+    integer_generator = IntegerGenerator(integer_job, 10, 100, 10, profile_for_each_workload=True)
+
+    collection_pairs = list(
+        integer_generator.generate(runner.run_collector)
+    )
+    assert len(collection_pairs) == 10
+
+    # When profile_for_each_workload is set, then we merge the resources
+    integer_generator = IntegerGenerator(integer_job, 10, 100, 10, profile_for_each_workload=False)
+    collection_pairs = list(
+        integer_generator.generate(runner.run_collector)
+    )
+    assert len(collection_pairs) == 1
+
+
 def test_loading_generators_from_config(monkeypatch, pcs_full):
     """Tests loading generator specification from config"""
     # Initialize the testing configurations

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -7,6 +7,7 @@ import perun.workload as workload
 
 from perun.utils.helpers import Job, CollectStatus, Unit
 from perun.workload.integer_generator import IntegerGenerator
+from perun.workload.singleton_generator import SingletonGenerator
 from perun.workload.generator import Generator
 
 
@@ -85,3 +86,18 @@ def test_loading_generators_from_config(monkeypatch, pcs_full):
         assert c_status == CollectStatus.OK
         assert profile
         assert len(profile['global']['resources'])
+
+
+def test_singleton():
+    """Tests singleton generator"""
+    collector = Unit('time', {})
+    integer_job = Job(collector, [], 'factor', '', '')
+    singleton_generator = SingletonGenerator(integer_job, "10")
+
+    job_count = 0
+    for c_status, profile in singleton_generator.generate():
+        assert c_status == CollectStatus.OK
+        assert profile
+        assert len(profile['global']['resources']) > 0
+        job_count += 1
+    assert job_count == 1

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -108,7 +108,7 @@ def test_singleton():
 def test_string_generator():
     """Tests string generator"""
     collector = Unit('time', {})
-    string_job = Job(collector, [], 'expr', 'length', '')
+    string_job = Job(collector, [], 'echo', '', '')
     string_generator = StringGenerator(string_job, 10, 20, 1)
 
     for c_status, profile in string_generator.generate(runner.run_collector):

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -1,0 +1,27 @@
+"""Basic tests of generators"""
+
+import pytest
+
+from perun.utils.helpers import Job, CollectStatus, Unit
+from perun.workload.integer_generator import IntegerGenerator
+from perun.workload.generator import Generator
+
+
+__author__ = 'Tomas Fiedor'
+
+
+def test_integer_generator():
+    """Tests generation of integers from given range"""
+    collector = Unit('time', {})
+    integer_job = Job(collector, [], 'factor', '', '')
+    integer_generator = IntegerGenerator(integer_job, 10, 100, 10)
+
+    for c_status, profile in integer_generator.generate():
+        assert c_status == CollectStatus.OK
+        assert profile
+        assert len(profile['global']['resources']) > 0
+
+    # Try that the pure generator raises error
+    pure_generator = Generator(integer_job)
+    with pytest.raises(SystemExit):
+        _ = list(pure_generator.generate())

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -4,6 +4,7 @@ import pytest
 
 import perun.logic.config as config
 import perun.workload as workload
+import perun.logic.runner as runner
 
 from perun.utils.helpers import Job, CollectStatus, Unit
 from perun.workload.integer_generator import IntegerGenerator
@@ -20,7 +21,7 @@ def test_integer_generator():
     integer_job = Job(collector, [], 'factor', '', '')
     integer_generator = IntegerGenerator(integer_job, 10, 100, 10)
 
-    for c_status, profile in integer_generator.generate():
+    for c_status, profile in integer_generator.generate(runner.run_collector):
         assert c_status == CollectStatus.OK
         assert profile
         assert len(profile['global']['resources']) > 0
@@ -28,7 +29,7 @@ def test_integer_generator():
     # Try that the pure generator raises error
     pure_generator = Generator(integer_job)
     with pytest.raises(SystemExit):
-        _ = list(pure_generator.generate())
+        _ = list(pure_generator.generate(runner.run_collector))
 
 
 def test_loading_generators_from_config(monkeypatch, pcs_full):
@@ -82,7 +83,7 @@ def test_loading_generators_from_config(monkeypatch, pcs_full):
 
     # Now test that the generators really work :P
     constructor, params = spec_map['gen1']
-    for c_status, profile in constructor(integer_job, **params).generate():
+    for c_status, profile in constructor(integer_job, **params).generate(runner.run_collector):
         assert c_status == CollectStatus.OK
         assert profile
         assert len(profile['global']['resources'])
@@ -95,7 +96,7 @@ def test_singleton():
     singleton_generator = SingletonGenerator(integer_job, "10")
 
     job_count = 0
-    for c_status, profile in singleton_generator.generate():
+    for c_status, profile in singleton_generator.generate(runner.run_collector):
         assert c_status == CollectStatus.OK
         assert profile
         assert len(profile['global']['resources']) > 0

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -2,6 +2,9 @@
 
 import pytest
 
+import perun.logic.config as config
+import perun.workload as workload
+
 from perun.utils.helpers import Job, CollectStatus, Unit
 from perun.workload.integer_generator import IntegerGenerator
 from perun.workload.generator import Generator
@@ -25,3 +28,60 @@ def test_integer_generator():
     pure_generator = Generator(integer_job)
     with pytest.raises(SystemExit):
         _ = list(pure_generator.generate())
+
+
+def test_loading_generators_from_config(monkeypatch, pcs_full):
+    """Tests loading generator specification from config"""
+    # Initialize the testing configurations
+    collector = Unit('time', {})
+    integer_job = Job(collector, [], 'factor', '', '')
+    temp_local = config.Config('local', '', {
+        'generators': {
+            'workload': [
+                {
+                    'id': 'gen1',
+                    'type': 'integer',
+                    'min_range': 10,
+                    'max_range': 20,
+                    'step': 1
+                }
+            ]
+        }
+    })
+    temp_global = config.Config('global', '', {
+        'generators': {
+            'workload': [
+                {
+                    'id': 'gen2',
+                    'type': 'integer',
+                    'min_range': 100,
+                    'max_range': 200,
+                    'step': 10
+                },
+                {
+                    'id': 'gen_incorrect',
+                    'min_range': 100
+                },
+                {
+                    'id': 'gen_almost_correct',
+                    'type': 'bogus'
+                }
+            ]
+        }
+    })
+    monkeypatch.setattr("perun.logic.config.local", lambda _: temp_local)
+    monkeypatch.setattr("perun.logic.config.shared", lambda: temp_global)
+
+    spec_map = workload.load_generator_specifications()
+    assert len(spec_map.keys()) == 2
+    assert 'gen1' in spec_map.keys()
+    assert 'gen2' in spec_map.keys()
+    assert 'gen_incorrect' not in spec_map.keys()
+    assert 'gen_almost_correct' not in spec_map.keys()
+
+    # Now test that the generators really work :P
+    constructor, params = spec_map['gen1']
+    for c_status, profile in constructor(integer_job, **params).generate():
+        assert c_status == CollectStatus.OK
+        assert profile
+        assert len(profile['global']['resources'])

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -10,6 +10,7 @@ from perun.utils.helpers import Job, CollectStatus, Unit
 from perun.workload.integer_generator import IntegerGenerator
 from perun.workload.singleton_generator import SingletonGenerator
 from perun.workload.string_generator import StringGenerator
+from perun.workload.textfile_generator import TextfileGenerator
 from perun.workload.generator import Generator
 
 
@@ -112,6 +113,18 @@ def test_string_generator():
     string_generator = StringGenerator(string_job, 10, 20, 1)
 
     for c_status, profile in string_generator.generate(runner.run_collector):
+        assert c_status == CollectStatus.OK
+        assert profile
+        assert len(profile['global']['resources']) > 0
+
+
+def test_file_generator():
+    """Tests file generator"""
+    collector = Unit('time', {})
+    file_job = Job(collector, [], 'wc', '-l', '')
+    file_generator = TextfileGenerator(file_job, 2, 5)
+
+    for c_status, profile in file_generator.generate(runner.run_collector):
         assert c_status == CollectStatus.OK
         assert profile
         assert len(profile['global']['resources']) > 0


### PR DESCRIPTION
This Pull Request rehauls the notion of workloads to support so called workload
generators. In previous version, one simply specified singleton values, which
were passed to the profiled program as they were. Now, one can specified the
workload generators, which continuously generates the workload values and
either merges all of the collected resources through all the runs (for
different generated workloads) or outputs one profile for each generated
workload.

Currently we support the following workload generators:
  1. **Integer**: for generating range of integer values,
  2. **String**: for generating range of strings of increasing length,
  3. **Text File**: for generating random files of increasing number of lines.