### PR TITLE
Stats module

### DIFF
--- a/perun/logic/commands.py
+++ b/perun/logic/commands.py
@@ -161,6 +161,7 @@ def init_perun_at(perun_path, is_reinit, vcs_config, config_template='master'):
     store.touch_dir(os.path.join(perun_full_path, 'jobs'))
     store.touch_dir(os.path.join(perun_full_path, 'logs'))
     store.touch_dir(os.path.join(perun_full_path, 'cache'))
+    store.touch_dir(os.path.join(perun_full_path, 'stats'))
     # If the config does not exist, we initialize the new version
     if not os.path.exists(os.path.join(perun_full_path, 'local.yml')):
         perun_config.init_local_config_at(perun_full_path, vcs_config, config_template)

--- a/perun/logic/index.py
+++ b/perun/logic/index.py
@@ -15,8 +15,10 @@ import perun.utils.log as perun_log
 import perun.utils.helpers as helpers
 import perun.logic.store as store
 import perun.logic.pcs as pcs
+import perun.logic.commands as commands
 
-from perun.utils.exceptions import EntryNotFoundException, MalformedIndexFileException
+from perun.utils.exceptions import (EntryNotFoundException, MalformedIndexFileException,
+                                    IndexNotFoundException)
 
 
 __author__ = 'Tomas Fiedor'
@@ -479,6 +481,62 @@ def lookup_all_entries_within_index(index_handle, predicate):
     :returns [BasicIndexEntry]: list of index entries satisfying given predicate
     """
     return [entry for entry in walk_index(index_handle) if predicate(entry)]
+
+
+def find_minor_index(minor_version):
+    """ Finds the corresponding index for the minor version or raises EntryNotFoundException if
+    the index was not found.
+
+    :param str minor_version: the minor version representation or None for HEAD
+
+    :return str: path to the index file
+    """
+    # Find the index file
+    _, index_file = store.split_object_name(pcs.get_object_directory(), minor_version)
+    if not os.path.exists(index_file):
+        raise IndexNotFoundException(index_file)
+    return index_file
+
+
+@commands.lookup_minor_version
+def find_profile_entry(profile, minor_version):
+    """ Finds the profile entry within the index file of the minor version.
+
+    :param str profile: the profile identification, can be given as tag, sha value,
+                        sha-path (path to tracked profile in obj) or source-name
+    :param str minor_version: the minor version representation or None for HEAD
+
+    :return IndexEntry: the profile entry from the index file
+    """
+
+    def sha_path_to_sha(sha_path):
+        """ Transforms the path of the minor version directory (represented by the SHA value) to
+        the actual SHA value as a string.
+
+        :param str sha_path: path to the minor version directory
+        :return str: the SHA value of the minor version
+        """
+        rest, lower_level = os.path.split(sha_path.rstrip(os.sep))
+        _, upper_level = os.path.split(rest.rstrip(os.sep))
+        return upper_level + lower_level
+
+    minor_index = find_minor_index(minor_version)
+
+    # If profile is given as tag, obtain the sha-path of the file
+    tag_match = store.INDEX_TAG_REGEX.match(profile)
+    if tag_match:
+        profile = commands.get_nth_profile_of(int(tag_match.group(1)), minor_version)
+    # Transform the sha-path (obtained or given) to the sha value
+    if not store.is_sha1(profile) and not profile.endswith('.perf'):
+        profile = sha_path_to_sha(profile)
+
+    # Search the minor index for the requested profile
+    with open(minor_index, 'rb') as index_handle:
+        # The profile can be only sha value or source path now
+        if store.is_sha1(profile):
+            return lookup_entry_within_index(index_handle, lambda x: x.checksum == profile, profile)
+        else:
+            return lookup_entry_within_index(index_handle, lambda x: x.path == profile, profile)
 
 
 def register_in_pending_index(registered_file, profile):

--- a/perun/logic/pcs.py
+++ b/perun/logic/pcs.py
@@ -110,6 +110,17 @@ def get_job_index():
     return os.path.join(jobs_directory, ".index")
 
 
+@singleton
+def get_stats_directory():
+    """Returns the name of the directory where statistics are stored
+
+    :return str: path to the statistics directory
+    """
+    stats_directory = os.path.join(get_path(), 'stats')
+    store.touch_dir(stats_directory)
+    return stats_directory
+
+
 @singleton_with_args
 def get_config_file(config_type):
     """Returns the config file for the given config type

--- a/perun/logic/stats.py
+++ b/perun/logic/stats.py
@@ -60,7 +60,7 @@ def build_stats_filename_as_profile_source(profile, ignore_timestamp, minor_vers
 
     :return str: the generated stats filename (not path!)
     """
-    profile_index_entry = index.find_profile_entry(profile, minor_version)
+    profile_index_entry = find_profile_entry(profile, minor_version)
     stats_name = profile_index_entry.path
     if ignore_timestamp:
         # Remove the timestamp entry in the profile name
@@ -81,7 +81,7 @@ def build_stats_filename_as_profile_sha(profile, minor_version=None):
 
     :return str: the generated stats filename (not path!)
     """
-    return index.find_profile_entry(profile, minor_version).checksum
+    return find_profile_entry(profile, minor_version).checksum
 
 
 def get_stats_file_path(stats_filename, minor_version=None, check_existence=False):
@@ -223,6 +223,49 @@ def _update_or_add_to_dict(dictionary, sid, extension):
         dictionary[sid].update(extension)
     else:
         _add_to_dict(dictionary, sid, extension)
+
+
+@commands.lookup_minor_version
+def find_profile_entry(profile, minor_version):
+    """ Finds the profile entry within the index file of the minor version.
+
+    :param str profile: the profile identification, can be given as tag, sha value,
+                        sha-path (path to tracked profile in obj) or source-name
+    :param str minor_version: the minor version representation or None for HEAD
+
+    :return IndexEntry: the profile entry from the index file
+    """
+
+    def sha_path_to_sha(sha_path):
+        """ Transforms the path of the minor version directory (represented by the SHA value) to
+        the actual SHA value as a string.
+
+        :param str sha_path: path to the minor version directory
+        :return str: the SHA value of the minor version
+        """
+        rest, lower_level = os.path.split(sha_path.rstrip(os.sep))
+        _, upper_level = os.path.split(rest.rstrip(os.sep))
+        return upper_level + lower_level
+
+    minor_index = index.find_minor_index(minor_version)
+
+    # If profile is given as tag, obtain the sha-path of the file
+    tag_match = store.INDEX_TAG_REGEX.match(profile)
+    if tag_match:
+        profile = commands.get_nth_profile_of(int(tag_match.group(1)), minor_version)
+    # Transform the sha-path (obtained or given) to the sha value
+    if not store.is_sha1(profile) and not profile.endswith('.perf'):
+        profile = sha_path_to_sha(profile)
+
+    # Search the minor index for the requested profile
+    with open(minor_index, 'rb') as index_handle:
+        # The profile can be only sha value or source path now
+        if store.is_sha1(profile):
+            return index.lookup_entry_within_index(index_handle, lambda x: x.checksum == profile,
+                                                   profile)
+        else:
+            return index.lookup_entry_within_index(index_handle, lambda x: x.path == profile,
+                                                   profile)
 
 
 @commands.lookup_minor_version

--- a/perun/logic/stats.py
+++ b/perun/logic/stats.py
@@ -1,3 +1,38 @@
+"""This module contains functions for manipulating statistics files (the so called 'stats')
+
+Stats are basically various data or statistics that need to be stored and manipulated by other
+modules, collectors, post-processors etc. The 'stats' file can be indirectly linked to a specific
+profile by using the profile 'source' or 'checksum' as a template for the name of the stats file.
+Or the stats file might be completely unrelated to profiles by using some custom name.
+
+Stats files are located in the .perun/stats directory.
+
+The format of the stats files is as follows:
+
+{
+    'some_ID':
+    {
+        stats data stored by the user
+    },
+
+    'another_ID':
+    {
+        some other stored data
+    },
+
+    'yet_another_ID':
+    {
+        ...
+    }
+}
+
+where the IDs uniquely represent stored statistics within the stats file and the ID is used to
+identify the data that should be manipulated by the functions.
+
+The contents of the stats file are stored in a compressed form to reduce the memory requirements.
+
+"""
+
 import os
 import json
 import re
@@ -6,38 +41,42 @@ import zlib
 import perun.logic.store as store
 import perun.logic.pcs as pcs
 import perun.utils.exceptions as exceptions
-import perun.vcs as vcs
 import perun.logic.commands as commands
+import perun.logic.index as index
 
 
 # Match the timestamp format of the profile names
 PROFILE_TIMESTAMP_REGEX = re.compile(r"(-?\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2})")
 
 
-def get_stats_filename_as_source(profile, ignore_timestamp, minor_version=None):
+def build_stats_filename_as_profile_source(profile, ignore_timestamp, minor_version=None):
     """Generate stats filename based on the 'source' property of the supplied profile,
     i.e. the stats filename will refer to the name of the profile before it was tracked.
 
     :param str profile: the profile identification, can be given as tag, sha value,
-                        sha-path (path to tracked profile in obj) or source-path
+                        sha-path (path to tracked profile in obj) or source-name
     :param bool ignore_timestamp: if set to True, removes the 'date' component in the source name
     :param str minor_version: representation of the minor version or None for HEAD
 
     :return str: the generated stats filename (not path!)
     """
     profile_index_entry = _find_profile_entry(profile, minor_version)
+    stats_name = profile_index_entry.path
     if ignore_timestamp:
         # Remove the timestamp entry in the profile name
-        return PROFILE_TIMESTAMP_REGEX.sub("", profile_index_entry.path)
-    return profile_index_entry.path
+        stats_name = PROFILE_TIMESTAMP_REGEX.sub("", stats_name)
+    if stats_name.endswith('.perf'):
+        # Remove the '.perf' suffix
+        stats_name = stats_name[:-5]
+    return stats_name
 
 
-def get_stats_filename_as_sha(profile, minor_version=None):
+def build_stats_filename_as_profile_sha(profile, minor_version=None):
     """Generate stats filename based on the 'SHA' property of the supplied profile,
     i.e. the stats filename will refer to the name of the profile after its tracking.
 
     :param str profile: the profile identification, can be given as tag, sha value,
-                        sha-path (path to tracked profile in obj) or source-path
+                        sha-path (path to tracked profile in obj) or source-name
     :param str minor_version: representation of the minor version or None for HEAD
 
     :return str: the generated stats filename (not path!)
@@ -60,59 +99,57 @@ def get_stats_file_path(stats_filename, minor_version=None, check_existence=Fals
     stats_dir = _touch_minor_stats_directory(minor_version)
     stats_file = os.path.join(stats_dir, os.path.basename(stats_filename.rstrip(os.sep)))
     # Check if the file exists
-    if check_existence and os.path.exists(stats_file):
+    if check_existence and not os.path.exists(stats_file):
         raise exceptions.StatsFileNotFoundException(stats_file)
     return stats_file
 
 
-def add_stats(stats_id, stats_content, stats_filename, minor_version=None):
+def add_stats(stats_filename, stats_ids, stats_contents, minor_version=None):
     """ Save some stats represented by an ID into the provided stats filename under a specific
-    minor version.
+    minor version. Creates the stats file if it does not exist yet.
 
-    :param str stats_id: a string that serves as a unique identification of the stored stats
-    :param dict stats_content: the stats data to save
     :param str stats_filename: the name of the stats file where the data will be stored
+    :param list of str stats_ids: strings that serve as unique identification of the stored stats
+    :param list of dict stats_contents: the stats data to save
     :param str minor_version: the minor version representation or None for HEAD
 
     :return str: the path to the stats file containing the stored data
     """
 
-    def add_to_dict(dictionary):
-        """ A helper function that stores the stats content in the given dict under the ID
-
-        :param dict dictionary: the dictionary where the content will be stored
-        """
-        dictionary[stats_id] = stats_content
-
     stats_file = get_stats_file_path(stats_filename, minor_version)
-    _modify_stats_file(stats_file, "wb+", add_to_dict)
+    # append: create the file if necessary, be able to read the whole file and write to the file
+    _modify_stats_file(stats_file, stats_ids, stats_contents, _add_to_dict)
 
     return stats_file
 
 
-def update_stats(stats_id, extension, stats_filename, minor_version=None):
+def update_stats(stats_filename, stats_ids, extensions, minor_version=None):
     """ Updates the stats represented by an ID in the given stats filename under a specific
-    minor version. The stats dictionary will be extended by the supplied extension.
+    minor version. The stats dictionary will be extended by the supplied extensions.
 
-    :param str stats_id: a string that serves as a unique identification of the stored stats
-    :param dict extension: the dict with the new / updated values
     :param str stats_filename: the name of the stats file where to update the stats
+    :param list of str stats_ids: strings that serve as unique identification of the stored stats
+    :param list of dict extensions: the dicts with the new / updated values
     :param str minor_version: the minor version representation or None for HEAD
     """
     stats_file = get_stats_file_path(stats_filename, minor_version)
-    _modify_stats_file(stats_file, "wb+", lambda r: r[stats_id].update(extension))
+    _modify_stats_file(stats_file, stats_ids, extensions,
+                       lambda d, sid, ext: d[sid].update(ext) if sid in d
+                       else _add_to_dict(d, sid, ext))
 
 
-def delete_stats(stats_id, stats_filename, minor_version=None):
+def delete_stats(stats_filename, stats_ids, minor_version=None):
     """ Deletes the stats represented by an ID in the stats filename under a specific
     minor version. Raises StatsFileNotFoundException if the given file does not exist.
 
-    :param str stats_id: a string that serves as a unique identification of the stored stats
     :param str stats_filename: the name of the stats file where to delete the stats
+    :param list of str stats_ids: strings that serve as unique identification of the stored stats
     :param str minor_version: the minor version representation or None for HEAD
     """
     stats_file = get_stats_file_path(stats_filename, minor_version, True)
-    _modify_stats_file(stats_file, "wb", lambda r: r.pop(stats_id, []))
+    # We need to construct some dummy 'contents' variable
+    _modify_stats_file(stats_file, stats_ids, [{} for _ in range(len(stats_ids))],
+                       lambda d, sid, _: d.pop(sid, []))
 
 
 def delete_stats_file(stats_filename, minor_version=None):
@@ -126,26 +163,27 @@ def delete_stats_file(stats_filename, minor_version=None):
     os.remove(stats_file)
 
 
-def get_stats_of(stats_filename, stats_id=None, minor_version=None):
+def get_stats_of(stats_filename, stats_ids=None, minor_version=None):
     """ Gets the stats content represented by an ID (or the whole content if stats_id is None)
     from the stats filename under a specific minor version.
     Raises StatsFileNotFoundException if the given file does not exist.
 
     :param str stats_filename: the name of the stats file where to search for the stats
-    :param str stats_id: a string that serves as a unique identification of the stored stats
+    :param list of str stats_ids: strings that serve as unique identification of the stored stats
     :param str minor_version: the minor version representation or None for HEAD
 
     :return dict: the stats content of the ID (or the whole file) or empty dict in case the
                   ID was not found in the stats file
     """
-    # TODO: extract the file finding / existence checking into a function
     stats_file = get_stats_file_path(stats_filename, minor_version, True)
 
     # Load the whole stats content and filter the ID if present
     with open(stats_file, "rb") as stats_handle:
-        if stats_id is None:
-            return _load_stats_from(stats_handle)
-        return _load_stats_from(stats_handle).get(stats_id, {})
+        stats_content = _load_stats_from(stats_handle)
+        if stats_ids is None:
+            return stats_content
+        # Extract the requested stats from the contents
+        return {sid: val for sid, val in stats_content.items() if sid in stats_ids}
 
 
 def list_stats_for_minor(minor_version=None):
@@ -161,6 +199,16 @@ def list_stats_for_minor(minor_version=None):
         _, _, files = next(os.walk(target_dir))
         return files
     return []
+
+
+def _add_to_dict(dictionary, sid, content):
+    """ A helper function that stores the stats content in the given dict under the ID
+
+    :param dict dictionary: the dictionary where the content will be stored
+    :param str sid: a string that serves as a unique identification of the stored stats
+    :param dict content: the stats data to save
+    """
+    dictionary[sid] = content
 
 
 @commands.lookup_minor_version
@@ -193,7 +241,6 @@ def _find_minor_stats_directory(minor_version):
     return os.path.exists(minor_dir), minor_dir
 
 
-# TODO: make public in store?
 def _find_minor_index(minor_version):
     """ Finds the corresponding index for the minor version or raises EntryNotFoundException if
     the index was not found.
@@ -205,17 +252,16 @@ def _find_minor_index(minor_version):
     # Find the index file
     _, index_file = store.split_object_name(pcs.get_object_directory(), minor_version)
     if not os.path.exists(index_file):
-        raise exceptions.EntryNotFoundException(index_file)
+        raise exceptions.IndexNotFoundException(index_file)
     return index_file
 
 
-# TODO: make public in store?
 @commands.lookup_minor_version
 def _find_profile_entry(profile, minor_version):
     """ Finds the profile entry within the index file of the minor version.
 
     :param str profile: the profile identification, can be given as tag, sha value,
-                        sha-path (path to tracked profile in obj) or source-path
+                        sha-path (path to tracked profile in obj) or source-name
     :param str minor_version: the minor version representation or None for HEAD
 
     :return IndexEntry: the profile entry from the index file
@@ -234,9 +280,11 @@ def _find_profile_entry(profile, minor_version):
     with open(minor_index, 'rb') as index_handle:
         # The profile can be only sha value or source path now
         if store.is_sha1(profile):
-            return store.lookup_entry_within_index(index_handle, lambda x: x.checksum == profile)
+            return index.lookup_entry_within_index(index_handle, lambda x: x.checksum == profile,
+                                                   profile)
         else:
-            return store.lookup_entry_within_index(index_handle, lambda x: x.path == profile)
+            return index.lookup_entry_within_index(index_handle, lambda x: x.path == profile,
+                                                   profile)
 
 
 def _load_stats_from(stats_handle):
@@ -247,6 +295,8 @@ def _load_stats_from(stats_handle):
     :return dict: the stats file contents
     """
     try:
+        # Make sure we're at the beginning
+        stats_handle.seek(0)
         return json.loads(store.read_and_deflate_chunk(stats_handle))
     except (ValueError, zlib.error):
         # Contents either empty or corrupted, init the content to empty dict
@@ -259,39 +309,29 @@ def _save_stats_to(stats_handle, stats_records):
     :param file stats_handle: the handle of the stats file
     :param dict stats_records: the contents to save
     """
+    # We need to rewrite the file contents, so move to the beginning and erase everything
+    stats_handle.seek(0)
+    stats_handle.truncate(0)
     compressed = store.pack_content(json.dumps(stats_records, indent=2).encode('utf-8'))
     stats_handle.write(compressed)
 
 
-def _modify_stats_file(stats_filepath, file_mode, modify_function):
+def _modify_stats_file(stats_filepath, stats_ids, stats_contents, modify_function):
     """ Modifies the contents of the given stats file by the provided modification function
 
     :param str stats_filepath: the path to the stats file
-    :param str file_mode: the file opening mode
+    :param list of str stats_ids: identifications of the stats block that are being modified
+    :param list of dict stats_contents: the data to modify (add, update, ...)
     :param function modify_function: function that takes the stats contents as a parameter and
                                      modifies it accordingly
     """
-    with open(stats_filepath, file_mode) as stats_handle:
+    with open(stats_filepath, 'a+b') as stats_handle:
         stats_records = _load_stats_from(stats_handle)
-        modify_function(stats_records)
+        for idx in range(min(len(stats_ids), len(stats_contents))):
+            modify_function(stats_records, stats_ids[idx], stats_contents[idx])
         _save_stats_to(stats_handle, stats_records)
 
 
-# TODO: make general publicly-accessible version? Like lookup_minor_version but not a decorator
-def _lookup_minor_version(minor_version):
-    """Looks up the given minor version and checks its existence.
-
-    :param str minor_version: the minor version representation or None for HEAD
-    :return str: the minor version representation
-    """
-    if minor_version is None:
-        minor_version = vcs.get_minor_head()
-    else:
-        vcs.check_minor_version_validity(minor_version)
-    return minor_version
-
-
-# TODO: make public?
 def _sha_path_to_sha(sha_path):
     """ Transforms the path of the minor version directory (represented by the SHA value) to the
     actual SHA value as a string.

--- a/perun/logic/stats.py
+++ b/perun/logic/stats.py
@@ -1,0 +1,189 @@
+import os
+import json
+import re
+import zlib
+
+import perun.logic.store as store
+import perun.logic.pcs as pcs
+import perun.utils.exceptions as exceptions
+import perun.vcs as vcs
+import perun.logic.commands as commands
+
+
+# Match the timestamp format of the profile names
+PROFILE_TIMESTAMP_REGEX = re.compile(r"(-?\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2})")
+
+
+def get_stats_filename_as_source(profile, ignore_timestamp, minor_version=None):
+    """Generate stats filename based on the 'source' property of the supplied profile,
+    i.e. the stats filename will refer to the name of the profile before it was tracked.
+
+    :param str profile: the profile identification, can be given as tag, sha value,
+                        sha-path (path to tracked profile in obj) or source-path
+    :param bool ignore_timestamp: if set to True, removes the 'date' component in the source name
+    :param str minor_version: representation of the minor version
+
+    :return str: the generated stats filename (not path!)
+    """
+    profile_index_entry = _find_profile_entry(profile, minor_version)
+    if ignore_timestamp:
+        return PROFILE_TIMESTAMP_REGEX.sub("", profile_index_entry.path)
+    return profile_index_entry.path
+
+
+def get_stats_filename_as_sha(profile, minor_version=None):
+    """Generate stats filename based on the 'SHA' property of the supplied profile,
+    i.e. the stats filename will refer to the name of the profile after its tracking.
+
+    :param str profile: the profile identification, can be given as tag, sha value,
+                        sha-path (path to tracked profile in obj) or source-path
+    :param bool ignore_timestamp: if set to True, removes the 'date' component in the source name
+    :param str minor_version: representation of the minor version
+
+    :return str: the generated stats filename (not path!)
+    """
+    profile_index_entry = _find_profile_entry(profile, minor_version)
+    return profile_index_entry.checksum
+
+
+def get_stats_file_path(stats_filename, minor_version=None):
+    target_dir = _touch_minor_stats_directory(minor_version)
+    stats_filename = os.path.basename(stats_filename.rstrip(os.sep))
+    return os.path.join(target_dir, stats_filename)
+
+
+def add_stats(stats_id, stats_content, stats_filename, minor_version=None):
+
+    def add_to_dict(dictionary):
+        dictionary[stats_id] = stats_content
+
+    target_file = get_stats_file_path(stats_filename, minor_version)
+    _modify_stats_file(target_file, "wb+", add_to_dict)
+
+    return target_file
+
+
+def update_stats(stats_id, extension, stats_filename, minor_version=None):
+    target_file = get_stats_file_path(stats_filename, minor_version)
+
+    _modify_stats_file(target_file, "wb+", lambda r: r[stats_id].update(extension))
+
+
+def delete_stats(stats_id, stats_filename, minor_version=None):
+    target_file = get_stats_file_path(stats_filename, minor_version)
+
+    if os.path.exists(target_file):
+        raise exceptions.StatsFileNotFoundException(target_file)
+
+    _modify_stats_file(target_file, "wb", lambda r: r.pop(stats_id, []))
+
+
+def delete_stats_file(stats_filename, minor_version=None):
+    target_file = get_stats_file_path(stats_filename, minor_version)
+    if not os.path.exists(target_file):
+        raise exceptions.StatsFileNotFoundException(target_file)
+    os.remove(target_file)
+
+
+def get_stats_of(stats_filename, stats_id=None, minor_version=None):
+    target_file = get_stats_file_path(stats_filename, minor_version)
+
+    if not os.path.exists(target_file):
+        raise exceptions.StatsFileNotFoundException(target_file)
+
+    with open(target_file, "rb") as stats_handle:
+        if stats_id is None:
+            return _load_stats_from(stats_handle)
+        return _load_stats_from(stats_handle).get(stats_id, None)
+
+
+def list_stats_for_minor(minor_version=None):
+    minor_exists, target_dir = _find_minor_stats_directory(minor_version)
+    if minor_exists:
+        _, _, files = next(os.walk(target_dir))
+        return files
+    return []
+
+
+@commands.lookup_minor_version
+def _touch_minor_stats_directory(minor_version):
+    # Obtain path to the directory for the given minor version
+    upper_level_dir, lower_level_dir = store.split_object_name(pcs.get_stats_directory(),
+                                                               minor_version)
+    # Create both directories for storing statistics to the given minor version
+    store.touch_dir(upper_level_dir)
+    store.touch_dir(lower_level_dir)
+    return lower_level_dir
+
+
+@commands.lookup_minor_version
+def _find_minor_stats_directory(minor_version):
+    _, minor_dir = store.split_object_name(pcs.get_stats_directory(), minor_version)
+    return os.path.exists(minor_dir), minor_dir
+
+
+# TODO: make public in store?
+def _find_minor_index(minor_version):
+    # Find the index file
+    _, index_file = store.split_object_name(pcs.get_object_directory(), minor_version)
+    if not os.path.exists(index_file):
+        raise exceptions.EntryNotFoundException(index_file)
+    return index_file
+
+
+# TODO: make public in store?
+@commands.lookup_minor_version
+def _find_profile_entry(profile, minor_version):
+    minor_index = _find_minor_index(minor_version)
+
+    # If profile is given as tag, obtain the sha-path of the file
+    tag_match = store.INDEX_TAG_REGEX.match(profile)
+    if tag_match:
+        profile = commands.get_nth_profile_of(int(tag_match.group(1)), minor_version)
+    # Transform the sha-path (obtained or given) to the sha value
+    if not store.is_sha1(profile) and not profile.endswith('.perf'):
+        profile = _sha_path_to_sha(profile)
+
+    # Search the minor index for the requested profile
+    with open(minor_index, 'rb') as index_handle:
+        # The profile can be only sha value or source path now
+        if store.is_sha1(profile):
+            return store.lookup_entry_within_index(index_handle, lambda x: x.checksum == profile)
+        else:
+            return store.lookup_entry_within_index(index_handle, lambda x: x.path == profile)
+
+
+def _load_stats_from(stats_handle):
+    try:
+        return json.loads(store.read_and_deflate_chunk(stats_handle))
+    except (ValueError, zlib.error):
+        # Contents either empty or corrupted, init the content to empty dict
+        return {}
+
+
+def _save_stats_to(stats_handle, stats_records):
+    compressed = store.pack_content(json.dumps(stats_records, indent=2).encode('utf-8'))
+    stats_handle.write(compressed)
+
+
+def _modify_stats_file(status_filepath, file_mode, modify_function):
+    with open(status_filepath, file_mode) as stats_handle:
+        stats_records = _load_stats_from(stats_handle)
+        modify_function(stats_records)
+        _save_stats_to(stats_handle, stats_records)
+
+
+# TODO: make general publicly-accessible version? Like lookup_minor_version but not decorator
+def _lookup_minor_version(minor_version):
+    if minor_version is None:
+        minor_version = vcs.get_minor_head()
+    else:
+        vcs.check_minor_version_validity(minor_version)
+    return minor_version
+
+
+# TODO: make public?
+def _sha_path_to_sha(sha_path):
+    rest, lower_level = os.path.split(sha_path.rstrip(os.sep))
+    _, upper_level = os.path.split(rest.rstrip(os.sep))
+    return upper_level + lower_level

--- a/perun/utils/exceptions.py
+++ b/perun/utils/exceptions.py
@@ -75,6 +75,17 @@ class EntryNotFoundException(Exception):
         return msg + " found in the index{}".format(": " + self.cause if self.cause else '')
 
 
+class StatsFileNotFoundException(Exception):
+    """Raised when the looked up stats file does not exist"""
+    def __init__(self, filename):
+        super().__init__("")
+        self.path = filename
+        self.msg = "The requested stats file '{}' does not exist".format(self.path)
+
+    def __str__(self):
+        return self.msg
+
+
 class VersionControlSystemException(Exception):
     """Raised when there is an issue with wrapped version control system.
 

--- a/perun/utils/exceptions.py
+++ b/perun/utils/exceptions.py
@@ -75,6 +75,19 @@ class EntryNotFoundException(Exception):
         return msg + " found in the index{}".format(": " + self.cause if self.cause else '')
 
 
+class IndexNotFoundException(Exception):
+    """Raised when the index file for the minor version does not exist"""
+    def __init__(self, minor_version):
+        """
+        :param str minor_version: the minor version that was supposed to have an index file
+        """
+        super().__init__("")
+        self.minor_version = minor_version
+
+    def __str__(self):
+        return "Index file for the minor version '{}' was not found.".format(self.minor_version)
+
+
 class StatsFileNotFoundException(Exception):
     """Raised when the looked up stats file does not exist"""
     def __init__(self, filename):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -502,6 +502,33 @@ def pcs_with_empty_git():
 
 
 @pytest.fixture(scope="function")
+def pcs_with_git_root_commit():
+    """
+    """
+    # Change working dir into the temporary directory
+    pcs_path = tempfile.mkdtemp()
+    os.chdir(pcs_path)
+    commands.init_perun_at(pcs_path, False, {'vcs': {'url': '../', 'type': 'git'}})
+
+    # Initialize git
+    vcs.init({})
+
+    # Populate repo with commits
+    repo = git.Repo(pcs_path)
+
+    # Create first commit
+    file1 = os.path.join(pcs_path, "file1")
+    store.touch_file(file1)
+    repo.index.add([file1])
+    repo.index.commit("root")
+
+    yield pcs
+
+    # clean up the directory
+    shutil.rmtree(pcs_path)
+
+
+@pytest.fixture(scope="function")
 def pcs_without_vcs():
     """
     """

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -29,8 +29,9 @@ def assert_perun_successfully_init_at(path):
     assert 'objects' in perun_content
     assert 'jobs' in perun_content
     assert 'logs' in perun_content
+    assert 'stats' in perun_content
     assert os.path.exists(os.path.join(perun_dir, 'local.yml'))
-    assert len(perun_content) == 5
+    assert len(perun_content) == 6
 
 
 def assert_git_successfully_init_at(path, is_bare=False):

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,0 +1,140 @@
+import os
+import pytest
+
+import perun.logic.stats as stats
+import perun.vcs as vcs
+import perun.logic.pcs as pcs
+import perun.logic.index as index
+import perun.utils.exceptions as exception
+
+
+def test_stats_filenames(pcs_full):
+    # Test stats name generation based on profile source and identified by a tag
+    generated_name = stats.build_stats_filename_as_profile_source('0@i', False)
+    assert generated_name == 'prof-2-2017-03-20-21-40-42'
+
+    # Test stats name generation with removed timestamps and identified by the source name
+    generated_name = stats.build_stats_filename_as_profile_source('prof-3-2017-05-15-15-43-42.perf',
+                                                                  True)
+    assert generated_name == 'prof-3'
+
+    # Prepare the git-related values
+    minor_head = vcs.get_minor_head()
+    minor_root = list(vcs.walk_minor_versions(minor_head))[1].checksum
+    profile_sha = index.get_profile_list_for_minor(pcs.get_object_directory(),
+                                                   minor_root)[0].checksum
+
+    # Test sha-based stats name on the root minor version profile identified by the profile-sha
+    generated_name = stats.build_stats_filename_as_profile_sha(profile_sha, minor_root)
+    assert generated_name == profile_sha
+
+    # Test sha-based stats name on the root minor version profile identified by the sha-path
+    sha_path = os.path.join(profile_sha[:2], profile_sha[2:])
+    print(sha_path)
+    generated_name = stats.build_stats_filename_as_profile_sha(sha_path, minor_root)
+    assert generated_name == profile_sha
+
+
+def test_stats_on_missing_index(pcs_with_git_root_commit):
+    with pytest.raises(exception.IndexNotFoundException) as exc:
+        stats.build_stats_filename_as_profile_source('0@i', False)
+    assert "was not found" in str(exc.value)
+
+
+def test_basic_stats_operations(pcs_full):
+    # Prepare two stats entries
+    stats_entry_1 = {'some_value': 10,
+                     'some_list': [1, 2, 3, 4],
+                     'inner_dict':
+                         {'func': 0x20202,
+                          'sampling': 12}
+                     }
+    stats_entry_2 = {'value_a': 'aaaa',
+                     'value_b': 'bbbb',
+                     'value_c': 'cccc'
+                     }
+
+    stats_entry_3 = {'simple': 'value'}
+    entry_2_new = {'value_d': 'dddd'}
+    entry_3_new = {'simple': 'values'}
+
+    # Prepare git values
+    minor_head = vcs.get_minor_head()
+    minor_path = os.path.join(minor_head[:2], minor_head[2:])
+    expected_stats_file = os.path.join(pcs.get_stats_directory(), minor_path, 'custom_stats')
+
+    # Try adding some stats to the file
+    stats_file = stats.add_stats('custom_stats', ['entry_1'], [stats_entry_1])
+    assert stats_file == expected_stats_file
+
+    # Try adding another stats to the file
+    stats_file = stats.add_stats('custom_stats', ['entry_2', 'entry_3'],
+                                 [stats_entry_2, stats_entry_3])
+    assert stats_file == expected_stats_file
+
+    # Test that the stats file contains the entries
+    stats_content = stats.get_stats_of('custom_stats')
+    assert (stats_content['entry_1'] == stats_entry_1 and stats_content['entry_2'] == stats_entry_2
+            and stats_content['entry_3']) == stats_entry_3
+
+    # Try updating entries 2 and 3 and test that the change has been made
+    stats.update_stats('custom_stats', ['entry_2', 'entry_3'], [entry_2_new, entry_3_new])
+    stats_content = stats.get_stats_of('custom_stats')
+    stats_entry_2.update(entry_2_new)
+    stats_entry_3.update(entry_3_new)
+    assert (stats_content['entry_1'] == stats_entry_1
+            and stats_content['entry_2'] == stats_entry_2
+            and stats_content['entry_3']) == stats_entry_3
+
+    # Try extracting some specific ids from the stats file
+    stats_content = stats.get_stats_of('custom_stats', ['entry_2'])
+    stats_content_2 = stats.get_stats_of('custom_stats', ['entry_1', 'entry_3'])
+    assert (stats_content['entry_2'] == stats_entry_2
+            and stats_content_2['entry_1'] == stats_entry_1
+            and stats_content_2['entry_3']) == stats_entry_3
+
+    # Try deleting some specific entries
+    stats.delete_stats('custom_stats', ['entry_1'])
+    stats_content = stats.get_stats_of('custom_stats')
+    assert ('entry_1' not in stats_content
+            and stats_content['entry_2'] == stats_entry_2
+            and stats_content['entry_3']) == stats_entry_3
+    stats.delete_stats('custom_stats', ['entry_2', 'entry_3'])
+    stats_content = stats.get_stats_of('custom_stats')
+    assert not stats_content
+
+    # Try deleting id that is not in the stats file
+    stats.delete_stats('custom_stats', ['made_up_id'])
+    stats_content = stats.get_stats_of('custom_stats')
+    assert not stats_content
+
+    # Try update operation on empty stats file
+    stats.update_stats('custom_stats', ['entry_new'], [stats_entry_2])
+    stats_content = stats.get_stats_of('custom_stats')
+    assert stats_content['entry_new'] == stats_entry_2
+
+    # Try to delete the stats file
+    stats.delete_stats_file('custom_stats')
+    with pytest.raises(exception.StatsFileNotFoundException) as exc:
+        stats.get_stats_of('custom_stats')
+    assert 'does not exist' in str(exc.value)
+
+    # Try to delete the stats file again
+    with pytest.raises(exception.StatsFileNotFoundException) as exc:
+        stats.delete_stats_file('custom_stats')
+    assert 'does not exist' in str(exc.value)
+
+
+def test_stats_in_minor_versions(pcs_full):
+    # Prepare the git-related values
+    minor_head = vcs.get_minor_head()
+    minor_root = list(vcs.walk_minor_versions(minor_head))[1].checksum
+
+    # Create stats files in the root version
+    stats.add_stats('root_stats', ['id_1'], [{'value': 10}], minor_root)
+    stats.add_stats('root_stats_2', ['id_1'], [{'value': 10}], minor_root)
+
+    root_files = stats.list_stats_for_minor(minor_root)
+    assert len(root_files) == 2 and 'root_stats' in root_files and 'root_stats_2' in root_files
+    head_files = stats.list_stats_for_minor(minor_head)
+    assert not head_files


### PR DESCRIPTION
This PR will add new 'stats' module to the core of perun. This module allows us to store and manipulate various useful data or statistics within files in the .perun/stats directory. 

The .perun/stats directory is further divided into a hierarchy of directories based on the SHA-value of the vcs minor versions - thus, every minor version has its own 'stats' files. Each 'stats' file can contain multiple records which are distinguished by the supplied ID. The content of the files is also compressed to reduce the memory requirements.