### PR TITLE
Temporary module

### DIFF
--- a/perun/cli.py
+++ b/perun/cli.py
@@ -1128,13 +1128,15 @@ def temp_group():
 
 @temp_group.command('list')
 @click.argument('root', type=click.Path(), required=False, default=pcs.get_tmp_directory())
-@click.option('--no-total-size', flag_value=True, default=False,
+@click.option('--no-color', '-c', flag_value=True, default=False,
+              help='Disable the output coloring, useful for storing the output to file etc.')
+@click.option('--no-total-size', '-t', flag_value=True, default=False,
               help='Do not show the total size of all the temporary files combined.')
-@click.option('--no-file-size', flag_value=True, default=False,
+@click.option('--no-file-size', '-f', flag_value=True, default=False,
               help='Do not show the size of each temporary file.')
-@click.option('--no-protection-level', flag_value=True, default=False,
+@click.option('--no-protection-level', '-p', flag_value=True, default=False,
               help='Do not show the protection level of the temporary files.')
-@click.option('--sort-by', '-sb', type=click.Choice(temp.SORT_ATTR), default=temp.SORT_ATTR[0],
+@click.option('--sort-by', '-s', type=click.Choice(temp.SORT_ATTR), default=temp.SORT_ATTR[0],
               help='Sorts the temporary files on the output.')
 @click.option('--filter-protection', '-fp', type=click.Choice(temp.PROTECTION_LEVEL),
               default=temp.PROTECTION_LEVEL[0],
@@ -1151,15 +1153,15 @@ def temp_list(root, **kwargs):
 
 @temp_group.command('delete')
 @click.argument('path', type=click.Path(), required=True)
-@click.option('--warn', '-w', flag_value=False, default=True,
+@click.option('--warn', '-w', flag_value=True, default=False,
               help='Warn the user (and abort the deletion with no files deleted) if protected files'
                    ' are present.')
 @click.option('--force', '-f', flag_value=True, default=False,
               help='If set, protected files are deleted regardless of --warn value.')
-@click.option('--keep-directories', '-kd', flag_value=True, default=False,
+@click.option('--keep-directories', '-k', flag_value=True, default=False,
               help='If path refers to directory, empty tmp/ directories and subdirectories '
                    'will be kept.')
-def delete_temp(path, warn, force, **kwargs):
+def temp_delete(path, warn, force, **kwargs):
     """Deletes the temporary file or directory.
 
     Use the command 'perun utils temp delete .' to safely delete all unprotected files in the
@@ -1172,7 +1174,7 @@ def delete_temp(path, warn, force, **kwargs):
     However, deleting temp files (protected or not) should not be done when other perun processes
     are running as it may cause them to crash due to a missing file.
     """
-    commands.delete_temps(path, warn, force, **kwargs)
+    commands.delete_temps(path, not warn, force, **kwargs)
 
 
 @temp_group.command('sync')

--- a/perun/cli.py
+++ b/perun/cli.py
@@ -1127,7 +1127,7 @@ def temp_group():
 
 
 @temp_group.command('list')
-@click.argument('root', type=click.Path(), required=False, default=pcs.get_tmp_directory())
+@click.argument('root', type=click.Path(), required=False, default='.')
 @click.option('--no-color', '-c', flag_value=True, default=False,
               help='Disable the output coloring, useful for storing the output to file etc.')
 @click.option('--no-total-size', '-t', flag_value=True, default=False,

--- a/perun/cli.py
+++ b/perun/cli.py
@@ -1175,6 +1175,17 @@ def delete_temp(path, warn, force, **kwargs):
     commands.delete_temps(path, warn, force, **kwargs)
 
 
+@temp_group.command('sync')
+def temp_sync():
+    """Synchronizes the '.perun/tmp/' directory contents with the internal tracking file. This is
+    useful when some files or directories were deleted manually and the resulting inconsistency is
+    causing troubles - however, this should be a very rare condition.
+
+    Invoking the 'temp list' command should also synchronize the internal state automatically.
+    """
+    commands.sync_temps()
+
+
 def init_unit_commands(lazy_init=True):
     """Runs initializations for all of the subcommands (shows, collectors, postprocessors)
 

--- a/perun/logic/commands.py
+++ b/perun/logic/commands.py
@@ -896,6 +896,7 @@ def print_temp_files(root, **kwargs):
     """
     # Try to load the files in the root directory
     try:
+        temp.synchronize_index()
         tmp_files = temp.list_all_temps_with_details(root)
     except InvalidTempPathException as exc:
         print("Error: " + str(exc))
@@ -991,3 +992,10 @@ def delete_temps(path, ignore_protected, force, **kwargs):
     except (InvalidTempPathException, ProtectedTempException) as exc:
         # Invalid path or protected files encountered
         print("Error: " + str(exc))
+
+
+def sync_temps():
+    """Synchronizes the internal state of the index file so that it corresponds to some possible
+    manual changes in the directory by the user.
+    """
+    temp.synchronize_index()

--- a/perun/logic/commands.py
+++ b/perun/logic/commands.py
@@ -919,21 +919,22 @@ def print_temp_files(root, **kwargs):
     if not kwargs['no_total_size']:
         total_size = utils.format_file_size(sum(size for _, _, size in tmp_files))
         print('Total size of all temporary files: {}'.format(
-            termcolor.colored(total_size, TEXT_EMPH_COLOUR, attrs=TEXT_ATTRS))
+            _set_color(total_size, TEXT_EMPH_COLOUR, not kwargs['no_color']))
         )
 
     # Print the file records
     print_formatted_temp_files(tmp_files, not kwargs['no_file_size'],
-                               not kwargs['no_protection_level'])
+                               not kwargs['no_protection_level'], not kwargs['no_color'])
 
 
-def print_formatted_temp_files(records, show_size, show_protection):
+def print_formatted_temp_files(records, show_size, show_protection, use_color):
     """Format and print temporary file records as:
     size | protection level | path from tmp/ directory
 
     :param list records: the list of temporary file records as tuple (size, protection, path)
     :param bool show_size: flag indicating whether size for each file should be shown
     :param bool show_protection: if set to True, show the protection level of each file
+    :param bool use_color: if set to True, certain parts of the output will be colored
     """
     # Handle empty tmp/ dir
     if not records:
@@ -945,24 +946,39 @@ def print_formatted_temp_files(records, show_size, show_protection):
     for file_name, protection, size in records:
         # Print the size of each file
         if show_size:
-            print('{}'.format(termcolor.colored(utils.format_file_size(size), TEXT_EMPH_COLOUR)),
-                  end=termcolor.colored(' | ', TEXT_WARN_COLOUR))
+            print('{}'.format(_set_color(utils.format_file_size(size),
+                                         TEXT_EMPH_COLOUR, use_color)),
+                  end=_set_color(' | ', TEXT_WARN_COLOUR, use_color))
         # Print the protection level of each file
         if show_protection:
             if protection == temp.UNPROTECTED:
                 print('{}'.format(temp.UNPROTECTED),
-                      end=termcolor.colored(' | ', TEXT_WARN_COLOUR))
+                      end=_set_color(' | ', TEXT_WARN_COLOUR, use_color))
             else:
-                print('{}  '.format(termcolor.colored(temp.PROTECTED, TEXT_WARN_COLOUR)),
-                      end=termcolor.colored(' | ', TEXT_WARN_COLOUR))
+                print('{}  '.format(_set_color(temp.PROTECTED, TEXT_WARN_COLOUR, use_color)),
+                      end=_set_color(' | ', TEXT_WARN_COLOUR, use_color))
 
         # Print the file path, emphasize the directory to make it a bit more readable
         file_name = file_name[prefix:]
         file_dir = os.path.dirname(file_name)
         if file_dir:
             file_dir += os.sep
-            print('{}'.format(termcolor.colored(file_dir, TEXT_EMPH_COLOUR)), end='')
+            print('{}'.format(_set_color(file_dir, TEXT_EMPH_COLOUR, use_color)), end='')
         print('{}'.format(os.path.basename(file_name)))
+
+
+def _set_color(output, color, enable_coloring=True):
+    """Transforms the output to colored version.
+
+    :param str output: the output text that should be colored
+    :param str color: the color
+    :param bool enable_coloring: switch that allows to disable the coloring - the function is no-op
+
+    :return str: the new colored output (if enabled)
+    """
+    if enable_coloring:
+        return termcolor.colored(output, color, attrs=TEXT_ATTRS)
+    return output
 
 
 def delete_temps(path, ignore_protected, force, **kwargs):

--- a/perun/logic/commands.py
+++ b/perun/logic/commands.py
@@ -904,7 +904,7 @@ def print_temp_files(root, **kwargs):
 
     # Filter the files by protection level if it is set to show only certain group
     if kwargs['filter_protection'] != 'all':
-        for idx, (name, level, size) in enumerate(list(tmp_files)):
+        for name, level, size in list(tmp_files):
             if level != kwargs['filter_protection']:
                 tmp_files.remove((name, level, size))
 

--- a/perun/logic/commands.py
+++ b/perun/logic/commands.py
@@ -899,8 +899,7 @@ def print_temp_files(root, **kwargs):
         temp.synchronize_index()
         tmp_files = temp.list_all_temps_with_details(root)
     except InvalidTempPathException as exc:
-        print("Error: " + str(exc))
-        return
+        perun_log.error(str(exc))
 
     # Filter the files by protection level if it is set to show only certain group
     if kwargs['filter_protection'] != 'all':
@@ -919,7 +918,7 @@ def print_temp_files(root, **kwargs):
     if not kwargs['no_total_size']:
         total_size = utils.format_file_size(sum(size for _, _, size in tmp_files))
         print('Total size of all temporary files: {}'.format(
-            _set_color(total_size, TEXT_EMPH_COLOUR, not kwargs['no_color']))
+            perun_log.set_color(total_size, TEXT_EMPH_COLOUR, not kwargs['no_color']))
         )
 
     # Print the file records
@@ -946,39 +945,26 @@ def print_formatted_temp_files(records, show_size, show_protection, use_color):
     for file_name, protection, size in records:
         # Print the size of each file
         if show_size:
-            print('{}'.format(_set_color(utils.format_file_size(size),
-                                         TEXT_EMPH_COLOUR, use_color)),
-                  end=_set_color(' | ', TEXT_WARN_COLOUR, use_color))
+            print('{}'.format(perun_log.set_color(utils.format_file_size(size),
+                                                  TEXT_EMPH_COLOUR, use_color)),
+                  end=perun_log.set_color(' | ', TEXT_WARN_COLOUR, use_color))
         # Print the protection level of each file
         if show_protection:
             if protection == temp.UNPROTECTED:
                 print('{}'.format(temp.UNPROTECTED),
-                      end=_set_color(' | ', TEXT_WARN_COLOUR, use_color))
+                      end=perun_log.set_color(' | ', TEXT_WARN_COLOUR, use_color))
             else:
-                print('{}  '.format(_set_color(temp.PROTECTED, TEXT_WARN_COLOUR, use_color)),
-                      end=_set_color(' | ', TEXT_WARN_COLOUR, use_color))
+                print('{}  '.format(perun_log.set_color(temp.PROTECTED, TEXT_WARN_COLOUR,
+                                                        use_color)),
+                      end=perun_log.set_color(' | ', TEXT_WARN_COLOUR, use_color))
 
         # Print the file path, emphasize the directory to make it a bit more readable
         file_name = file_name[prefix:]
         file_dir = os.path.dirname(file_name)
         if file_dir:
             file_dir += os.sep
-            print('{}'.format(_set_color(file_dir, TEXT_EMPH_COLOUR, use_color)), end='')
+            print('{}'.format(perun_log.set_color(file_dir, TEXT_EMPH_COLOUR, use_color)), end='')
         print('{}'.format(os.path.basename(file_name)))
-
-
-def _set_color(output, color, enable_coloring=True):
-    """Transforms the output to colored version.
-
-    :param str output: the output text that should be colored
-    :param str color: the color
-    :param bool enable_coloring: switch that allows to disable the coloring - the function is no-op
-
-    :return str: the new colored output (if enabled)
-    """
-    if enable_coloring:
-        return termcolor.colored(output, color, attrs=TEXT_ATTRS)
-    return output
 
 
 def delete_temps(path, ignore_protected, force, **kwargs):
@@ -1003,11 +989,11 @@ def delete_temps(path, ignore_protected, force, **kwargs):
                 temp.delete_temp_dir(path, ignore_protected, force)
         # The supplied path does not exist, inform the user so they can correct the path
         else:
-            print("Note: The supplied path '{}' does not exist, no files deleted"
-                  .format(temp.temp_path(path)))
+            perun_log.warn("The supplied path '{}' does not exist, no files deleted"
+                           .format(temp.temp_path(path)))
     except (InvalidTempPathException, ProtectedTempException) as exc:
         # Invalid path or protected files encountered
-        print("Error: " + str(exc))
+        perun_log.error(str(exc))
 
 
 def sync_temps():

--- a/perun/logic/commands.py
+++ b/perun/logic/commands.py
@@ -162,6 +162,7 @@ def init_perun_at(perun_path, is_reinit, vcs_config, config_template='master'):
     store.touch_dir(os.path.join(perun_full_path, 'logs'))
     store.touch_dir(os.path.join(perun_full_path, 'cache'))
     store.touch_dir(os.path.join(perun_full_path, 'stats'))
+    store.touch_dir(os.path.join(perun_full_path, 'tmp'))
     # If the config does not exist, we initialize the new version
     if not os.path.exists(os.path.join(perun_full_path, 'local.yml')):
         perun_config.init_local_config_at(perun_full_path, vcs_config, config_template)

--- a/perun/logic/commands.py
+++ b/perun/logic/commands.py
@@ -13,6 +13,7 @@ import re
 import click
 import colorama
 import termcolor
+from operator import itemgetter
 
 import perun.logic.pcs as pcs
 import perun.logic.config as perun_config
@@ -23,9 +24,11 @@ import perun.utils as utils
 import perun.utils.log as perun_log
 import perun.utils.timestamps as timestamp
 import perun.vcs as vcs
+import perun.logic.temp as temp
 
 from perun.utils.exceptions import NotPerunRepositoryException, \
-    ExternalEditorErrorException, MissingConfigSectionException
+    ExternalEditorErrorException, MissingConfigSectionException, InvalidTempPathException, \
+    ProtectedTempException
 from perun.utils.helpers import \
     TEXT_EMPH_COLOUR, TEXT_ATTRS, TEXT_WARN_COLOUR, \
     PROFILE_TYPE_COLOURS, SUPPORTED_PROFILE_TYPES, HEADER_ATTRS, HEADER_COMMIT_COLOUR, \
@@ -883,3 +886,108 @@ def load_profile_from_args(profile_name, minor_version):
     loaded_profile = store.load_profile_from_file(profile_name, False)
 
     return loaded_profile
+
+
+def print_temp_files(root, **kwargs):
+    """Print the temporary files in the root directory.
+
+    :param str root: the path to the directory that should be listed
+    :param kwargs: additional parameters such as sorting, output formatting etc.
+    """
+    # Try to load the files in the root directory
+    try:
+        tmp_files = temp.list_all_temps_with_details(root)
+    except InvalidTempPathException as exc:
+        print("Error: " + str(exc))
+        return
+
+    # Filter the files by protection level if it is set to show only certain group
+    if kwargs['filter_protection'] != 'all':
+        for idx, (name, level, size) in enumerate(list(tmp_files)):
+            if level != kwargs['filter_protection']:
+                tmp_files.remove((name, level, size))
+
+    # First sort by the name
+    tmp_files.sort(key=itemgetter(0))
+    # Now apply 'sort-by' if it differs from name:
+    if kwargs['sort_by'] != 'name':
+        sort_map = temp.SORT_ATTR_MAP[kwargs['sort_by']]
+        tmp_files.sort(key=itemgetter(sort_map['pos']), reverse=sort_map['reverse'])
+
+    # Print the total files size if needed
+    if not kwargs['no_total_size']:
+        total_size = utils.format_file_size(sum(size for _, _, size in tmp_files))
+        print('Total size of all temporary files: {}'.format(
+            termcolor.colored(total_size, TEXT_EMPH_COLOUR, attrs=TEXT_ATTRS))
+        )
+
+    # Print the file records
+    print_formatted_temp_files(tmp_files, not kwargs['no_file_size'],
+                               not kwargs['no_protection_level'])
+
+
+def print_formatted_temp_files(records, show_size, show_protection):
+    """Format and print temporary file records as:
+    size | protection level | path from tmp/ directory
+
+    :param list records: the list of temporary file records as tuple (size, protection, path)
+    :param bool show_size: flag indicating whether size for each file should be shown
+    :param bool show_protection: if set to True, show the protection level of each file
+    """
+    # Handle empty tmp/ dir
+    if not records:
+        cprintln('== No results in the .perun/tmp/ directory ==', 'white')
+        return
+
+    # Absolute path might be a bit too long, we remove the path component to the tmp/ directory
+    prefix = len(pcs.get_tmp_directory()) + 1
+    for file_name, protection, size in records:
+        # Print the size of each file
+        if show_size:
+            print('{}'.format(termcolor.colored(utils.format_file_size(size), TEXT_EMPH_COLOUR)),
+                  end=termcolor.colored(' | ', TEXT_WARN_COLOUR))
+        # Print the protection level of each file
+        if show_protection:
+            if protection == temp.UNPROTECTED:
+                print('{}'.format(temp.UNPROTECTED),
+                      end=termcolor.colored(' | ', TEXT_WARN_COLOUR))
+            else:
+                print('{}  '.format(termcolor.colored(temp.PROTECTED, TEXT_WARN_COLOUR)),
+                      end=termcolor.colored(' | ', TEXT_WARN_COLOUR))
+
+        # Print the file path, emphasize the directory to make it a bit more readable
+        file_name = file_name[prefix:]
+        file_dir = os.path.dirname(file_name)
+        if file_dir:
+            file_dir += os.sep
+            print('{}'.format(termcolor.colored(file_dir, TEXT_EMPH_COLOUR)), end='')
+        print('{}'.format(os.path.basename(file_name)))
+
+
+def delete_temps(path, ignore_protected, force, **kwargs):
+    """Delete the temporary file(s) identified by the path. The path can be either file (= delete
+    only the file) or directory (= delete files in the directory or the whole directory).
+
+    :param str path: the path to the target file or directory
+    :param bool ignore_protected: if True, protected files are ignored and not deleted, otherwise
+                                  deletion process is aborted and exception is raised
+    :param bool force: if True, delete also protected files
+    :param kwargs: additional parameters
+    """
+    try:
+        # Determine if path is file or directory and call the correct functions for that
+        if temp.exists_temp_file(path):
+            temp.delete_temp_file(path, ignore_protected, force)
+        elif temp.exists_temp_dir(path):
+            # We might delete only files or files + empty directories
+            if kwargs['keep_directories']:
+                temp.delete_all_temps(path, ignore_protected, force)
+            else:
+                temp.delete_temp_dir(path, ignore_protected, force)
+        # The supplied path does not exist, inform the user so they can correct the path
+        else:
+            print("Note: The supplied path '{}' does not exist, no files deleted"
+                  .format(temp.temp_path(path)))
+    except (InvalidTempPathException, ProtectedTempException) as exc:
+        # Invalid path or protected files encountered
+        print("Error: " + str(exc))

--- a/perun/logic/config.py
+++ b/perun/logic/config.py
@@ -321,7 +321,7 @@ def lookup_shared_config_dir():
                    "where the global config will be stored and rerun the command."
         perun_log.error(err_msg)
 
-    store.touch_dir_range(home_directory, perun_config_dir)
+    store.touch_dir(perun_config_dir)
     return perun_config_dir
 
 

--- a/perun/logic/pcs.py
+++ b/perun/logic/pcs.py
@@ -121,6 +121,28 @@ def get_stats_directory():
     return stats_directory
 
 
+@singleton
+def get_tmp_directory():
+    """Returns the name of the directory, where various or temporary files are stored
+
+    :return str: path to the tmp directory
+    """
+    tmp_directory = os.path.join(get_path(), 'tmp')
+    store.touch_dir(tmp_directory)
+    return tmp_directory
+
+
+@singleton
+def get_tmp_index():
+    """Returns the path to the index file in tmp directory, where details about some tmp files
+    are stored
+
+    :return str: path to the tmp index file
+    """
+    tmp_directory = get_tmp_directory()
+    return os.path.join(tmp_directory, '.index')
+
+
 @singleton_with_args
 def get_config_file(config_type):
     """Returns the config file for the given config type

--- a/perun/logic/store.py
+++ b/perun/logic/store.py
@@ -11,14 +11,13 @@ import string
 import struct
 import zlib
 
-import demandimport
-with demandimport.enabled():
-    import hashlib
-
 from perun.utils.helpers import LINE_PARSING_REGEX, SUPPORTED_PROFILE_TYPES
 from perun.utils.structs import PerformanceChange, DegradationInfo
 from perun.utils.exceptions import NotPerunRepositoryException, IncorrectProfileFormatException
 
+import demandimport
+with demandimport.enabled():
+    import hashlib
 
 __author__ = 'Tomas Fiedor'
 
@@ -26,6 +25,7 @@ INDEX_TAG_REGEX = re.compile(r"^(\d+)@i$")
 INDEX_TAG_RANGE_REGEX = re.compile(r"^(\d+)@i-(\d+)@i$")
 PENDING_TAG_REGEX = re.compile(r"^(\d+)@p$")
 PENDING_TAG_RANGE_REGEX = re.compile(r"^(\d+)@p-(\d+)@p$")
+
 
 def touch_file(touched_filename, times=None):
     """
@@ -48,22 +48,7 @@ def touch_dir(touched_dir):
     :param str touched_dir: path that will be touched
     """
     if not os.path.exists(touched_dir):
-        os.mkdir(touched_dir)
-
-
-def touch_dir_range(touched_dir_start, touched_dir_end):
-    """Iterates through the range of the subdirs between start and end touching each one of the dir
-
-    E.g. for the following:
-    touched_dir_start = '/a/b', touched_dir_end = '/a/b/c/d/e'
-    following will be touched: /a/b, /a/b/c, ..., /a/b/c/d/e
-
-    :param str touched_dir_start: base case of the touched dirs
-    :param str touched_dir_end: end case of the touched dirs
-    """
-    for subdir in path_to_subpaths(touched_dir_end):
-        if subdir.startswith(touched_dir_start):
-            touch_dir(subdir)
+        os.makedirs(touched_dir)
 
 
 def path_to_subpaths(path):
@@ -158,7 +143,7 @@ def split_object_name(base_dir, object_name, object_ext=""):
 
 def add_loose_object_to_dir(base_dir, object_name, object_content):
     """
-    :param path base_dir: path to the base directory
+    :param str base_dir: path to the base directory
     :param str object_name: sha-1 string representing the object (possibly with extension)
     :param bytes object_content: contents of the packed object
     """
@@ -377,7 +362,7 @@ def load_profile_from_handle(file_name, file_handle, is_raw_profile):
 
         # Check the header, if the body is not malformed
         if prefix != 'profile' or profile_type not in SUPPORTED_PROFILE_TYPES or \
-                        len(body) != int(profile_size):
+                len(body) != int(profile_size):
             raise IncorrectProfileFormatException(file_name, "malformed profile '{}'")
 
     # Try to load the json, if there is issue with the profile

--- a/perun/logic/temp.py
+++ b/perun/logic/temp.py
@@ -1,0 +1,567 @@
+"""This module contains functions for manipulating temporary files and directories located
+in the .perun/tmp/ directory.
+
+The .perun/tmp/ directory can be used to store various temporary files used during data collection,
+postprocessing, visualization, logging, command output capturing, etc.
+It is also possible to create directories and subdirectories to better separate files from different
+sources.
+
+The file name or content format is not restricted by any means. The user may or may not use the
+interface provided by this module to store and retrieve temporary data, however, using at least
+some minimal subset of functions can bring certain benefits in working with the tmp/ directory.
+
+Some examples of the minimal interface operations:
+--------------------------------------------------
+ - temp_path: transforms supplied path (applies mostly for relative paths) into the context of the
+              tmp/ directory and ensures that the resulting path is actually in the tmp/.
+ - touch_temp_dir / touch_temp_file: Touches the required files or directory hierarchy.
+ - delete_temp_dir / delete_temp_file: Safe deletion of the temporary files or directory hierarchy
+                                       that respects protected status of files.
+ - set_protected_status: Protects the temporary files against deletion when using this interface -
+                         this will, however, not protect it against manual deletion by the user
+                         directly in the file system. Can be also used to remove the protection.
+
+The rest of the interface allows to also write to and read from the temporary files, clear the
+contents of the file, list all temporary files etc.
+
+Paths:
+--------------------------------------------------
+The interface functions that take a path argument accept either absolute or relative paths. The
+relative paths are transformed to absolute ones, where the root/working directory is considered to
+be the .perun/tmp/ directory. All resulting paths are checked so that no temporary file or
+directory would be created outside of the .perun/tmp/ directory.
+
+The transformation works as follows:
+- absolute path located in the .perun/tmp/ directory: no change
+- relative path: transformed to absolute path where .perun/tmp/ is considered as the
+                 root/working directory for the relative path
+- absolute or relative path out of the .perun/tmp/: an exception is thrown
+
+
+Protected files:
+--------------------------------------------------
+The protection status of files is simply a corresponding flag stored in the index file. When
+deleting files using this interface, the protection flag is checked and if the 'force' mode
+is not used, the file will not be deleted and exception will be raised. This allows to ensure
+that some important files are not easily and accidentally removed, while also providing a
+mechanism to delete them if the need for complete cleanup arises.
+
+"""
+
+
+import os
+import json
+import zlib
+
+import perun.logic.pcs as pcs
+import perun.logic.store as store
+import perun.utils.exceptions as exceptions
+
+
+def temp_path(path):
+    """Transforms the provided path to the tmp/ directory context, i.e.:
+        - absolute path located in the .perun/tmp/ directory: no change
+        - relative path: transformed to absolute path where .perun/tmp/ is considered as the
+                         root/working directory for the relative path
+        - absolute or relative path out of the .perun/tmp/: an exception is thrown
+
+    :param str path: the path that should be transformed
+
+    :return str: the transformed path
+    """
+    return _join_to_tmp_path(path)
+
+
+def touch_temp_dir(dir_path):
+    """Touches the given directory path.
+
+    For details regarding the path format, see the module docstring.
+
+    :param str dir_path: the directory path
+    """
+    # Append the path to the tmp/ directory
+    dir_path = _join_to_tmp_path(dir_path)
+    # Create the new directory(ies)
+    if not os.path.exists(dir_path):
+        os.makedirs(dir_path)
+
+
+def touch_temp_file(file_path, protect=False):
+    """Touches the given temporary file and sets the protection level.
+
+    For details regarding the path format, see the module docstring.
+
+    :param str file_path: the temporary file path
+    :param bool protect: if True, the temporary file will be indexed as protected
+    """
+    # Append the file path to the tmp/ directory
+    file_path = _join_to_tmp_path(file_path.rstrip(os.sep))
+    # Make sure that the directory hierarchy for the file exists
+    touch_temp_dir(os.path.dirname(file_path))
+
+    store.touch_file(file_path)
+    # Register the file as protected if needed
+    if protect:
+        _add_to_index(file_path, protected=protect)
+
+
+def exists_temp_dir(dir_path):
+    """Checks if the temporary directory given by 'dir_path' exists.
+
+    For details regarding the path format, see the module docstring.
+
+    :param str dir_path: the temporary directory
+
+    :return bool: True if the directory exists
+    """
+    dir_path = _join_to_tmp_path(dir_path)
+    return os.path.exists(dir_path) and os.path.isdir(dir_path)
+
+
+def exists_temp_file(file_path):
+    """Checks if the temporary file given by 'file_path' exists.
+
+    For details regarding the path format, see the module docstring.
+
+    :param str file_path: the temporary file
+
+    :return bool: True if the file exists
+    """
+    file_path = _join_to_tmp_path(file_path)
+    return os.path.exists(file_path) and os.path.isfile(file_path)
+
+
+def new_temp(file_path, content, json_format=False, protect=False, compress=False):
+    """Creates new temporary file if it does not exist yet and writes the 'content' into the file.
+    An exception is raised if the file already exists.
+
+    For details regarding the path format, see the module docstring.
+
+    :param str file_path: the path to the file to create
+    :param content: the content of the new temporary file
+    :param bool json_format: if True, the content will be formatted as json
+    :param bool protect: if True, the file will have the protected status
+    :param bool compress: if True, the content will be compressed
+    """
+    # Do not allow file overwrite
+    file_path = _join_to_tmp_path(file_path)
+    if os.path.exists(file_path):
+        raise exceptions.InvalidTempPathException("The temporary file '{}' already exists."
+                                                  .format(file_path))
+    _write_to_temp(file_path, content, json_format, protect, compress)
+
+
+def store_temp(file_path, content, json_format=False, protect=False, compress=False):
+    """Writes the 'content' to the temporary file given by the 'file_path'. The temporary file is
+    created if it does not exist and overwritten if it does.
+
+    For details regarding the path format, see the module docstring.
+
+    :param str file_path: the path to the temporary file
+    :param content: the new content of the temporary file
+    :param bool json_format: if True, the content will be formatted as json
+    :param bool protect: if True, the file will have the protected status
+    :param bool compress: if True, the content will be compressed
+    """
+    file_path = _join_to_tmp_path(file_path)
+    _write_to_temp(file_path, content, json_format, protect, compress)
+
+
+def get_temp(file_path):
+    """Gets the content of the temporary file 'file_path'. An exception is raised if the file does
+    not exist. None is returned if the file could not have been read, is corrupted, has
+    inconsistent or invalid index properties.
+
+    For details regarding the path format, see the module docstring.
+
+    :param str file_path: the path to the temporary file to read
+
+    :return str or None: the file content or None if an error occurred
+    """
+    # Check the existence of the file and obtain its properties
+    file_path = _join_to_tmp_path(file_path)
+    _is_tmp_file(file_path)
+    json_format, _, compressed = _get_index_entry(file_path)
+    try:
+        with open(file_path, 'rb' if compressed else 'r') as tmp_handle:
+            # Take care of possible compression
+            if compressed:
+                content = store.read_and_deflate_chunk(tmp_handle)
+            else:
+                content = tmp_handle.read()
+            # Parse the json-formatted files
+            if json_format:
+                content = json.loads(content)
+        return content
+    # Handle possible errors
+    except (OSError, ValueError, zlib.error):
+        return None
+
+
+def clear_temp(file_path):
+    """Clears the content of the temporary file 'file_path'
+
+    For details regarding the path format, see the module docstring.
+
+    :param str file_path: the path to the temporary file
+    """
+    file_path = _join_to_tmp_path(file_path)
+    _is_tmp_file(file_path)
+    with open(file_path, 'w'):
+        pass
+
+
+def list_all_temps(root=None):
+    """Provides a list of all the temporary files in the 'root' folder and all its subfolders.
+
+    For details regarding the path format, see the module docstring.
+
+    If the 'root' is not provided or None, the whole tmp/ folder is considered as the root.
+
+    :param str root: the path to the root folder
+
+    :return list: paths to all the files in the 'root' folder hierarchy
+    """
+    if root is None:
+        root = pcs.get_tmp_directory()
+    else:
+        root = _join_to_tmp_path(root)
+    _is_tmp_dir(root)
+    return [os.path.join(dirpath, file) for dirpath, _, files in os.walk(root) for file in files]
+
+
+def get_temp_properties(file_path):
+    """Returns the known properties of the temporary file such as:
+        - json_formatted
+        - protected
+        - compressed
+
+    If the file has no known or registered properties, the default value is False for all properties
+
+    For details regarding the path format, see the module docstring.
+
+    :param str file_path: the path to the temporary file
+
+    :return tuple: (json_formatted, protected, compressed)
+    """
+    return _get_index_entry(_join_to_tmp_path(file_path))
+
+
+def set_protected_status(file_path, protected):
+    """Sets a new protection status of a temporary file.
+
+    For details regarding the path format, see the module docstring.
+
+    :param str file_path: the path to the temporary file
+    :param bool protected: True for protected file, False for unprotected file
+    """
+    file_path = _join_to_tmp_path(file_path)
+    _is_tmp_file(file_path)
+    _add_to_index(file_path, protected=protected)
+
+
+def delete_temp_dir(root, ignore_protected=False, force=False):
+    """Delete the whole temporary directory given by the 'root' and all its content.
+
+    For details regarding the path format, see the module docstring.
+
+    If 'ignore_protected' is False and the directory structure contains protected temporary files,
+    the whole deletion process is aborted, no file is deleted and an exception is raised.
+    If set to True, protected files will be kept and only unprotected files and empty folders
+    will be deleted.
+
+    If 'force' is True, all the files including the protected ones are deleted regardless of the
+    'ignore_protected' value.
+
+    :param str root: path to the temporary directory to delete
+    :param bool ignore_protected: protected files in the directory will either abort the deletion
+                                  process or they will be ignored and not deleted
+    :param bool force: if True, the protected files will be also deleted
+    """
+    root = _join_to_tmp_path(root)
+    # Check if the directory path is valid
+    _is_tmp_dir(root)
+
+    # Delete all the temporary files and empty directories
+    delete_all_temps(root, ignore_protected, force)
+    _delete_empty_directories(root)
+
+
+def delete_temp_file(file_path, force=False):
+    """Delete the temporary file identified by the 'file_path'.
+
+    For details regarding the path format, see the module docstring.
+
+    :param str file_path: path to the temporary file to delete
+    :param bool force: if True and the 'filepath' is protected, the file will be deleted anyway
+    """
+    file_path = _join_to_tmp_path(file_path.rstrip(os.sep))
+    # Check if tmp file exists
+    _is_tmp_file(file_path)
+    # Don't delete protected temp files unless forced
+    _delete_files([file_path], False, force)
+
+
+def delete_all_temps(root=None, ignore_protected=None, force=None):
+    """Deletes all the temporary files in the 'root' folder and its subfolders.
+
+    For details regarding the path format, see the module docstring.
+
+    If 'ignore_protected' is False and the directory structure contains protected temporary files,
+    the whole deletion process is aborted, no file is deleted and an exception is raised.
+    If set to True, protected files will be kept and only unprotected files will be deleted.
+
+    If 'force' is True, all the files including the protected ones are deleted regardless of the
+    'ignore_protected' value.
+
+    :param str root: the path to the root folder
+    :param bool ignore_protected: protected files in the directories will either abort the deletion
+                                  process or they will be ignored and not deleted
+    :param bool force: if True, the protected files will be also deleted
+    """
+    tmp_files = list_all_temps(root)
+    _delete_files(tmp_files, ignore_protected, force)
+
+
+def synchronize_index():
+    """Synchronizes the index file with the content of the tmp/ directory.
+
+    Namely removes index entries that are not needed or refer to no longer existing files
+    """
+    index_entries = _load_index()
+    tmp_files = list_all_temps()
+    for tmp_name, conf in index_entries.items():
+        # Remove records of files that are deleted or not necessary to track
+        if tmp_name not in tmp_files or (not conf['json'] and not conf['protected']
+                                         and not conf['compressed']):
+            del index_entries[tmp_name]
+    # Save the updated index
+    _save_index(index_entries)
+
+
+def _join_to_tmp_path(path):
+    """Helper function that obtains absolute path based on the supplied path in the context of
+    the tmp/ directory. The path may already be absolute or relative - in this case, the
+    root (working) directory is assumed to be .perun/tmp/
+
+    In case the resulting path would not be located in the .perun/tmp/, an exception is raised.
+
+    :param str path: the path that should be transformed
+
+    :return str: the resulting transformed path
+    """
+    tmp_location = pcs.get_tmp_directory()
+
+    # The 'path' may be absolute with tmp/ location as prefix, which os.path.join handles well
+    # However it might also be a custom path '/ab/ef/' which causes join to create '/ab/ef/'
+    path = os.path.abspath(os.path.join(tmp_location, path))
+    # The resulting path might end up out of tmp/ for both absolute or relative paths
+    if not path.startswith(tmp_location):
+        raise exceptions.InvalidTempPathException("The resulting path '{}' is not located in "
+                                                  "the tmp/ perun directory.".format(path))
+    return path
+
+
+def _is_tmp_path(path):
+    """Checks if the provided path exists and is within the .perun/tmp/ directory. If not, an
+    exception is raised.
+
+    :param str path: the path that should be checked
+    """
+    if not path.startswith(pcs.get_tmp_directory()) or not os.path.exists(path):
+        raise exceptions.InvalidTempPathException("The 'tmp' path '{}' does not exist."
+                                                  .format(path))
+
+
+def _is_tmp_file(path):
+    """Checks if the provided path is valid and existing temporary file. If not, an exception is
+    raised.
+
+    :param str path: the path to the temporary file to check
+    """
+    _is_tmp_path(path)
+    if not os.path.isfile(path):
+        raise exceptions.InvalidTempPathException("The 'tmp' path '{}' is not a file.".format(path))
+
+
+def _is_tmp_dir(path):
+    """Checks if the provided path is valid and existing temporary directory. if not, an exception
+    is raised.
+
+    :param str path: the path to the temporary directory to check
+    """
+    _is_tmp_path(path)
+    if not os.path.isdir(path):
+        raise exceptions.InvalidTempPathException("The 'tmp' path '{}' is not a directory."
+                                                  .format(path))
+
+
+def _delete_files(tmp_files, ignore_protected, force):
+    """Deletes the supplied temporary files.
+
+    If 'ignore_protected' is False and the directory structure contains protected temporary files,
+    the whole deletion process is aborted, no file is deleted and an exception is raised.
+    If set to True, protected files will be kept and only unprotected files will be deleted.
+
+    If 'force' is True, all the files including the protected ones are deleted regardless of the
+    'ignore_protected' value.
+
+    :param list tmp_files: a list of the temporary file paths to delete
+    :param bool ignore_protected: protected files in the directories will either abort the deletion
+                                  process or they will be ignored and not deleted
+    :param bool force: if True, the protected files will be also deleted
+    """
+    # Check for protected files
+    if not force:
+        tmp_files, protected = _filter_protected_files(tmp_files)
+        if protected and not ignore_protected:
+            # Abort the operation if ignore_protected is not set
+            raise exceptions.ProtectedTempException("Aborted temporary files deletion due to a "
+                                                    "presence of protected files.")
+    # Delete all the files and their potential records in the index
+    for file in tmp_files:
+        os.remove(file)
+    _delete_index_entries(tmp_files)
+
+
+def _filter_protected_files(tmp_files):
+    """Filters the protected files in the supplied temporary files.
+
+    :param list tmp_files: a list of the temporary files
+
+    :return tuple: (list of unprotected files, list of protected files)
+    """
+    index_entries = _load_index()
+    unprotected, protected = [], []
+    for file in tmp_files:
+        # Check if file is indexed and protected
+        if index_entries.get(file, {'protected': False})['protected']:
+            protected.append(file)
+        else:
+            unprotected.append(file)
+    return unprotected, protected
+
+
+def _delete_empty_directories(root):
+    """Identifies and deletes all empty directories and subdirectories in the 'root' directory.
+
+    The .perun/tmp/ directory, however, will not be deleted this way.
+
+    :param str root: the path to the root directory
+    """
+    # Obtain all the subdirectories in the root in the reverse order, however make sure tmp/ stays
+    tmp_root = pcs.get_tmp_directory()
+    root = _join_to_tmp_path(root)
+    all_dirs = [dirs for dirs, _, _ in os.walk(root, topdown=False) if dirs != tmp_root]
+    # Check if the given directory is empty and delete it
+    for directory in all_dirs:
+        if not os.listdir(directory):
+            os.remove(directory)
+
+
+def _write_to_temp(file_path, content, json_format, protect, compress):
+    """Writes the 'content' into the temporary file and stores the properties into the index
+    if needed.
+
+    :param str file_path: the path to the temporary file
+    :param content: the new content of the temporary file
+    :param bool json_format: if True, the content will be formatted as json
+    :param bool protect: if True, the file will have the protected status
+    :param bool compress: if True, the content will be compressed
+    """
+    # Optionally encode the content to json and compress it
+    file_mode = 'w+'
+    if json_format:
+        content = json.dumps(content, indent=2)
+    if compress:
+        file_mode = 'w+b'
+        content = store.pack_content(content.encode('utf-8'))
+    # Write the content to the tmp file
+    with open(file_path, file_mode) as tmp_handle:
+        tmp_handle.write(content)
+    # Save the properties to the index file if needed
+    _add_to_index(file_path, json_format, protect, compress)
+
+
+def _add_to_index(tmp_file, json_format=False, protected=False, compressed=False):
+    """Adds a new entry into the index. The entry tracks 'json_format, protected, compressed'
+    properties for the given tmp_file. If all of those properties are False, no entry is created.
+
+    :param str tmp_file: the path of the temporary file
+    :param bool json_format: the property describing if json format was used
+    :param bool protected: the protection level property
+    :param bool compressed: the compression property
+    """
+    # Do not index entries that have no True parameters
+    if not json_format and not protected and not compressed:
+        # However remove possible outdated occurrences of the index entry
+        _delete_index_entries([tmp_file])
+        return
+    # Otherwise save the parameters
+    index_records = _load_index()
+    file_config = index_records.setdefault(tmp_file, {})
+    file_config['json'] = json_format
+    file_config['protected'] = protected
+    file_config['compressed'] = compressed
+    _save_index(index_records)
+
+
+def _get_index_entry(tmp_file):
+    """Gets an index entry (i.e. the tracked properties) for the given temporary file.
+
+    If no corresponding entry for the file exists, then all of the properties are assumed
+    to be False.
+
+    :param str tmp_file: the path of the temporary file
+    :return tuple: (json_format, protected, compressed)
+    """
+    file_record = _load_index().get(tmp_file)
+    if file_record is None:
+        # Non-existent entries are assumed to be all False
+        return False, False, False
+    return file_record['json'], file_record['protected'], file_record['compressed']
+
+
+def _delete_index_entries(tmp_files):
+    """Deletes the index entries (if they exist) of the supplied temporary files.
+
+    :param list tmp_files: the list of the temporary files for which to delete the entries
+    """
+    index_records = _load_index()
+    for tmp_file in tmp_files:
+        if tmp_file in index_records:
+            del index_records[tmp_file]
+    _save_index(index_records)
+
+
+def _load_index():
+    """Loads the content of the index file as dictionary.
+
+    The index is json-formatted and compressed, in case the index cannot be read for some reason,
+    an empty dictionary is returned.
+
+    :return dict: the decompressed and json-decoded index content.
+    """
+    # Create the tmp index file if it does not exist yet
+    tmp_index = pcs.get_tmp_index()
+    if not os.path.exists(tmp_index):
+        store.touch_file(tmp_index)
+    # Open and load the file
+    try:
+        with open(tmp_index, 'rb') as tmp_handle:
+            return json.loads(store.read_and_deflate_chunk(tmp_handle))
+    except (ValueError, zlib.error):
+        # Contents either empty or corrupted, init the content to empty dict
+        return {}
+
+
+def _save_index(records):
+    """Saves the index records to the index file. The index file is created if it does not exist or
+    overwritten if it does.
+
+    :param dict records: the index entries/records in the dictionary format
+    """
+    tmp_index = pcs.get_tmp_index()
+    with open(tmp_index, 'w+b') as tmp_handle:
+        compressed = store.pack_content(json.dumps(records, indent=2).encode('utf-8'))
+        tmp_handle.write(compressed)

--- a/perun/logic/temp.py
+++ b/perun/logic/temp.py
@@ -283,12 +283,15 @@ def list_all_temps_with_details(root=None):
     tmp_files = list_all_temps(root)
     unprotected, protected = _filter_protected_files(tmp_files)
     u_sizes, p_sizes = _get_temps_size(unprotected), _get_temps_size(protected)
+    # Create 3 lists representing the names, protection levels and sizes
+    tmp_files = unprotected + protected
+    sizes = u_sizes + p_sizes
+    protection_level = [UNPROTECTED] * len(unprotected) + [PROTECTED] * len(protected)
+
     # Create tuples out of the parameters
     result = []
-    for idx, p_file in enumerate(protected):
-        result.append((p_file, PROTECTED, p_sizes[idx]))
-    for idx, u_file in enumerate(unprotected):
-        result.append((u_file, UNPROTECTED, u_sizes[idx]))
+    for idx, file in enumerate(tmp_files):
+        result.append((file, protection_level[idx], sizes[idx]))
     return result
 
 

--- a/perun/logic/temp.py
+++ b/perun/logic/temp.py
@@ -400,7 +400,7 @@ def synchronize_index():
     """
     index_entries = _load_index()
     tmp_files = list_all_temps()
-    for tmp_name, conf in index_entries.items():
+    for (tmp_name, conf) in list(index_entries.items()):
         # Remove records of files that are deleted or not necessary to track
         if tmp_name not in tmp_files or (not conf['json'] and not conf['protected']
                                          and not conf['compressed']):

--- a/perun/utils/__init__.py
+++ b/perun/utils/__init__.py
@@ -421,10 +421,10 @@ def format_file_size(size):
 
     :return str: the formatted size for output
     """
-    for unit in ['', 'Ki', 'Mi', 'Gi', 'Ti', 'Pi', 'Ei', 'Zi']:
+    for unit in ['', 'Ki', 'Mi', 'Gi', 'Ti']:
         if abs(size) < 1024.0:
             if unit == '':
                 return "{:6.0f} B  ".format(size)
             return "{:6.1f} {}B".format(size, unit)
         size /= 1024.0
-    return "{:.1f} YiB".format(size)
+    return "{:.1f} PiB".format(size)

--- a/perun/utils/__init__.py
+++ b/perun/utils/__init__.py
@@ -409,3 +409,22 @@ def build_command_str(cmd, args, workload):
     if workload:
         cmd += ' ' + workload
     return cmd
+
+
+def format_file_size(size):
+    """Format file size in Bytes into a fixed-length output so that it can be easily printed.
+
+    Courtesy of 'https://stackoverflow.com/questions/1094841/reusable-library-to-get-human-
+    readable-version-of-file-size'
+
+    :param int size: the size in Bytes
+
+    :return str: the formatted size for output
+    """
+    for unit in ['', 'Ki', 'Mi', 'Gi', 'Ti', 'Pi', 'Ei', 'Zi']:
+        if abs(size) < 1024.0:
+            if unit == '':
+                return "{:6.0f} B  ".format(size)
+            return "{:6.1f} {}B".format(size, unit)
+        size /= 1024.0
+    return "{:.1f} YiB".format(size)

--- a/perun/utils/exceptions.py
+++ b/perun/utils/exceptions.py
@@ -99,6 +99,27 @@ class StatsFileNotFoundException(Exception):
         return self.msg
 
 
+class InvalidTempPathException(Exception):
+    """Raised when the looked up temporary path (file or directory) does not exist or the given
+    path is of invalid type for the given operation (file path for directory operation etc.)"""
+    def __init__(self, msg):
+        super().__init__("")
+        self.msg = msg
+
+    def __str__(self):
+        return self.msg
+
+
+class ProtectedTempException(Exception):
+    """Raised when an attempt to delete protected temp file is made."""
+    def __init__(self, msg):
+        super().__init__("")
+        self.msg = msg
+
+    def __str__(self):
+        return self.msg
+
+
 class VersionControlSystemException(Exception):
     """Raised when there is an issue with wrapped version control system.
 

--- a/perun/utils/log.py
+++ b/perun/utils/log.py
@@ -269,6 +269,21 @@ def failed(ending='\n'):
     print(']', end=ending)
 
 
+def set_color(output, color, enable_coloring=True, attrs=None):
+    """Transforms the output to colored version.
+
+    :param str output: the output text that should be colored
+    :param str color: the color
+    :param bool enable_coloring: switch that allows to disable the coloring - the function is no-op
+    :param list attrs: list of additional attributes for the coloring
+
+    :return str: the new colored output (if enabled)
+    """
+    if enable_coloring:
+        return termcolor.colored(output, color, attrs=attrs)
+    return output
+
+
 def count_degradations_per_group(degradation_list):
     """Counts the number of optimizations and degradations
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1718,7 +1718,7 @@ def test_temp(pcs_with_empty_git):
 
     # Try to list files in invalid path
     result = runner.invoke(cli.temp_list, ['../'])
-    assert result.exit_code == 0
+    assert result.exit_code == 1
     assert 'not located in' in result.output
 
     # Add some files to the tmp/
@@ -1732,10 +1732,10 @@ def test_temp(pcs_with_empty_git):
         file_deg_content = deg_handle.read()
     with open(os.path.join(files_dir, 'const1.perf'), 'r') as deg_handle:
         file_deg2_content = deg_handle.read()
-    temp.new_temp(file_lock, "Some important data", protect=True)
-    temp.new_temp(file_records, file_records_content)
-    temp.new_temp(file_deg, file_deg_content, protect=True)
-    temp.new_temp(file_deg2, file_deg2_content)
+    temp.create_new_temp(file_lock, "Some important data", protect=True)
+    temp.create_new_temp(file_records, file_records_content)
+    temp.create_new_temp(file_deg, file_deg_content, protect=True)
+    temp.create_new_temp(file_deg2, file_deg2_content)
 
     # List the now-nonempty tmp/ directory in colored mode
     result = runner.invoke(cli.temp_list, [pcs.get_tmp_directory()])
@@ -1785,7 +1785,7 @@ def test_temp(pcs_with_empty_git):
 
     # Test the warning
     result = runner.invoke(cli.temp_delete, ['.', '-w'])
-    assert result.exit_code == 0
+    assert result.exit_code == 1
     assert 'Aborted' in result.output
     assert temp.exists_temp_file(file_deg)
 
@@ -1807,8 +1807,8 @@ def test_temp(pcs_with_empty_git):
     assert temp.exists_temp_dir('degradations') and temp.exists_temp_dir('trace')
 
     # Partially repopulate the directory
-    temp.new_temp(file_lock, "Some important data", protect=True)
-    temp.new_temp(file_deg2, file_deg2_content)
+    temp.create_new_temp(file_lock, "Some important data", protect=True)
+    temp.create_new_temp(file_deg2, file_deg2_content)
 
     # Test the complete deletion of the tmp/ directory
     result = runner.invoke(cli.temp_delete, ['.', '-f'])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1716,6 +1716,11 @@ def test_temp(pcs_with_empty_git):
     assert result.exit_code == 0
     assert 'Total size of all' not in result.output and 'No results in' in result.output
 
+    # Try to list files in invalid path
+    result = runner.invoke(cli.temp_list, ['../'])
+    assert result.exit_code == 0
+    assert 'not located in' in result.output
+
     # Add some files to the tmp/
     file_lock = 'trace/lock.txt'
     file_records = 'trace/data/records.data'
@@ -1773,6 +1778,11 @@ def test_temp(pcs_with_empty_git):
     assert temp.get_temp_properties(file_lock) == (False, False, False)
 
     # Test the deletion
+    # Try to delete non-existent directory
+    result = runner.invoke(cli.temp_delete, ['some/invalid/dir'])
+    assert result.exit_code == 0
+    assert 'does not exist, no files deleted' in result.output
+
     # Test the warning
     result = runner.invoke(cli.temp_delete, ['.', '-w'])
     assert result.exit_code == 0

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -30,8 +30,9 @@ def assert_perun_successfully_init_at(path):
     assert 'jobs' in perun_content
     assert 'logs' in perun_content
     assert 'stats' in perun_content
+    assert 'tmp' in perun_content
     assert os.path.exists(os.path.join(perun_dir, 'local.yml'))
-    assert len(perun_content) == 6
+    assert len(perun_content) == 7
 
 
 def assert_git_successfully_init_at(path, is_bare=False):

--- a/tests/test_temp.py
+++ b/tests/test_temp.py
@@ -90,32 +90,32 @@ def test_temp_file_operations(pcs_with_empty_git):
     """
     # Create a new temporary file and check it
     lock_file = 'trace/lock.txt'
-    temp.new_temp(lock_file, 'Some test data in custom format')
+    temp.create_new_temp(lock_file, 'Some test data in custom format')
     assert temp.exists_temp_file(lock_file)
     assert temp.get_temp_properties(lock_file) == (False, False, False)
-    assert temp.get_temp(lock_file) == 'Some test data in custom format'
+    assert temp.read_temp(lock_file) == 'Some test data in custom format'
 
     # new_temp should not allow overwriting
     with pytest.raises(exceptions.InvalidTempPathException) as exc:
-        temp.new_temp(lock_file, 'Another test data')
+        temp.create_new_temp(lock_file, 'Another test data')
     assert 'already exists' in str(exc.value)
 
     # Create new temporary file using store_temp
     collect_file = 'trace/files/collect.log'
     temp.store_temp(collect_file, 'Some log data')
     assert temp.exists_temp_file(collect_file)
-    assert temp.get_temp(collect_file) == 'Some log data'
+    assert temp.read_temp(collect_file) == 'Some log data'
 
     # store_temp should allow overwriting
     temp.store_temp(collect_file, 'Some data for overwrite')
-    assert temp.get_temp(collect_file) == 'Some data for overwrite'
+    assert temp.read_temp(collect_file) == 'Some data for overwrite'
 
     # Test the file properties json and compressed
     temp_data = {'id': 0x11ef, 'data': {'important': ['values']}}
     temp.store_temp(collect_file, temp_data, True, False, True)
     # The index should take care of correct formatting and (de)compression
     assert temp.get_temp_properties(collect_file) == (True, False, True)
-    assert temp.get_temp(collect_file) == temp_data
+    assert temp.read_temp(collect_file) == temp_data
     # Test manually the content to ensure the formatting and compression happened
     expected_content = store.pack_content(json.dumps(temp_data, indent=2).encode('utf-8'))
     with open(temp.temp_path(collect_file), 'rb') as tmp_handle:
@@ -127,11 +127,11 @@ def test_temp_file_operations(pcs_with_empty_git):
     with open(temp.temp_path(collect_file), 'w') as tmp_handle:
         # The file is still considered json-formatted and compressed, thus error occurs when reading
         tmp_handle.write('Some uncompressed and not formatted data')
-    assert temp.get_temp(collect_file) is None
+    assert temp.read_temp(collect_file) is None
 
     # Reset the corrupted file
     temp.reset_temp(collect_file)
-    assert temp.get_temp(collect_file) == ''
+    assert temp.read_temp(collect_file) == ''
 
 
 def test_temp_file_deletion(pcs_with_empty_git):
@@ -149,7 +149,7 @@ def test_temp_file_deletion(pcs_with_empty_git):
     temp.touch_temp_file(file_collect)
     temp.touch_temp_file(file_records)
     temp.touch_temp_file(file_deg_info)
-    temp.new_temp(file_deg_records, temp_data, json_format=True, protect=True, compress=True)
+    temp.create_new_temp(file_deg_records, temp_data, json_format=True, protect=True, compress=True)
     temp.store_temp(file_deg_log, "Some log data", json_format=False, protect=False, compress=True)
     # Test correct properties
     assert temp.get_temp_properties(file_lock) == (False, True, False)
@@ -311,7 +311,7 @@ def test_temp_sync(pcs_with_empty_git):
     # Create some dummy files
     file_lock, file_results = 'trace/lock.txt', 'degradation/results.data'
     temp.touch_temp_file(file_lock, protect=True)
-    temp.new_temp(file_results, 'Some degradations', True, True, True)
+    temp.create_new_temp(file_results, 'Some degradations', True, True, True)
     # Check the index contents
     assert temp.get_temp_properties(file_lock) == (False, True, False)
     assert temp.get_temp_properties(file_results) == (True, True, True)

--- a/tests/test_temp.py
+++ b/tests/test_temp.py
@@ -1,0 +1,336 @@
+import os
+import pytest
+import json
+
+import perun.logic.temp as temp
+import perun.logic.store as store
+import perun.logic.pcs as pcs
+import perun.utils.exceptions as exceptions
+
+
+def test_temp_invalid_paths(pcs_with_empty_git):
+    """Test various invalid paths for temp operations.
+
+    'temp_path' uses private function that is used in all the public functions thus testing this
+    function should be enough as long as change is not made.
+    """
+    # Test paths that end up out of the tmp/ scope
+    with pytest.raises(exceptions.InvalidTempPathException) as exc:
+        temp.temp_path('../testtmp')
+    assert 'is not located in the perun tmp/ directory' in str(exc.value)
+
+    with pytest.raises(exceptions.InvalidTempPathException) as exc:
+        temp.temp_path('./inner/../../testtmp')
+    assert 'is not located in the perun tmp/ directory' in str(exc.value)
+
+    with pytest.raises(exceptions.InvalidTempPathException) as exc:
+        temp.temp_path('/tmp/testtmp')
+    assert 'is not located in the perun tmp/ directory' in str(exc.value)
+
+    with pytest.raises(exceptions.InvalidTempPathException) as exc:
+        temp.temp_path(os.path.join(pcs.get_tmp_directory(), '../testtmp'))
+    assert 'is not located in the perun tmp/ directory' in str(exc.value)
+
+
+def test_temp_basics(pcs_with_empty_git):
+    """Test some basic operations with the temp module such as touching files / dirs, existence
+    checks, listing temporary files etc.
+    """
+    tmp_dir = pcs.get_tmp_directory()
+
+    # Create a directory
+    temp.touch_temp_dir('trace/trace_files')
+    temp.touch_temp_dir('trace')
+    # Check that only the two inner directories really exist
+    tmp_content = os.listdir(tmp_dir)
+    trace_content = os.listdir(os.path.join(tmp_dir, 'trace'))
+    assert len(tmp_content) == 1 and tmp_content[0] == 'trace'
+    assert len(trace_content) == 1 and trace_content[0] == 'trace_files'
+    assert not os.listdir(os.path.join(tmp_dir, 'trace', 'trace_files'))
+    # Test the existence functions
+    assert temp.exists_temp_dir('trace/trace_files')
+    assert not temp.exists_temp_dir('trace/another_trace_files')
+
+    # Check that no temporary file exists yet
+    assert not temp.list_all_temps()
+    # Add two files, one of them protected
+    temp.touch_temp_file('trace/trace_files/collect_log')
+    temp.touch_temp_file('trace/lock.txt', True)
+    # Check that the files are there
+    temps = temp.list_all_temps()
+    file1 = os.path.join(tmp_dir, 'trace/trace_files/collect_log')
+    file2 = os.path.join(tmp_dir, 'trace/lock.txt')
+    assert (len(temps) == 2 and file1 in temps and file2 in temps)
+    # Test the existence function
+    assert temp.exists_temp_file('trace/lock.txt')
+    assert not temp.exists_temp_file('trace/trace_files/lock2.txt')
+    # Test the list with details
+    temps = temp.list_all_temps_with_details()
+    assert (len(temps) == 2 and (file1, temp.UNPROTECTED, 0) in temps
+            and (file2, temp.PROTECTED, 0) in temps)
+    # Test the list functions with different root
+    temps = temp.list_all_temps('trace/trace_files')
+    assert len(temps) == 1 and file1 in temps
+    temps = temp.list_all_temps_with_details('trace/trace_files')
+    assert len(temps) == 1 and (file1, temp.UNPROTECTED, 0) in temps
+
+    # Test the list function on nonexistent root
+    with pytest.raises(exceptions.InvalidTempPathException) as exc:
+        temp.list_all_temps('trace/invalid/dir')
+    assert 'does not exist' in str(exc.value)
+
+    # Test the list function on file instead of directory
+    with pytest.raises(exceptions.InvalidTempPathException) as exc:
+        temp.list_all_temps('trace/lock.txt')
+    assert 'is not a directory' in str(exc.value)
+
+
+def test_temp_file_operations(pcs_with_empty_git):
+    """Test temporary file manipulation such as creating, reading, properties etc.
+    """
+    # Create a new temporary file and check it
+    lock_file = 'trace/lock.txt'
+    temp.new_temp(lock_file, 'Some test data in custom format')
+    assert temp.exists_temp_file(lock_file)
+    assert temp.get_temp_properties(lock_file) == (False, False, False)
+    assert temp.get_temp(lock_file) == 'Some test data in custom format'
+
+    # new_temp should not allow overwriting
+    with pytest.raises(exceptions.InvalidTempPathException) as exc:
+        temp.new_temp(lock_file, 'Another test data')
+    assert 'already exists' in str(exc.value)
+
+    # Create new temporary file using store_temp
+    collect_file = 'trace/files/collect.log'
+    temp.store_temp(collect_file, 'Some log data')
+    assert temp.exists_temp_file(collect_file)
+    assert temp.get_temp(collect_file) == 'Some log data'
+
+    # store_temp should allow overwriting
+    temp.store_temp(collect_file, 'Some data for overwrite')
+    assert temp.get_temp(collect_file) == 'Some data for overwrite'
+
+    # Test the file properties json and compressed
+    temp_data = {'id': 0x11ef, 'data': {'important': ['values']}}
+    temp.store_temp(collect_file, temp_data, True, False, True)
+    # The index should take care of correct formatting and (de)compression
+    assert temp.get_temp_properties(collect_file) == (True, False, True)
+    assert temp.get_temp(collect_file) == temp_data
+    # Test manually the content to ensure the formatting and compression happened
+    expected_content = store.pack_content(json.dumps(temp_data, indent=2).encode('utf-8'))
+    with open(temp.temp_path(collect_file), 'rb') as tmp_handle:
+        content = tmp_handle.read()
+        assert isinstance(content, (bytes, bytearray))
+        assert content == expected_content
+
+    # Manually change the content so that corruption is simulated
+    with open(temp.temp_path(collect_file), 'w') as tmp_handle:
+        # The file is still considered json-formatted and compressed, thus error occurs when reading
+        tmp_handle.write('Some uncompressed and not formatted data')
+    assert temp.get_temp(collect_file) is None
+
+    # Reset the corrupted file
+    temp.reset_temp(collect_file)
+    assert temp.get_temp(collect_file) == ''
+
+
+def test_temp_file_deletion(pcs_with_empty_git):
+    """Test temporary files / directories deletion.
+    """
+    # Create some temp files and directories
+    temp_data = {'id': 0x11ef, 'data': {'important': ['values']}}
+    file_lock = 'trace/lock.txt'
+    file_collect = 'trace/trace_files/collect.log'
+    file_records = 'trace/trace_files/records.data'
+    file_deg_info = 'degradation/info.log'
+    file_deg_records = 'degradation/results/records.deg'
+    file_deg_log = 'degradation/results/details/degradation.log'
+    temp.touch_temp_file(file_lock, protect=True)
+    temp.touch_temp_file(file_collect)
+    temp.touch_temp_file(file_records)
+    temp.touch_temp_file(file_deg_info)
+    temp.new_temp(file_deg_records, temp_data, json_format=True, protect=True, compress=True)
+    temp.store_temp(file_deg_log, "Some log data", json_format=False, protect=False, compress=True)
+    # Test correct properties
+    assert temp.get_temp_properties(file_lock) == (False, True, False)
+    assert temp.get_temp_properties(file_deg_records) == (True, True, True)
+    assert temp.get_temp_properties(file_deg_log) == (False, False, True)
+    # Test the index content
+    _check_index([file_lock, file_deg_records, file_deg_log])
+
+    # Current status:
+    #   trace/
+    #       lock.txt (P)
+    #       trace_files/
+    #           collect.log
+    #           records.data
+    #   degradation/
+    #       info.log
+    #       results/
+    #           records.deg (P)
+    #           details/
+    #               degradation.log
+
+    # Try to delete nonexistent file
+    with pytest.raises(exceptions.InvalidTempPathException) as exc:
+        temp.delete_temp_file('some/invalid/file')
+    assert 'does not exist' in str(exc.value)
+
+    # Try to delete directory with file deletion function
+    with pytest.raises(exceptions.InvalidTempPathException) as exc:
+        temp.delete_temp_file('trace/trace_files/')
+    assert 'is not a file' in str(exc.value)
+
+    # Try to delete protected file without force
+    with pytest.raises(exceptions.ProtectedTempException) as exc:
+        temp.delete_temp_file(file_lock)
+    assert 'Aborted' in str(exc.value)
+    # Check if ignore_protected works
+    temp.delete_temp_file(file_lock, ignore_protected=True)
+    assert temp.exists_temp_file(file_lock)
+
+    # Try to delete unprotected file
+    temp.delete_temp_file(file_collect)
+    assert not temp.exists_temp_file(file_collect)
+
+    # Set protected status to a file and try to delete it with force
+    temp.set_protected_status(file_records, True)
+    assert temp.get_temp_properties(file_records) == (False, True, False)
+    temp.delete_temp_file(file_records, force=True)
+    assert not temp.exists_temp_file(file_records)
+
+    # Disable protection status and try to delete a file
+    temp.set_protected_status(file_lock, False)
+    assert temp.get_temp_properties(file_lock) == (False, False, False)
+    temp.delete_temp_file(file_lock)
+    assert not temp.exists_temp_file(file_lock)
+
+    # The index should have only two files by now
+    _check_index([file_deg_records, file_deg_log])
+
+    # Current status:
+    #   trace/
+    #       trace_files/
+    #   degradation/
+    #       info.log
+    #       results/
+    #           records.deg (P)
+    #           details/
+    #               degradation.log
+
+    # Try to delete all files in nonexistent directory
+    with pytest.raises(exceptions.InvalidTempPathException) as exc:
+        temp.delete_all_temps('trace/trace/')
+    assert 'does not exist' in str(exc.value)
+    # Try to delete all files in root that is a file
+    with pytest.raises(exceptions.InvalidTempPathException) as exc:
+        temp.delete_all_temps(file_deg_info)
+    assert 'not a directory' in str(exc.value)
+
+    # Try to delete all files in empty directory
+    temp.delete_all_temps('trace')
+    _check_dirs_and_files(['trace', 'trace/trace_files'], [],
+                          [file_deg_info, file_deg_records, file_deg_log], [])
+
+    # Try to delete all files without ignore_protected and with protected files
+    with pytest.raises(exceptions.ProtectedTempException) as exc:
+        temp.delete_all_temps('degradation')
+    assert 'Aborted' in str(exc.value)
+    _check_dirs_and_files(['trace', 'trace/trace_files'], [],
+                          [file_deg_info, file_deg_records, file_deg_log], [])
+
+    # Try to delete all files with ignore_protected and protected files
+    temp.delete_all_temps('degradation', ignore_protected=True)
+    _check_dirs_and_files(['trace', 'trace/trace_files', 'degradation/results/details'], [],
+                          [file_deg_records], [file_deg_log, file_deg_info])
+    # Check the index
+    _check_index([file_deg_records])
+
+    # Restore the degradation directory
+    temp.touch_temp_file(file_deg_info)
+    temp.store_temp(file_deg_log, "Some log data", json_format=False, protect=False, compress=True)
+
+    # Try to use force with ignore_protected
+    temp.delete_all_temps('degradation', ignore_protected=True, force=True)
+    _check_dirs_and_files(['trace', 'trace/trace_files', 'degradation/results/details'], [],
+                          [], [file_deg_records, file_deg_log, file_deg_info])
+    _check_index([])
+
+    # Update the hierarchy so that we can test the deletion of directories
+    file_log = 'trace/details/trace.log'
+    temp.touch_temp_file(file_log, protect=True)
+    temp.touch_temp_file(file_deg_info, protect=True)
+    temp.store_temp(file_deg_log, "Some log data", json_format=False, protect=False, compress=True)
+
+    # Current status:
+    #   trace/
+    #       trace_files/
+    #       details/
+    #           trace.log (P)
+    #   degradation/
+    #       info.log (P)
+    #       results/
+    #           details/
+    #               degradation.log
+
+    # Try to delete the trace without ignore_protected
+    with pytest.raises(exceptions.ProtectedTempException) as exc:
+        temp.delete_temp_dir('trace')
+    assert 'Aborted' in str(exc.value)
+    _check_dirs_and_files(['trace/trace_files'], [],
+                          [file_log, file_deg_log], [])
+
+    # Try to delete trace with ignore_protected
+    temp.delete_temp_dir('trace', ignore_protected=True)
+    _check_dirs_and_files([], ['trace/trace_files'],
+                          [file_log, file_deg_log], [])
+
+    # Try to delete details with force
+    temp.delete_temp_dir('trace/details', force=True)
+    _check_dirs_and_files(['trace'], ['trace/details'],
+                          [file_deg_log, file_deg_info], [file_log])
+    _check_index([file_deg_info, file_deg_log])
+
+    # Try to delete the whole tmp/ with force
+    temp.delete_temp_dir('.', force=True)
+    tmp_content = os.listdir(pcs.get_tmp_directory())
+    assert temp.exists_temp_dir('.') and len(tmp_content) == 1 and '.index' in tmp_content
+    _check_index([])
+
+    # Try to corrupt the index to force exception handling
+    temp.touch_temp_file(file_lock, protect=True)
+    _check_index([file_lock])
+    with open(os.path.join(pcs.get_tmp_directory(), '.index'), 'w') as index_handle:
+        index_handle.write('Some invalid data')
+    _check_index([])
+
+
+def _check_index(expected_content):
+    """Check if the index file contains exactly the entries in expected_content.
+
+    :param list expected_content: the list of expected entries in the index
+    """
+    index_content = temp._load_index()
+    index_keys = list(index_content.keys())
+    assert len(index_keys) == len(expected_content)
+    for record in expected_content:
+        assert temp.temp_path(record) in index_keys
+
+
+def _check_dirs_and_files(dirs, dirs_del, files, files_del):
+    """Check the existence and nonexistence of files and directories.
+
+    :param list dirs: the list of directories that should exist
+    :param list dirs_del: the list of directories that should not exist
+    :param list files: the list of files that should exist
+    :param list files_del: the list of files that should not exist
+    :return:
+    """
+    for d in dirs:
+        assert temp.exists_temp_dir(d)
+    for d in dirs_del:
+        assert not temp.exists_temp_dir(d)
+    for f in files:
+        assert temp.exists_temp_file(f)
+    for f in files_del:
+        assert not temp.exists_temp_file(f)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -157,3 +157,18 @@ def test_binaries_lookup():
     assert len(binaries2) == 2
     assert binaries2[0].endswith('utils_tree/testdir/quicksort')
     assert binaries2[1].endswith('utils_tree/testdir/nobuild/quicksort')
+
+
+def test_size_formatting():
+    """Test the file size formatting
+    """
+    # Test small size values
+    assert utils.format_file_size(148) == '   148 B  '
+    assert utils.format_file_size(1012) == '  1012 B  '
+    # Test some larger values
+    assert utils.format_file_size(23456) == '  22.9 KiB'
+    assert utils.format_file_size(1054332440) == '1005.5 MiB'
+    # Test some ridiculously large values
+    assert utils.format_file_size(8273428342423) == '   7.5 TiB'
+    assert utils.format_file_size(81273198731928371) == '72.2 PiB'
+    assert utils.format_file_size(87329487294792342394293489232) == '77564166018710.8 PiB'

--- a/tests/tmp_files/const1.perf
+++ b/tests/tmp_files/const1.perf
@@ -1,0 +1,7173 @@
+{
+  "collector_info": {
+    "params": {
+      "internal_direct_output": false,
+      "sampling": [],
+      "target_dir": "./target",
+      "internal_storage_size": 20000,
+      "files": [
+        "../example_sources/skiplist_parameters_cpp/skiplist_height_low.cpp",
+        "../example_sources/structures/skiplist.cpp",
+        "../example_sources/structures/skiplist.h"
+      ],
+      "rules": [
+        "skiplistSearch"
+      ],
+      "internal_data_filename": "trace.log"
+    },
+    "name": "complexity"
+  },
+  "origin": "f7f3dcea69b97f2b03c421a223a770917149cfae",
+  "global": {
+    "time": "18.484409s",
+    "models": [
+      {
+        "model": "power",
+        "method": "full",
+        "coeffs": [
+          {
+            "value": 0.9931974686591577,
+            "name": "b0"
+          },
+          {
+            "value": 0.0006056992911439742,
+            "name": "b1"
+          }
+        ],
+        "x_interval_end": 1000000,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "r_square": 0.0008114073836928499,
+        "x_interval_start": 1
+      },
+      {
+        "model": "quadratic",
+        "method": "full",
+        "coeffs": [
+          {
+            "value": 1.0033465662126233,
+            "name": "b0"
+          },
+          {
+            "value": -2.4573681909883146e-08,
+            "name": "b1"
+          },
+          {
+            "value": 3.0546844851318393e-14,
+            "name": "b2"
+          }
+        ],
+        "x_interval_end": 1000000,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "r_square": 0.007999701297937256,
+        "x_interval_start": 1
+      },
+      {
+        "model": "exponential",
+        "method": "full",
+        "coeffs": [
+          {
+            "value": 0.9988420841152046,
+            "name": "b0"
+          },
+          {
+            "value": 1.0000000041771508,
+            "name": "b1"
+          }
+        ],
+        "x_interval_end": 1000000,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "r_square": 0.0028495784489828983,
+        "x_interval_start": 1
+      },
+      {
+        "model": "logarithmic",
+        "method": "full",
+        "coeffs": [
+          {
+            "value": 0.9900139127163327,
+            "name": "b0"
+          },
+          {
+            "value": 0.0008776677482891205,
+            "name": "b1"
+          }
+        ],
+        "x_interval_end": 1000000,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "r_square": 0.0008472704553399315,
+        "x_interval_start": 1
+      },
+      {
+        "model": "linear",
+        "method": "full",
+        "coeffs": [
+          {
+            "value": 0.9982503949011492,
+            "name": "b0"
+          },
+          {
+            "value": 6.003527599069949e-09,
+            "name": "b1"
+          }
+        ],
+        "x_interval_end": 1000000,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "r_square": 0.002927320652343462,
+        "x_interval_start": 1
+      },
+      {
+        "model": "constant",
+        "method": "full",
+        "coeffs": [
+          {
+            "value": 1.0012551604644837,
+            "name": "b0"
+          },
+          {
+            "value": 0,
+            "name": "b1"
+          }
+        ],
+        "x_interval_end": 1000000,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "r_square": 1,
+        "x_interval_start": 1
+      }
+    ],
+    "resources": [
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 2,
+        "structure-unit-size": 1000000,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.999321845493484,
+        "structure-unit-size": 1,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.007250587855196,
+        "structure-unit-size": 1001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9932980666021644,
+        "structure-unit-size": 2001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9906825410339312,
+        "structure-unit-size": 3001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0018327911727747,
+        "structure-unit-size": 4001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0029513703463084,
+        "structure-unit-size": 5001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.009497107063536,
+        "structure-unit-size": 6001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.000583560156723,
+        "structure-unit-size": 7001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9939246159912485,
+        "structure-unit-size": 8001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9973250596506904,
+        "structure-unit-size": 9001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0100722563284998,
+        "structure-unit-size": 10001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.007514630494377,
+        "structure-unit-size": 11001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.005599127056355,
+        "structure-unit-size": 12001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9922498513693806,
+        "structure-unit-size": 13001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.994765324601053,
+        "structure-unit-size": 14001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9929479781182406,
+        "structure-unit-size": 15001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0048654197103901,
+        "structure-unit-size": 16001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9934534807475579,
+        "structure-unit-size": 17001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9936442330392251,
+        "structure-unit-size": 18001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0072151721517753,
+        "structure-unit-size": 19001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.009638924429651,
+        "structure-unit-size": 20001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.995183526029967,
+        "structure-unit-size": 21001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.999086983906596,
+        "structure-unit-size": 22001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0089616222187885,
+        "structure-unit-size": 23001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0051844490739719,
+        "structure-unit-size": 24001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0040484664810154,
+        "structure-unit-size": 25001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0038506720239724,
+        "structure-unit-size": 26001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.993995427004231,
+        "structure-unit-size": 27001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.002403156463606,
+        "structure-unit-size": 28001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9954406429665573,
+        "structure-unit-size": 29001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0033921084477555,
+        "structure-unit-size": 30001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0084530770161135,
+        "structure-unit-size": 31001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0066752202939544,
+        "structure-unit-size": 32001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0035635141967016,
+        "structure-unit-size": 33001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9906878917039533,
+        "structure-unit-size": 34001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0010685272658166,
+        "structure-unit-size": 35001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9976150185059941,
+        "structure-unit-size": 36001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0093318723881464,
+        "structure-unit-size": 37001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9943006512363284,
+        "structure-unit-size": 38001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.009803522420049,
+        "structure-unit-size": 39001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9972652749617269,
+        "structure-unit-size": 40001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0061971463345287,
+        "structure-unit-size": 41001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0047924305372815,
+        "structure-unit-size": 42001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9912111866913247,
+        "structure-unit-size": 43001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0010868074912183,
+        "structure-unit-size": 44001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0037227625910223,
+        "structure-unit-size": 45001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.997769064831024,
+        "structure-unit-size": 46001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9941061358249943,
+        "structure-unit-size": 47001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.996963069651077,
+        "structure-unit-size": 48001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9985627143235603,
+        "structure-unit-size": 49001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0007421337788027,
+        "structure-unit-size": 50001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0010518343481585,
+        "structure-unit-size": 51001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0076733333743209,
+        "structure-unit-size": 52001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9920416975949512,
+        "structure-unit-size": 53001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0065665074200616,
+        "structure-unit-size": 54001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0097664778025848,
+        "structure-unit-size": 55001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9908878896840632,
+        "structure-unit-size": 56001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0040834397309288,
+        "structure-unit-size": 57001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9904491296701535,
+        "structure-unit-size": 58001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0066285291244732,
+        "structure-unit-size": 59001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.005236851805563,
+        "structure-unit-size": 60001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0051682230725485,
+        "structure-unit-size": 61001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.004708425872267,
+        "structure-unit-size": 62001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0008819134469056,
+        "structure-unit-size": 63001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9959247484260624,
+        "structure-unit-size": 64001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9973480637444413,
+        "structure-unit-size": 65001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.005795921933484,
+        "structure-unit-size": 66001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0053168941665478,
+        "structure-unit-size": 67001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9914784306960979,
+        "structure-unit-size": 68001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0054700921256272,
+        "structure-unit-size": 69001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0009088077244788,
+        "structure-unit-size": 70001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.008701203785281,
+        "structure-unit-size": 71001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9974367363819422,
+        "structure-unit-size": 72001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9978523527341749,
+        "structure-unit-size": 73001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9922149987271325,
+        "structure-unit-size": 74001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9951025224983123,
+        "structure-unit-size": 75001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9933267351908442,
+        "structure-unit-size": 76001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0057695066167527,
+        "structure-unit-size": 77001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0048941722261306,
+        "structure-unit-size": 78001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9901676296660344,
+        "structure-unit-size": 79001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9967296915397627,
+        "structure-unit-size": 80001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0003419665396118,
+        "structure-unit-size": 81001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0097356553408017,
+        "structure-unit-size": 82001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.001568794749981,
+        "structure-unit-size": 83001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.995863728758191,
+        "structure-unit-size": 84001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.004906025514866,
+        "structure-unit-size": 85001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.00401286805872,
+        "structure-unit-size": 86001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0031148254155973,
+        "structure-unit-size": 87001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9945334459508555,
+        "structure-unit-size": 88001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9998926134191589,
+        "structure-unit-size": 89001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9942176751364237,
+        "structure-unit-size": 90001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9928991259492405,
+        "structure-unit-size": 91001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9950881918785763,
+        "structure-unit-size": 92001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.002995564762019,
+        "structure-unit-size": 93001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0039044149817085,
+        "structure-unit-size": 94001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9921253779889089,
+        "structure-unit-size": 95001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9987282113345498,
+        "structure-unit-size": 96001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.998944035410086,
+        "structure-unit-size": 97001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9907355131767468,
+        "structure-unit-size": 98001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0076796452606265,
+        "structure-unit-size": 99001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.000345059218345,
+        "structure-unit-size": 100001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9955658522590376,
+        "structure-unit-size": 101001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9928148006411812,
+        "structure-unit-size": 102001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9991527759129829,
+        "structure-unit-size": 103001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9968344478064319,
+        "structure-unit-size": 104001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9942414164260798,
+        "structure-unit-size": 105001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.996756916690165,
+        "structure-unit-size": 106001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9992543186026454,
+        "structure-unit-size": 107001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9940487382480953,
+        "structure-unit-size": 108001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9985929007456983,
+        "structure-unit-size": 109001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9939731269451045,
+        "structure-unit-size": 110001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0083438021849205,
+        "structure-unit-size": 111001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9958569307578957,
+        "structure-unit-size": 112001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9910346334642315,
+        "structure-unit-size": 113001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0012333176231571,
+        "structure-unit-size": 114001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9973323964358403,
+        "structure-unit-size": 115001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.99470944235143,
+        "structure-unit-size": 116001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9949667942515931,
+        "structure-unit-size": 117001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0091280440927652,
+        "structure-unit-size": 118001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9957587285452871,
+        "structure-unit-size": 119001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9934592026487027,
+        "structure-unit-size": 120001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9919535392675195,
+        "structure-unit-size": 121001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0027100510776652,
+        "structure-unit-size": 122001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0005393717056232,
+        "structure-unit-size": 123001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9985259279619638,
+        "structure-unit-size": 124001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0013983203510748,
+        "structure-unit-size": 125001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.00976154137773,
+        "structure-unit-size": 126001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0100556240707994,
+        "structure-unit-size": 127001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9902463350277524,
+        "structure-unit-size": 128001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.005270811744259,
+        "structure-unit-size": 129001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0002921088495675,
+        "structure-unit-size": 130001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0089537978598169,
+        "structure-unit-size": 131001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9987322374112513,
+        "structure-unit-size": 132001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0067735734993788,
+        "structure-unit-size": 133001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.005618715584176,
+        "structure-unit-size": 134001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0058516456086493,
+        "structure-unit-size": 135001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0094939751569898,
+        "structure-unit-size": 136001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0034017238479016,
+        "structure-unit-size": 137001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0027812942377288,
+        "structure-unit-size": 138001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9985673346857975,
+        "structure-unit-size": 139001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.001930489035997,
+        "structure-unit-size": 140001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0100389519557533,
+        "structure-unit-size": 141001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9993700696844052,
+        "structure-unit-size": 142001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.00228007007804,
+        "structure-unit-size": 143001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9958683999132478,
+        "structure-unit-size": 144001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9916927422462458,
+        "structure-unit-size": 145001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9967897903201759,
+        "structure-unit-size": 146001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9955670015177692,
+        "structure-unit-size": 147001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0046320814751222,
+        "structure-unit-size": 148001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.003113762452329,
+        "structure-unit-size": 149001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0048236372784483,
+        "structure-unit-size": 150001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0080949391208402,
+        "structure-unit-size": 151001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9954909795148013,
+        "structure-unit-size": 152001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9974811500435274,
+        "structure-unit-size": 153001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9923969905851598,
+        "structure-unit-size": 154001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9921370245686704,
+        "structure-unit-size": 155001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9921688981031824,
+        "structure-unit-size": 156001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9987191139816693,
+        "structure-unit-size": 157001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9936656350471401,
+        "structure-unit-size": 158001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0023087912385877,
+        "structure-unit-size": 159001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9906959701775323,
+        "structure-unit-size": 160001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9985187667672312,
+        "structure-unit-size": 161001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.004450902224813,
+        "structure-unit-size": 162001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.993229628296481,
+        "structure-unit-size": 163001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9960624314090913,
+        "structure-unit-size": 164001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9925270151541541,
+        "structure-unit-size": 165001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0001372966357818,
+        "structure-unit-size": 166001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9933075474877763,
+        "structure-unit-size": 167001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.00732288475323,
+        "structure-unit-size": 168001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9919897811729944,
+        "structure-unit-size": 169001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0019576852477314,
+        "structure-unit-size": 170001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0061120667184065,
+        "structure-unit-size": 171001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.009720538538981,
+        "structure-unit-size": 172001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0096840412452497,
+        "structure-unit-size": 173001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0088257162513539,
+        "structure-unit-size": 174001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9954543903223991,
+        "structure-unit-size": 175001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9912537572268272,
+        "structure-unit-size": 176001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0050173328722884,
+        "structure-unit-size": 177001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9922866693168131,
+        "structure-unit-size": 178001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9962880964861113,
+        "structure-unit-size": 179001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9966317485133598,
+        "structure-unit-size": 180001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9903783229186661,
+        "structure-unit-size": 181001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0080499959625593,
+        "structure-unit-size": 182001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9923451528486731,
+        "structure-unit-size": 183001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.010001991978099,
+        "structure-unit-size": 184001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9966079724064358,
+        "structure-unit-size": 185001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0010722882873964,
+        "structure-unit-size": 186001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9930960302856391,
+        "structure-unit-size": 187001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9917084101331515,
+        "structure-unit-size": 188001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9958949364482244,
+        "structure-unit-size": 189001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0073709281268808,
+        "structure-unit-size": 190001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0073270090038833,
+        "structure-unit-size": 191001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0044028894776673,
+        "structure-unit-size": 192001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0100099590551492,
+        "structure-unit-size": 193001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.006291927655627,
+        "structure-unit-size": 194001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9985442673106127,
+        "structure-unit-size": 195001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9985967350365874,
+        "structure-unit-size": 196001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9926439148612839,
+        "structure-unit-size": 197001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.993499658006569,
+        "structure-unit-size": 198001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0059443918017323,
+        "structure-unit-size": 199001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0088677819990854,
+        "structure-unit-size": 200001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9949660296870995,
+        "structure-unit-size": 201001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9977426109545544,
+        "structure-unit-size": 202001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0035740515301081,
+        "structure-unit-size": 203001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9936682697767053,
+        "structure-unit-size": 204001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0004179595953278,
+        "structure-unit-size": 205001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9910838310575264,
+        "structure-unit-size": 206001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0021427065838808,
+        "structure-unit-size": 207001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0090062151752872,
+        "structure-unit-size": 208001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0074732372134136,
+        "structure-unit-size": 209001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0016763404777957,
+        "structure-unit-size": 210001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0050386069976192,
+        "structure-unit-size": 211001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0030323468983104,
+        "structure-unit-size": 212001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0100126958594964,
+        "structure-unit-size": 213001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0016424143015987,
+        "structure-unit-size": 214001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0025315991622927,
+        "structure-unit-size": 215001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.001071787698561,
+        "structure-unit-size": 216001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9956656779870516,
+        "structure-unit-size": 217001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0033969952397939,
+        "structure-unit-size": 218001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0046086101901694,
+        "structure-unit-size": 219001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.008253516598125,
+        "structure-unit-size": 220001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9976010678557095,
+        "structure-unit-size": 221001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0055178314657753,
+        "structure-unit-size": 222001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9919983347315923,
+        "structure-unit-size": 223001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.008614598312877,
+        "structure-unit-size": 224001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0034844365251796,
+        "structure-unit-size": 225001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.990475529620975,
+        "structure-unit-size": 226001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.005844889655664,
+        "structure-unit-size": 227001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0002217702599436,
+        "structure-unit-size": 228001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9907075729899502,
+        "structure-unit-size": 229001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9958101625290362,
+        "structure-unit-size": 230001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0019565183006094,
+        "structure-unit-size": 231001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0053428242019393,
+        "structure-unit-size": 232001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.004376202312419,
+        "structure-unit-size": 233001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0028730150483105,
+        "structure-unit-size": 234001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0084748047917576,
+        "structure-unit-size": 235001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0064230573978803,
+        "structure-unit-size": 236001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.001670741238025,
+        "structure-unit-size": 237001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9914428856294684,
+        "structure-unit-size": 238001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0060107750032756,
+        "structure-unit-size": 239001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9987559321597473,
+        "structure-unit-size": 240001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9971074790265194,
+        "structure-unit-size": 241001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0068519976318948,
+        "structure-unit-size": 242001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0094265557536533,
+        "structure-unit-size": 243001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9989007871193967,
+        "structure-unit-size": 244001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0015448450196858,
+        "structure-unit-size": 245001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0041043365384341,
+        "structure-unit-size": 246001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9970088395024012,
+        "structure-unit-size": 247001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0049405334593302,
+        "structure-unit-size": 248001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9954661208868096,
+        "structure-unit-size": 249001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9980637556076021,
+        "structure-unit-size": 250001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.006512804983128,
+        "structure-unit-size": 251001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.008437999999442,
+        "structure-unit-size": 252001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0011883592642767,
+        "structure-unit-size": 253001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0049993479969912,
+        "structure-unit-size": 254001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.009874454318067,
+        "structure-unit-size": 255001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0012406550158404,
+        "structure-unit-size": 256001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0092879773832477,
+        "structure-unit-size": 257001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9986351421331044,
+        "structure-unit-size": 258001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.992178245304413,
+        "structure-unit-size": 259001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0054078966130098,
+        "structure-unit-size": 260001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0079249875976315,
+        "structure-unit-size": 261001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0014680700690883,
+        "structure-unit-size": 262001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0039770796792897,
+        "structure-unit-size": 263001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0014320601585758,
+        "structure-unit-size": 264001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0098676935297914,
+        "structure-unit-size": 265001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0028437669525534,
+        "structure-unit-size": 266001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0035600930210227,
+        "structure-unit-size": 267001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9985854187778751,
+        "structure-unit-size": 268001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0020266405882092,
+        "structure-unit-size": 269001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9927482684700462,
+        "structure-unit-size": 270001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.00101304583122,
+        "structure-unit-size": 271001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9964275801826866,
+        "structure-unit-size": 272001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.006873808307022,
+        "structure-unit-size": 273001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.990793176593901,
+        "structure-unit-size": 274001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9961808714682374,
+        "structure-unit-size": 275001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.000881446058596,
+        "structure-unit-size": 276001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.004861200952063,
+        "structure-unit-size": 277001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.990935674020673,
+        "structure-unit-size": 278001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9907433435129871,
+        "structure-unit-size": 279001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9986195148018455,
+        "structure-unit-size": 280001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9937304767152878,
+        "structure-unit-size": 281001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9959717699244234,
+        "structure-unit-size": 282001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0005957324023906,
+        "structure-unit-size": 283001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.004570092809415,
+        "structure-unit-size": 284001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9919336754275714,
+        "structure-unit-size": 285001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.994475294088941,
+        "structure-unit-size": 286001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9935160399693473,
+        "structure-unit-size": 287001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0003457894349876,
+        "structure-unit-size": 288001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0098204444028958,
+        "structure-unit-size": 289001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0090703334583397,
+        "structure-unit-size": 290001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.006879021668452,
+        "structure-unit-size": 291001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0037565579829757,
+        "structure-unit-size": 292001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9912008529147891,
+        "structure-unit-size": 293001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9969527584201777,
+        "structure-unit-size": 294001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9933439017348634,
+        "structure-unit-size": 295001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9923916944421298,
+        "structure-unit-size": 296001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9972425437941055,
+        "structure-unit-size": 297001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0050976667495861,
+        "structure-unit-size": 298001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.008669243387145,
+        "structure-unit-size": 299001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0010504557113118,
+        "structure-unit-size": 300001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9923578269506002,
+        "structure-unit-size": 301001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9949182832749981,
+        "structure-unit-size": 302001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.005751720146671,
+        "structure-unit-size": 303001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0020293278542882,
+        "structure-unit-size": 304001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9964123580942011,
+        "structure-unit-size": 305001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9960791620823015,
+        "structure-unit-size": 306001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9956427554835179,
+        "structure-unit-size": 307001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.009321441627882,
+        "structure-unit-size": 308001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0029881905243665,
+        "structure-unit-size": 309001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9988453133524563,
+        "structure-unit-size": 310001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0012351574477791,
+        "structure-unit-size": 311001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9981878408548711,
+        "structure-unit-size": 312001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0068380048790244,
+        "structure-unit-size": 313001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0001733326674835,
+        "structure-unit-size": 314001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0028670428251125,
+        "structure-unit-size": 315001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0016329082102557,
+        "structure-unit-size": 316001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9984977685367397,
+        "structure-unit-size": 317001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0091479919090942,
+        "structure-unit-size": 318001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9972651356256997,
+        "structure-unit-size": 319001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9956209731775074,
+        "structure-unit-size": 320001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.992405969639106,
+        "structure-unit-size": 321001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0074320165920683,
+        "structure-unit-size": 322001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0015276068859793,
+        "structure-unit-size": 323001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0012570506086902,
+        "structure-unit-size": 324001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9921647301135667,
+        "structure-unit-size": 325001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9911588934884946,
+        "structure-unit-size": 326001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9924914005532535,
+        "structure-unit-size": 327001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0015027214766012,
+        "structure-unit-size": 328001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.995711693011209,
+        "structure-unit-size": 329001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0030815427309148,
+        "structure-unit-size": 330001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0026533384291656,
+        "structure-unit-size": 331001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0018415762341775,
+        "structure-unit-size": 332001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9949586323111907,
+        "structure-unit-size": 333001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.002442842929991,
+        "structure-unit-size": 334001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.996217100402587,
+        "structure-unit-size": 335001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9946433327752211,
+        "structure-unit-size": 336001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.991433411601105,
+        "structure-unit-size": 337001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9940374181351189,
+        "structure-unit-size": 338001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9932288879756346,
+        "structure-unit-size": 339001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9956064576605247,
+        "structure-unit-size": 340001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0057373686655668,
+        "structure-unit-size": 341001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9948127203722661,
+        "structure-unit-size": 342001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0017388953370707,
+        "structure-unit-size": 343001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0028000161740869,
+        "structure-unit-size": 344001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9993569322067533,
+        "structure-unit-size": 345001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0038832021219595,
+        "structure-unit-size": 346001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0001562089560334,
+        "structure-unit-size": 347001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0016113611909638,
+        "structure-unit-size": 348001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.009979776888744,
+        "structure-unit-size": 349001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0027965905122591,
+        "structure-unit-size": 350001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0096359435984577,
+        "structure-unit-size": 351001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9905054607850323,
+        "structure-unit-size": 352001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9984690366070472,
+        "structure-unit-size": 353001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0008817950802136,
+        "structure-unit-size": 354001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0038721345467752,
+        "structure-unit-size": 355001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0085589463947844,
+        "structure-unit-size": 356001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9938194261821808,
+        "structure-unit-size": 357001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9996009850762321,
+        "structure-unit-size": 358001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9928056880451464,
+        "structure-unit-size": 359001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0080199943001713,
+        "structure-unit-size": 360001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9968524977727222,
+        "structure-unit-size": 361001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9981499988216818,
+        "structure-unit-size": 362001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0047974289754058,
+        "structure-unit-size": 363001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9952776549222795,
+        "structure-unit-size": 364001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9975199485827685,
+        "structure-unit-size": 365001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9948813447671021,
+        "structure-unit-size": 366001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9906458655027992,
+        "structure-unit-size": 367001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.000825508053619,
+        "structure-unit-size": 368001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0072786152565663,
+        "structure-unit-size": 369001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0077589473974373,
+        "structure-unit-size": 370001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9941518716927847,
+        "structure-unit-size": 371001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.995507984568204,
+        "structure-unit-size": 372001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0064214704330068,
+        "structure-unit-size": 373001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0012683319549127,
+        "structure-unit-size": 374001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.99350216422814,
+        "structure-unit-size": 375001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.00303445683617,
+        "structure-unit-size": 376001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.009178716499154,
+        "structure-unit-size": 377001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0055593681917798,
+        "structure-unit-size": 378001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0075729068521693,
+        "structure-unit-size": 379001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0065867369702446,
+        "structure-unit-size": 380001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0100955845812347,
+        "structure-unit-size": 381001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0067681103239337,
+        "structure-unit-size": 382001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9921173393089388,
+        "structure-unit-size": 383001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0082325304613862,
+        "structure-unit-size": 384001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.990657092767892,
+        "structure-unit-size": 385001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0084655025279,
+        "structure-unit-size": 386001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0097601755217036,
+        "structure-unit-size": 387001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0059168714976277,
+        "structure-unit-size": 388001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0044242417204274,
+        "structure-unit-size": 389001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0033565709566086,
+        "structure-unit-size": 390001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0053560387310072,
+        "structure-unit-size": 391001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0023672238165462,
+        "structure-unit-size": 392001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.005042505235995,
+        "structure-unit-size": 393001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.008427464616887,
+        "structure-unit-size": 394001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9972047256934267,
+        "structure-unit-size": 395001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0079418096061556,
+        "structure-unit-size": 396001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0079600366158783,
+        "structure-unit-size": 397001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0080002770827987,
+        "structure-unit-size": 398001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9983805244302993,
+        "structure-unit-size": 399001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0037390733271427,
+        "structure-unit-size": 400001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0032367190260638,
+        "structure-unit-size": 401001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9942972832664339,
+        "structure-unit-size": 402001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.001320009047758,
+        "structure-unit-size": 403001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9928308005252736,
+        "structure-unit-size": 404001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.991539081216054,
+        "structure-unit-size": 405001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9943781264246747,
+        "structure-unit-size": 406001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9903028759974595,
+        "structure-unit-size": 407001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0040663364382456,
+        "structure-unit-size": 408001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9994147433381135,
+        "structure-unit-size": 409001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0092101718602535,
+        "structure-unit-size": 410001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0020476846023567,
+        "structure-unit-size": 411001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9979117522777357,
+        "structure-unit-size": 412001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0031386637752246,
+        "structure-unit-size": 413001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9991897636690574,
+        "structure-unit-size": 414001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9944643922286104,
+        "structure-unit-size": 415001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0068166217368795,
+        "structure-unit-size": 416001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0065974018169774,
+        "structure-unit-size": 417001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0023724627986181,
+        "structure-unit-size": 418001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0010829205256178,
+        "structure-unit-size": 419001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.009362040581555,
+        "structure-unit-size": 420001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0070281903018754,
+        "structure-unit-size": 421001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.00881183675181,
+        "structure-unit-size": 422001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9945447087782318,
+        "structure-unit-size": 423001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9909923733850942,
+        "structure-unit-size": 424001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9981923394687542,
+        "structure-unit-size": 425001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9992395863295311,
+        "structure-unit-size": 426001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9941316765326143,
+        "structure-unit-size": 427001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9908764937784894,
+        "structure-unit-size": 428001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9933816649053941,
+        "structure-unit-size": 429001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0033962707221504,
+        "structure-unit-size": 430001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.009653827595386,
+        "structure-unit-size": 431001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9948377566547085,
+        "structure-unit-size": 432001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9946267092860355,
+        "structure-unit-size": 433001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9937746305007471,
+        "structure-unit-size": 434001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.998621859199344,
+        "structure-unit-size": 435001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9914550957306854,
+        "structure-unit-size": 436001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0078932164934,
+        "structure-unit-size": 437001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.006854429797403,
+        "structure-unit-size": 438001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0059138362337188,
+        "structure-unit-size": 439001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0015079629180605,
+        "structure-unit-size": 440001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0057151876073358,
+        "structure-unit-size": 441001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0057180361136502,
+        "structure-unit-size": 442001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9964067112088066,
+        "structure-unit-size": 443001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0076197534268434,
+        "structure-unit-size": 444001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0031708592873982,
+        "structure-unit-size": 445001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9946606174594796,
+        "structure-unit-size": 446001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9989022624517354,
+        "structure-unit-size": 447001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.997987777280738,
+        "structure-unit-size": 448001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.009637508569886,
+        "structure-unit-size": 449001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.992866620732288,
+        "structure-unit-size": 450001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0022330110060975,
+        "structure-unit-size": 451001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.007522592733713,
+        "structure-unit-size": 452001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9927060585425808,
+        "structure-unit-size": 453001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.998894046822395,
+        "structure-unit-size": 454001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.001618857380366,
+        "structure-unit-size": 455001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9908699877195104,
+        "structure-unit-size": 456001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9965562070972782,
+        "structure-unit-size": 457001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9976708420822877,
+        "structure-unit-size": 458001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9998311207439861,
+        "structure-unit-size": 459001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9936806617626331,
+        "structure-unit-size": 460001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0005684472356897,
+        "structure-unit-size": 461001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0026439825005804,
+        "structure-unit-size": 462001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0015415682250974,
+        "structure-unit-size": 463001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0063700599757124,
+        "structure-unit-size": 464001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.008892271141026,
+        "structure-unit-size": 465001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.993016738065366,
+        "structure-unit-size": 466001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9931197015211064,
+        "structure-unit-size": 467001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0027489329351047,
+        "structure-unit-size": 468001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9962024004671323,
+        "structure-unit-size": 469001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9906308608253305,
+        "structure-unit-size": 470001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.002993334657127,
+        "structure-unit-size": 471001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.991219309609594,
+        "structure-unit-size": 472001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0011440724768321,
+        "structure-unit-size": 473001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9959988049103239,
+        "structure-unit-size": 474001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0099058976029378,
+        "structure-unit-size": 475001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9935870973864549,
+        "structure-unit-size": 476001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.00762845119714,
+        "structure-unit-size": 477001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0046820819357813,
+        "structure-unit-size": 478001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.006317709055842,
+        "structure-unit-size": 479001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0082177102582879,
+        "structure-unit-size": 480001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9906951526730788,
+        "structure-unit-size": 481001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0054391725977738,
+        "structure-unit-size": 482001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9921884282322878,
+        "structure-unit-size": 483001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0053413780471985,
+        "structure-unit-size": 484001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0038118137981438,
+        "structure-unit-size": 485001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0012450580032928,
+        "structure-unit-size": 486001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0047759923427046,
+        "structure-unit-size": 487001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9985984060532686,
+        "structure-unit-size": 488001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0095961621955358,
+        "structure-unit-size": 489001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0099894157642617,
+        "structure-unit-size": 490001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9991677132831042,
+        "structure-unit-size": 491001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9943129523531463,
+        "structure-unit-size": 492001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9983342976680976,
+        "structure-unit-size": 493001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9938944949963983,
+        "structure-unit-size": 494001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.992575463093143,
+        "structure-unit-size": 495001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9982960266359885,
+        "structure-unit-size": 496001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9965331305280998,
+        "structure-unit-size": 497001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0062523120046187,
+        "structure-unit-size": 498001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9992196819453235,
+        "structure-unit-size": 499001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0074199741501275,
+        "structure-unit-size": 500001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9980234572119485,
+        "structure-unit-size": 501001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9902763888487803,
+        "structure-unit-size": 502001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0100661043053738,
+        "structure-unit-size": 503001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9934130780022515,
+        "structure-unit-size": 504001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9994489452571289,
+        "structure-unit-size": 505001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9932818158734503,
+        "structure-unit-size": 506001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9973983116281994,
+        "structure-unit-size": 507001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.994187573093936,
+        "structure-unit-size": 508001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9932636132772366,
+        "structure-unit-size": 509001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9962128353370051,
+        "structure-unit-size": 510001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9932493078951583,
+        "structure-unit-size": 511001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0067371155766243,
+        "structure-unit-size": 512001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9934549972869888,
+        "structure-unit-size": 513001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0096988498986312,
+        "structure-unit-size": 514001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9950283060978339,
+        "structure-unit-size": 515001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0044216635664536,
+        "structure-unit-size": 516001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9924357613365475,
+        "structure-unit-size": 517001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9926997250296772,
+        "structure-unit-size": 518001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0064793833550325,
+        "structure-unit-size": 519001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0092338098873885,
+        "structure-unit-size": 520001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0046354814795102,
+        "structure-unit-size": 521001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.993938895804969,
+        "structure-unit-size": 522001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0032703693255618,
+        "structure-unit-size": 523001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0041100085491643,
+        "structure-unit-size": 524001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.008027817745968,
+        "structure-unit-size": 525001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0074977211361442,
+        "structure-unit-size": 526001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0002748633065042,
+        "structure-unit-size": 527001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.992998719893391,
+        "structure-unit-size": 528001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.991500044241396,
+        "structure-unit-size": 529001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0002353798398764,
+        "structure-unit-size": 530001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.004951666562559,
+        "structure-unit-size": 531001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0093591396080912,
+        "structure-unit-size": 532001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0064196256379951,
+        "structure-unit-size": 533001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9936091163673593,
+        "structure-unit-size": 534001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0026066435743464,
+        "structure-unit-size": 535001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0059941168596893,
+        "structure-unit-size": 536001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9985758959756499,
+        "structure-unit-size": 537001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0049456753123325,
+        "structure-unit-size": 538001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9980129288679221,
+        "structure-unit-size": 539001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9920706046338132,
+        "structure-unit-size": 540001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.000582758879931,
+        "structure-unit-size": 541001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9950348871431933,
+        "structure-unit-size": 542001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0042579568304482,
+        "structure-unit-size": 543001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9981553557052891,
+        "structure-unit-size": 544001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9988023022237527,
+        "structure-unit-size": 545001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9933146028308492,
+        "structure-unit-size": 546001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0013530879799208,
+        "structure-unit-size": 547001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0049363086951857,
+        "structure-unit-size": 548001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9950589277715638,
+        "structure-unit-size": 549001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9920232505765988,
+        "structure-unit-size": 550001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.995432125637091,
+        "structure-unit-size": 551001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.002454431731901,
+        "structure-unit-size": 552001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0096547834515055,
+        "structure-unit-size": 553001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9909574064660048,
+        "structure-unit-size": 554001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0001738985454396,
+        "structure-unit-size": 555001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9922390100164242,
+        "structure-unit-size": 556001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9963134616321977,
+        "structure-unit-size": 557001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0054848816161424,
+        "structure-unit-size": 558001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9964444369030916,
+        "structure-unit-size": 559001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0026961339401994,
+        "structure-unit-size": 560001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0018356065627798,
+        "structure-unit-size": 561001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9987909283575096,
+        "structure-unit-size": 562001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9903418304923981,
+        "structure-unit-size": 563001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0021783995554185,
+        "structure-unit-size": 564001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0010415733663076,
+        "structure-unit-size": 565001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0013331457482468,
+        "structure-unit-size": 566001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0060360446365955,
+        "structure-unit-size": 567001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9917679311442226,
+        "structure-unit-size": 568001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9927189371501102,
+        "structure-unit-size": 569001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0010086035401613,
+        "structure-unit-size": 570001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9973342053345591,
+        "structure-unit-size": 571001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9916557224918178,
+        "structure-unit-size": 572001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9990886278160912,
+        "structure-unit-size": 573001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0028183397612178,
+        "structure-unit-size": 574001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0061766210017848,
+        "structure-unit-size": 575001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9915697613645353,
+        "structure-unit-size": 576001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0082601967573452,
+        "structure-unit-size": 577001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9920070271905818,
+        "structure-unit-size": 578001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0086262279062803,
+        "structure-unit-size": 579001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0007374207297028,
+        "structure-unit-size": 580001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0074541831256365,
+        "structure-unit-size": 581001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9925348318417455,
+        "structure-unit-size": 582001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0078948234923122,
+        "structure-unit-size": 583001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9952630512342522,
+        "structure-unit-size": 584001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9908632869741942,
+        "structure-unit-size": 585001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0026347129478421,
+        "structure-unit-size": 586001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9970969679212764,
+        "structure-unit-size": 587001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9923782156594416,
+        "structure-unit-size": 588001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0090483938605945,
+        "structure-unit-size": 589001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9982718705747469,
+        "structure-unit-size": 590001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0044203259653446,
+        "structure-unit-size": 591001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.993619546325802,
+        "structure-unit-size": 592001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9943284033333473,
+        "structure-unit-size": 593001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0078138648020174,
+        "structure-unit-size": 594001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9960370407463119,
+        "structure-unit-size": 595001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9904331840646072,
+        "structure-unit-size": 596001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9915974644196223,
+        "structure-unit-size": 597001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0077958747520837,
+        "structure-unit-size": 598001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9983770108636711,
+        "structure-unit-size": 599001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.001089027840725,
+        "structure-unit-size": 600001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0051752707677766,
+        "structure-unit-size": 601001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0037877970777858,
+        "structure-unit-size": 602001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0042886425017632,
+        "structure-unit-size": 603001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0002050091334855,
+        "structure-unit-size": 604001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9934360390745341,
+        "structure-unit-size": 605001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0083059718278577,
+        "structure-unit-size": 606001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9933534441861528,
+        "structure-unit-size": 607001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0020103732585546,
+        "structure-unit-size": 608001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9973325363231409,
+        "structure-unit-size": 609001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9995714866279942,
+        "structure-unit-size": 610001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9946528132380444,
+        "structure-unit-size": 611001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9992309732818812,
+        "structure-unit-size": 612001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.998282845665689,
+        "structure-unit-size": 613001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.009001733149776,
+        "structure-unit-size": 614001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.997542259039822,
+        "structure-unit-size": 615001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.993997871531794,
+        "structure-unit-size": 616001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9908662240015726,
+        "structure-unit-size": 617001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0044730942690863,
+        "structure-unit-size": 618001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0053338984383604,
+        "structure-unit-size": 619001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.00826168204171,
+        "structure-unit-size": 620001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9915167221463198,
+        "structure-unit-size": 621001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0091293606328484,
+        "structure-unit-size": 622001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0100225724512306,
+        "structure-unit-size": 623001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9949591779142557,
+        "structure-unit-size": 624001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.007450554040358,
+        "structure-unit-size": 625001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.003510275699588,
+        "structure-unit-size": 626001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0068507079829845,
+        "structure-unit-size": 627001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9927678107099578,
+        "structure-unit-size": 628001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9948873482918025,
+        "structure-unit-size": 629001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9970549059193212,
+        "structure-unit-size": 630001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9960742950232963,
+        "structure-unit-size": 631001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0006095093798255,
+        "structure-unit-size": 632001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0082904626465146,
+        "structure-unit-size": 633001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0052975321540876,
+        "structure-unit-size": 634001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.002175545007558,
+        "structure-unit-size": 635001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.002425509326897,
+        "structure-unit-size": 636001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.003101903377375,
+        "structure-unit-size": 637001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9901897282248823,
+        "structure-unit-size": 638001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0063977122128507,
+        "structure-unit-size": 639001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0035932268977292,
+        "structure-unit-size": 640001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0033362732931572,
+        "structure-unit-size": 641001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9922561796211328,
+        "structure-unit-size": 642001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0098457728481394,
+        "structure-unit-size": 643001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9959345480463051,
+        "structure-unit-size": 644001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9952645513411744,
+        "structure-unit-size": 645001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9972868632840866,
+        "structure-unit-size": 646001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.006461841546552,
+        "structure-unit-size": 647001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9907704370609182,
+        "structure-unit-size": 648001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0040218984504705,
+        "structure-unit-size": 649001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0086255201515668,
+        "structure-unit-size": 650001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9923153203042776,
+        "structure-unit-size": 651001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9995095521340523,
+        "structure-unit-size": 652001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9981879140667743,
+        "structure-unit-size": 653001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9973640430129659,
+        "structure-unit-size": 654001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0071959311451277,
+        "structure-unit-size": 655001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9976559517829796,
+        "structure-unit-size": 656001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.997870362017542,
+        "structure-unit-size": 657001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0063719277880594,
+        "structure-unit-size": 658001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9975378025015442,
+        "structure-unit-size": 659001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9983844302289211,
+        "structure-unit-size": 660001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9915449822289272,
+        "structure-unit-size": 661001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0032856650340927,
+        "structure-unit-size": 662001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0052616764558386,
+        "structure-unit-size": 663001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0058240025808534,
+        "structure-unit-size": 664001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0013426499999072,
+        "structure-unit-size": 665001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9965749178020454,
+        "structure-unit-size": 666001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0097879075620546,
+        "structure-unit-size": 667001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.993330090414094,
+        "structure-unit-size": 668001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9991995969751879,
+        "structure-unit-size": 669001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9963346987086162,
+        "structure-unit-size": 670001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9918848483415476,
+        "structure-unit-size": 671001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9935271825113469,
+        "structure-unit-size": 672001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0024112134080239,
+        "structure-unit-size": 673001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0064339505768325,
+        "structure-unit-size": 674001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9925607858116212,
+        "structure-unit-size": 675001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0083259352597325,
+        "structure-unit-size": 676001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0084572664644047,
+        "structure-unit-size": 677001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9949980357723133,
+        "structure-unit-size": 678001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9921792796850638,
+        "structure-unit-size": 679001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0003419532969418,
+        "structure-unit-size": 680001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0042308217835154,
+        "structure-unit-size": 681001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9945551874305917,
+        "structure-unit-size": 682001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9952738446623794,
+        "structure-unit-size": 683001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0093349400045606,
+        "structure-unit-size": 684001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0014165340969847,
+        "structure-unit-size": 685001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0018014531354154,
+        "structure-unit-size": 686001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9956839623889066,
+        "structure-unit-size": 687001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9907809357790739,
+        "structure-unit-size": 688001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.009028239586818,
+        "structure-unit-size": 689001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9960807022975916,
+        "structure-unit-size": 690001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0036989754565704,
+        "structure-unit-size": 691001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0064411675197387,
+        "structure-unit-size": 692001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.00879681768572,
+        "structure-unit-size": 693001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0026603873678972,
+        "structure-unit-size": 694001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9948933032147699,
+        "structure-unit-size": 695001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9939030353757805,
+        "structure-unit-size": 696001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0015095409421964,
+        "structure-unit-size": 697001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0026338728461146,
+        "structure-unit-size": 698001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0086287222140287,
+        "structure-unit-size": 699001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0041611618774209,
+        "structure-unit-size": 700001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9908685751688571,
+        "structure-unit-size": 701001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0010679656230086,
+        "structure-unit-size": 702001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0092443389312855,
+        "structure-unit-size": 703001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0036634161640328,
+        "structure-unit-size": 704001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9965838866596654,
+        "structure-unit-size": 705001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.991649706096411,
+        "structure-unit-size": 706001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9987632236387415,
+        "structure-unit-size": 707001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9988353996556517,
+        "structure-unit-size": 708001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9979651633510669,
+        "structure-unit-size": 709001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9901171738856211,
+        "structure-unit-size": 710001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.998045287115362,
+        "structure-unit-size": 711001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9999303608411915,
+        "structure-unit-size": 712001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9909315942391014,
+        "structure-unit-size": 713001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9917101428397741,
+        "structure-unit-size": 714001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9991110985030716,
+        "structure-unit-size": 715001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9995616934553332,
+        "structure-unit-size": 716001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0052649233453814,
+        "structure-unit-size": 717001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9947769829345489,
+        "structure-unit-size": 718001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0043569896618865,
+        "structure-unit-size": 719001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9955574163555705,
+        "structure-unit-size": 720001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0009126853570307,
+        "structure-unit-size": 721001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0005344982549251,
+        "structure-unit-size": 722001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.005442422998258,
+        "structure-unit-size": 723001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0073773493226112,
+        "structure-unit-size": 724001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0054039338756298,
+        "structure-unit-size": 725001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9949660764308376,
+        "structure-unit-size": 726001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9928897673151298,
+        "structure-unit-size": 727001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9903388423967298,
+        "structure-unit-size": 728001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0046941378555128,
+        "structure-unit-size": 729001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0091597898080327,
+        "structure-unit-size": 730001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9914704557266221,
+        "structure-unit-size": 731001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9953414636339264,
+        "structure-unit-size": 732001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0009843119414656,
+        "structure-unit-size": 733001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0015261891441252,
+        "structure-unit-size": 734001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9965648930924031,
+        "structure-unit-size": 735001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9918046485574058,
+        "structure-unit-size": 736001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9957822185970474,
+        "structure-unit-size": 737001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0086990253702057,
+        "structure-unit-size": 738001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9981607309274798,
+        "structure-unit-size": 739001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.99419009659304,
+        "structure-unit-size": 740001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0083194613672328,
+        "structure-unit-size": 741001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0063204991006425,
+        "structure-unit-size": 742001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0057114612952183,
+        "structure-unit-size": 743001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.993057158882279,
+        "structure-unit-size": 744001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.997400563900145,
+        "structure-unit-size": 745001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0044305300647443,
+        "structure-unit-size": 746001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9972106738499539,
+        "structure-unit-size": 747001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9925268385845524,
+        "structure-unit-size": 748001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.001332466098094,
+        "structure-unit-size": 749001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9980809305050103,
+        "structure-unit-size": 750001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.999111137356041,
+        "structure-unit-size": 751001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0089899104578124,
+        "structure-unit-size": 752001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.008411043222452,
+        "structure-unit-size": 753001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9964687120315601,
+        "structure-unit-size": 754001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.003736137473252,
+        "structure-unit-size": 755001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9983294235839532,
+        "structure-unit-size": 756001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0097843161313333,
+        "structure-unit-size": 757001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0090909076967236,
+        "structure-unit-size": 758001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9957545660318284,
+        "structure-unit-size": 759001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.996099682691912,
+        "structure-unit-size": 760001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9915405724616887,
+        "structure-unit-size": 761001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9936979603893569,
+        "structure-unit-size": 762001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0030685681964793,
+        "structure-unit-size": 763001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0085930799014295,
+        "structure-unit-size": 764001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.992756144749429,
+        "structure-unit-size": 765001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9982396048450395,
+        "structure-unit-size": 766001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0059054715934215,
+        "structure-unit-size": 767001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0000803942655891,
+        "structure-unit-size": 768001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9906903415098938,
+        "structure-unit-size": 769001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.999696057753633,
+        "structure-unit-size": 770001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0070859245957164,
+        "structure-unit-size": 771001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9953398493564265,
+        "structure-unit-size": 772001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0084068786353695,
+        "structure-unit-size": 773001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9912001088572927,
+        "structure-unit-size": 774001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0041090798843626,
+        "structure-unit-size": 775001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0071653453336917,
+        "structure-unit-size": 776001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9992011304193018,
+        "structure-unit-size": 777001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9931778047654526,
+        "structure-unit-size": 778001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0001670183993372,
+        "structure-unit-size": 779001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9905199987531039,
+        "structure-unit-size": 780001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.995866326837242,
+        "structure-unit-size": 781001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0048361045227687,
+        "structure-unit-size": 782001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0079727888607581,
+        "structure-unit-size": 783001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.991060592955138,
+        "structure-unit-size": 784001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0072289247024826,
+        "structure-unit-size": 785001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0026036810112589,
+        "structure-unit-size": 786001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9937187541704606,
+        "structure-unit-size": 787001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0055954942466148,
+        "structure-unit-size": 788001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0005643998036664,
+        "structure-unit-size": 789001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.00731093624897,
+        "structure-unit-size": 790001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9989416705188603,
+        "structure-unit-size": 791001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9982238329344729,
+        "structure-unit-size": 792001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9905973532084779,
+        "structure-unit-size": 793001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.009589235147287,
+        "structure-unit-size": 794001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9950125492158952,
+        "structure-unit-size": 795001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0032955376018868,
+        "structure-unit-size": 796001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9995323243814772,
+        "structure-unit-size": 797001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.008334417627158,
+        "structure-unit-size": 798001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0025738811833613,
+        "structure-unit-size": 799001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9935182210168462,
+        "structure-unit-size": 800001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0023481332561675,
+        "structure-unit-size": 801001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0045473553753383,
+        "structure-unit-size": 802001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0010677046690815,
+        "structure-unit-size": 803001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.991441363331636,
+        "structure-unit-size": 804001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9951970600383918,
+        "structure-unit-size": 805001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9965102321922065,
+        "structure-unit-size": 806001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0005254795144485,
+        "structure-unit-size": 807001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0057004093342923,
+        "structure-unit-size": 808001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0004380614014823,
+        "structure-unit-size": 809001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9952920058937839,
+        "structure-unit-size": 810001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9935901792715142,
+        "structure-unit-size": 811001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9968234705990896,
+        "structure-unit-size": 812001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0016316174605466,
+        "structure-unit-size": 813001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0039785684641958,
+        "structure-unit-size": 814001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0077403472181796,
+        "structure-unit-size": 815001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9982356135668918,
+        "structure-unit-size": 816001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0032692565048142,
+        "structure-unit-size": 817001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0060729984564591,
+        "structure-unit-size": 818001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9938313061554962,
+        "structure-unit-size": 819001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0088992203563572,
+        "structure-unit-size": 820001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0017304461830754,
+        "structure-unit-size": 821001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9920670986675247,
+        "structure-unit-size": 822001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9911325505256084,
+        "structure-unit-size": 823001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0056224555057856,
+        "structure-unit-size": 824001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9951731015829091,
+        "structure-unit-size": 825001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9959580134367161,
+        "structure-unit-size": 826001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9943185600353992,
+        "structure-unit-size": 827001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0080334644474278,
+        "structure-unit-size": 828001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0080789064177254,
+        "structure-unit-size": 829001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9948801496613298,
+        "structure-unit-size": 830001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9981637264101793,
+        "structure-unit-size": 831001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9967744284467162,
+        "structure-unit-size": 832001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.001692322956554,
+        "structure-unit-size": 833001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0078433497267714,
+        "structure-unit-size": 834001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0078895575933626,
+        "structure-unit-size": 835001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0028887869873808,
+        "structure-unit-size": 836001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9952853149504178,
+        "structure-unit-size": 837001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.006262921579426,
+        "structure-unit-size": 838001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0032027678187982,
+        "structure-unit-size": 839001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0092108178007115,
+        "structure-unit-size": 840001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0022657714336662,
+        "structure-unit-size": 841001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0086107696353765,
+        "structure-unit-size": 842001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0054975661136147,
+        "structure-unit-size": 843001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0047676648740642,
+        "structure-unit-size": 844001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0067242646467787,
+        "structure-unit-size": 845001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0078032137760646,
+        "structure-unit-size": 846001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9910955631205741,
+        "structure-unit-size": 847001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.003496091844407,
+        "structure-unit-size": 848001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.002989827919556,
+        "structure-unit-size": 849001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.004122120915308,
+        "structure-unit-size": 850001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0028288175510953,
+        "structure-unit-size": 851001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9955636099603932,
+        "structure-unit-size": 852001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0055104035330578,
+        "structure-unit-size": 853001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9939674029749399,
+        "structure-unit-size": 854001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0006761668298725,
+        "structure-unit-size": 855001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9913675013022478,
+        "structure-unit-size": 856001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0051674373303792,
+        "structure-unit-size": 857001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0036992422230542,
+        "structure-unit-size": 858001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0050003651451322,
+        "structure-unit-size": 859001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0084298345165095,
+        "structure-unit-size": 860001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9942762470103834,
+        "structure-unit-size": 861001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.991925144748035,
+        "structure-unit-size": 862001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9936553956831157,
+        "structure-unit-size": 863001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9974654591794382,
+        "structure-unit-size": 864001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0056157458106016,
+        "structure-unit-size": 865001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9980657712163251,
+        "structure-unit-size": 866001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0019440835947355,
+        "structure-unit-size": 867001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0067557165099552,
+        "structure-unit-size": 868001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.000213182651777,
+        "structure-unit-size": 869001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.993925992920926,
+        "structure-unit-size": 870001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0066966226530358,
+        "structure-unit-size": 871001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.006531664653571,
+        "structure-unit-size": 872001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9952127786242695,
+        "structure-unit-size": 873001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0017261485873281,
+        "structure-unit-size": 874001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.007586075082783,
+        "structure-unit-size": 875001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.002812646545774,
+        "structure-unit-size": 876001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.007361997499531,
+        "structure-unit-size": 877001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9950803931072595,
+        "structure-unit-size": 878001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0020745266484434,
+        "structure-unit-size": 879001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9940803661498298,
+        "structure-unit-size": 880001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0068049237029457,
+        "structure-unit-size": 881001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0033176535604822,
+        "structure-unit-size": 882001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.00337494532063,
+        "structure-unit-size": 883001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0027133940599395,
+        "structure-unit-size": 884001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9981626263950999,
+        "structure-unit-size": 885001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9994761827110203,
+        "structure-unit-size": 886001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.990706499814366,
+        "structure-unit-size": 887001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9981695368675583,
+        "structure-unit-size": 888001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0074282749837598,
+        "structure-unit-size": 889001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0070543381497514,
+        "structure-unit-size": 890001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9911592788554364,
+        "structure-unit-size": 891001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.996750975042487,
+        "structure-unit-size": 892001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9954402376548053,
+        "structure-unit-size": 893001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9964897756120281,
+        "structure-unit-size": 894001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9978606020206056,
+        "structure-unit-size": 895001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9936414760219988,
+        "structure-unit-size": 896001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0000071870786627,
+        "structure-unit-size": 897001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9916889579929035,
+        "structure-unit-size": 898001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0067161477301017,
+        "structure-unit-size": 899001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.001480437494081,
+        "structure-unit-size": 900001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0034058794986687,
+        "structure-unit-size": 901001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0022929338188271,
+        "structure-unit-size": 902001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0022537218857168,
+        "structure-unit-size": 903001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0094614287773083,
+        "structure-unit-size": 904001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9991182835909582,
+        "structure-unit-size": 905001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9964389421379134,
+        "structure-unit-size": 906001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9916717695001223,
+        "structure-unit-size": 907001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9940410996609056,
+        "structure-unit-size": 908001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.004161902461533,
+        "structure-unit-size": 909001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9964803728138988,
+        "structure-unit-size": 910001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0073434268228336,
+        "structure-unit-size": 911001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.99822137583868,
+        "structure-unit-size": 912001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.003318547888816,
+        "structure-unit-size": 913001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0073919120128279,
+        "structure-unit-size": 914001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0012617979616354,
+        "structure-unit-size": 915001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0031958298756953,
+        "structure-unit-size": 916001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0100112684430196,
+        "structure-unit-size": 917001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9999081619659053,
+        "structure-unit-size": 918001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.001145258989393,
+        "structure-unit-size": 919001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.999589315679725,
+        "structure-unit-size": 920001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9971379894603717,
+        "structure-unit-size": 921001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0080436702815936,
+        "structure-unit-size": 922001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.00970669044548,
+        "structure-unit-size": 923001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0049403874922973,
+        "structure-unit-size": 924001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.001475374268026,
+        "structure-unit-size": 925001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9913119410355369,
+        "structure-unit-size": 926001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9908772493971092,
+        "structure-unit-size": 927001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.992290790073954,
+        "structure-unit-size": 928001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9908794771874231,
+        "structure-unit-size": 929001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.001498829436311,
+        "structure-unit-size": 930001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0077647803632352,
+        "structure-unit-size": 931001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0099481385532445,
+        "structure-unit-size": 932001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9978479904308949,
+        "structure-unit-size": 933001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.007332545630991,
+        "structure-unit-size": 934001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0023842335434097,
+        "structure-unit-size": 935001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0086897792111151,
+        "structure-unit-size": 936001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.002743508721223,
+        "structure-unit-size": 937001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9904376732011048,
+        "structure-unit-size": 938001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0018516501159536,
+        "structure-unit-size": 939001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9934504102925652,
+        "structure-unit-size": 940001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.001946787687335,
+        "structure-unit-size": 941001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9923406811775564,
+        "structure-unit-size": 942001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0027540713903262,
+        "structure-unit-size": 943001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9925686188974088,
+        "structure-unit-size": 944001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0006342871420584,
+        "structure-unit-size": 945001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0035736196017104,
+        "structure-unit-size": 946001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.009556827059006,
+        "structure-unit-size": 947001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0081773985256135,
+        "structure-unit-size": 948001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9936704814693432,
+        "structure-unit-size": 949001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0001662070182988,
+        "structure-unit-size": 950001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9946515077633205,
+        "structure-unit-size": 951001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9982081352322042,
+        "structure-unit-size": 952001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9968062575889118,
+        "structure-unit-size": 953001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9940498532942245,
+        "structure-unit-size": 954001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.005128824640609,
+        "structure-unit-size": 955001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0059037256267316,
+        "structure-unit-size": 956001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0022806090913972,
+        "structure-unit-size": 957001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9918534363502459,
+        "structure-unit-size": 958001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9981164382441998,
+        "structure-unit-size": 959001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.999552622474631,
+        "structure-unit-size": 960001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0006722675380706,
+        "structure-unit-size": 961001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0015042667910985,
+        "structure-unit-size": 962001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.006611497209957,
+        "structure-unit-size": 963001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0083680268690491,
+        "structure-unit-size": 964001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9921817782684984,
+        "structure-unit-size": 965001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.999538459749531,
+        "structure-unit-size": 966001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0032021333066037,
+        "structure-unit-size": 967001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9955538864717415,
+        "structure-unit-size": 968001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0087971771832842,
+        "structure-unit-size": 969001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9958935348334447,
+        "structure-unit-size": 970001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0074498143282882,
+        "structure-unit-size": 971001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.994840735658579,
+        "structure-unit-size": 972001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.010003795740122,
+        "structure-unit-size": 973001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0029194321385537,
+        "structure-unit-size": 974001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9987163275742449,
+        "structure-unit-size": 975001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.00834259457228,
+        "structure-unit-size": 976001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0092248419010164,
+        "structure-unit-size": 977001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9914244841501116,
+        "structure-unit-size": 978001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9943065394010036,
+        "structure-unit-size": 979001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9984359963349758,
+        "structure-unit-size": 980001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9992976978869001,
+        "structure-unit-size": 981001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.998880797615223,
+        "structure-unit-size": 982001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9942512385717799,
+        "structure-unit-size": 983001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9973431536005284,
+        "structure-unit-size": 984001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0036188420232541,
+        "structure-unit-size": 985001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9978520572901423,
+        "structure-unit-size": 986001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.000765528502268,
+        "structure-unit-size": 987001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9989507006789591,
+        "structure-unit-size": 988001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9917353873197154,
+        "structure-unit-size": 989001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0023954048920316,
+        "structure-unit-size": 990001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9997872118124349,
+        "structure-unit-size": 991001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0086620302049707,
+        "structure-unit-size": 992001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0035540871624602,
+        "structure-unit-size": 993001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0044774864944834,
+        "structure-unit-size": 994001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.993117686581161,
+        "structure-unit-size": 995001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9998298778278263,
+        "structure-unit-size": 996001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9993789531575473,
+        "structure-unit-size": 997001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 1.0033379465845187,
+        "structure-unit-size": 998001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9935319290452646,
+        "structure-unit-size": 999001,
+        "subtype": "time delta"
+      },
+      {
+        "type": "mixed",
+        "uid": "skiplistSearch(skiplist*, int)",
+        "amount": 0.9969037231952902,
+        "structure-unit-size": 1000000,
+        "subtype": "time delta"
+      }
+    ]
+  },
+  "postprocessors": [
+    {
+      "params": {
+        "steps": 3,
+        "method": "full",
+        "regression_models": []
+      },
+      "name": "regression_analysis"
+    }
+  ],
+  "header": {
+    "args": "",
+    "cmd": "cmd",
+    "type": "mixed",
+    "workload": "wl",
+    "units": {
+      "mixed(time delta)": "ms"
+    }
+  }
+}

--- a/tests/tmp_files/lin1.perf
+++ b/tests/tmp_files/lin1.perf
@@ -1,0 +1,7157 @@
+{
+  "header": {
+    "cmd": "cmd",
+    "type": "mixed",
+    "units": {
+      "mixed(time delta)": "ms"
+    },
+    "args": "",
+    "workload": "wl"
+  },
+  "postprocessors": [],
+  "collector_info": {
+    "name": "complexity",
+    "params": {
+      "rules": [
+        "skiplistSearch"
+      ],
+      "internal_storage_size": 20000,
+      "target_dir": "./target",
+      "sampling": [],
+      "files": [
+        "../example_sources/skiplist_parameters_cpp/skiplist_height_low.cpp",
+        "../example_sources/structures/skiplist.cpp",
+        "../example_sources/structures/skiplist.h"
+      ],
+      "internal_direct_output": false,
+      "internal_data_filename": "trace.log"
+    }
+  },
+  "origin": "f7f3dcea69b97f2b03c421a223a770917149cfae",
+  "global": {
+    "resources": [
+      {
+        "structure-unit-size": 1,
+        "type": "mixed",
+        "amount": 28,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 1001,
+        "type": "mixed",
+        "amount": 367,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 2001,
+        "type": "mixed",
+        "amount": 335,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 3001,
+        "type": "mixed",
+        "amount": 381,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 4001,
+        "type": "mixed",
+        "amount": 559,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 5001,
+        "type": "mixed",
+        "amount": 741,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 6001,
+        "type": "mixed",
+        "amount": 725,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 7001,
+        "type": "mixed",
+        "amount": 907,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 8001,
+        "type": "mixed",
+        "amount": 788,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 9001,
+        "type": "mixed",
+        "amount": 905,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 10001,
+        "type": "mixed",
+        "amount": 969,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 11001,
+        "type": "mixed",
+        "amount": 914,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 12001,
+        "type": "mixed",
+        "amount": 1062,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 13001,
+        "type": "mixed",
+        "amount": 1261,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 14001,
+        "type": "mixed",
+        "amount": 1295,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 15001,
+        "type": "mixed",
+        "amount": 1421,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 16001,
+        "type": "mixed",
+        "amount": 1556,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 17001,
+        "type": "mixed",
+        "amount": 1686,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 18001,
+        "type": "mixed",
+        "amount": 1650,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 19001,
+        "type": "mixed",
+        "amount": 1731,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 20001,
+        "type": "mixed",
+        "amount": 1844,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 21001,
+        "type": "mixed",
+        "amount": 1842,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 22001,
+        "type": "mixed",
+        "amount": 1864,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 23001,
+        "type": "mixed",
+        "amount": 1945,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 24001,
+        "type": "mixed",
+        "amount": 1658,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 25001,
+        "type": "mixed",
+        "amount": 1574,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 26001,
+        "type": "mixed",
+        "amount": 1680,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 27001,
+        "type": "mixed",
+        "amount": 1637,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 28001,
+        "type": "mixed",
+        "amount": 1666,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 29001,
+        "type": "mixed",
+        "amount": 1712,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 30001,
+        "type": "mixed",
+        "amount": 1708,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 31001,
+        "type": "mixed",
+        "amount": 1757,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 32001,
+        "type": "mixed",
+        "amount": 1843,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 33001,
+        "type": "mixed",
+        "amount": 1877,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 34001,
+        "type": "mixed",
+        "amount": 1880,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 35001,
+        "type": "mixed",
+        "amount": 1918,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 36001,
+        "type": "mixed",
+        "amount": 1981,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 37001,
+        "type": "mixed",
+        "amount": 1896,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 38001,
+        "type": "mixed",
+        "amount": 1917,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 39001,
+        "type": "mixed",
+        "amount": 2032,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 40001,
+        "type": "mixed",
+        "amount": 2073,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 41001,
+        "type": "mixed",
+        "amount": 2147,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 42001,
+        "type": "mixed",
+        "amount": 2239,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 43001,
+        "type": "mixed",
+        "amount": 2184,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 44001,
+        "type": "mixed",
+        "amount": 2253,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 45001,
+        "type": "mixed",
+        "amount": 2361,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 46001,
+        "type": "mixed",
+        "amount": 2421,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 47001,
+        "type": "mixed",
+        "amount": 2578,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 48001,
+        "type": "mixed",
+        "amount": 2510,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 49001,
+        "type": "mixed",
+        "amount": 2560,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 50001,
+        "type": "mixed",
+        "amount": 2552,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 51001,
+        "type": "mixed",
+        "amount": 2547,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 52001,
+        "type": "mixed",
+        "amount": 2536,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 53001,
+        "type": "mixed",
+        "amount": 2583,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 54001,
+        "type": "mixed",
+        "amount": 2633,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 55001,
+        "type": "mixed",
+        "amount": 2703,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 56001,
+        "type": "mixed",
+        "amount": 2703,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 57001,
+        "type": "mixed",
+        "amount": 2878,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 58001,
+        "type": "mixed",
+        "amount": 2940,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 59001,
+        "type": "mixed",
+        "amount": 3089,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 60001,
+        "type": "mixed",
+        "amount": 3060,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 61001,
+        "type": "mixed",
+        "amount": 3059,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 62001,
+        "type": "mixed",
+        "amount": 3057,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 63001,
+        "type": "mixed",
+        "amount": 3057,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 64001,
+        "type": "mixed",
+        "amount": 3083,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 65001,
+        "type": "mixed",
+        "amount": 3250,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 66001,
+        "type": "mixed",
+        "amount": 3338,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 67001,
+        "type": "mixed",
+        "amount": 3269,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 68001,
+        "type": "mixed",
+        "amount": 3401,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 69001,
+        "type": "mixed",
+        "amount": 3365,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 70001,
+        "type": "mixed",
+        "amount": 3392,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 71001,
+        "type": "mixed",
+        "amount": 3464,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 72001,
+        "type": "mixed",
+        "amount": 3466,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 73001,
+        "type": "mixed",
+        "amount": 3484,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 74001,
+        "type": "mixed",
+        "amount": 3549,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 75001,
+        "type": "mixed",
+        "amount": 3829,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 76001,
+        "type": "mixed",
+        "amount": 3738,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 77001,
+        "type": "mixed",
+        "amount": 3920,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 78001,
+        "type": "mixed",
+        "amount": 3890,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 79001,
+        "type": "mixed",
+        "amount": 3807,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 80001,
+        "type": "mixed",
+        "amount": 3754,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 81001,
+        "type": "mixed",
+        "amount": 3793,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 82001,
+        "type": "mixed",
+        "amount": 3776,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 83001,
+        "type": "mixed",
+        "amount": 3795,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 84001,
+        "type": "mixed",
+        "amount": 4019,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 85001,
+        "type": "mixed",
+        "amount": 4038,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 86001,
+        "type": "mixed",
+        "amount": 4017,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 87001,
+        "type": "mixed",
+        "amount": 4186,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 88001,
+        "type": "mixed",
+        "amount": 4241,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 89001,
+        "type": "mixed",
+        "amount": 4243,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 90001,
+        "type": "mixed",
+        "amount": 4292,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 91001,
+        "type": "mixed",
+        "amount": 4315,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 92001,
+        "type": "mixed",
+        "amount": 4436,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 93001,
+        "type": "mixed",
+        "amount": 4438,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 94001,
+        "type": "mixed",
+        "amount": 4577,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 95001,
+        "type": "mixed",
+        "amount": 4653,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 96001,
+        "type": "mixed",
+        "amount": 4681,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 97001,
+        "type": "mixed",
+        "amount": 4732,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 98001,
+        "type": "mixed",
+        "amount": 4736,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 99001,
+        "type": "mixed",
+        "amount": 4709,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 100001,
+        "type": "mixed",
+        "amount": 4926,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 101001,
+        "type": "mixed",
+        "amount": 4931,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 102001,
+        "type": "mixed",
+        "amount": 4952,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 103001,
+        "type": "mixed",
+        "amount": 4933,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 104001,
+        "type": "mixed",
+        "amount": 5037,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 105001,
+        "type": "mixed",
+        "amount": 5086,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 106001,
+        "type": "mixed",
+        "amount": 5079,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 107001,
+        "type": "mixed",
+        "amount": 5069,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 108001,
+        "type": "mixed",
+        "amount": 5187,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 109001,
+        "type": "mixed",
+        "amount": 5304,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 110001,
+        "type": "mixed",
+        "amount": 5316,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 111001,
+        "type": "mixed",
+        "amount": 5167,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 112001,
+        "type": "mixed",
+        "amount": 5397,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 113001,
+        "type": "mixed",
+        "amount": 5411,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 114001,
+        "type": "mixed",
+        "amount": 5542,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 115001,
+        "type": "mixed",
+        "amount": 5546,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 116001,
+        "type": "mixed",
+        "amount": 5750,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 117001,
+        "type": "mixed",
+        "amount": 5834,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 118001,
+        "type": "mixed",
+        "amount": 5872,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 119001,
+        "type": "mixed",
+        "amount": 5899,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 120001,
+        "type": "mixed",
+        "amount": 5876,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 121001,
+        "type": "mixed",
+        "amount": 5921,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 122001,
+        "type": "mixed",
+        "amount": 5968,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 123001,
+        "type": "mixed",
+        "amount": 6082,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 124001,
+        "type": "mixed",
+        "amount": 6044,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 125001,
+        "type": "mixed",
+        "amount": 6108,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 126001,
+        "type": "mixed",
+        "amount": 6204,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 127001,
+        "type": "mixed",
+        "amount": 6124,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 128001,
+        "type": "mixed",
+        "amount": 6227,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 129001,
+        "type": "mixed",
+        "amount": 6349,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 130001,
+        "type": "mixed",
+        "amount": 6334,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 131001,
+        "type": "mixed",
+        "amount": 6389,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 132001,
+        "type": "mixed",
+        "amount": 6570,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 133001,
+        "type": "mixed",
+        "amount": 6547,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 134001,
+        "type": "mixed",
+        "amount": 6671,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 135001,
+        "type": "mixed",
+        "amount": 6697,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 136001,
+        "type": "mixed",
+        "amount": 6714,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 137001,
+        "type": "mixed",
+        "amount": 6815,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 138001,
+        "type": "mixed",
+        "amount": 6941,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 139001,
+        "type": "mixed",
+        "amount": 6837,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 140001,
+        "type": "mixed",
+        "amount": 6926,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 141001,
+        "type": "mixed",
+        "amount": 6886,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 142001,
+        "type": "mixed",
+        "amount": 6860,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 143001,
+        "type": "mixed",
+        "amount": 7073,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 144001,
+        "type": "mixed",
+        "amount": 6977,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 145001,
+        "type": "mixed",
+        "amount": 7227,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 146001,
+        "type": "mixed",
+        "amount": 7055,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 147001,
+        "type": "mixed",
+        "amount": 7091,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 148001,
+        "type": "mixed",
+        "amount": 7304,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 149001,
+        "type": "mixed",
+        "amount": 7188,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 150001,
+        "type": "mixed",
+        "amount": 7415,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 151001,
+        "type": "mixed",
+        "amount": 7208,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 152001,
+        "type": "mixed",
+        "amount": 7187,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 153001,
+        "type": "mixed",
+        "amount": 7218,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 154001,
+        "type": "mixed",
+        "amount": 7326,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 155001,
+        "type": "mixed",
+        "amount": 7579,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 156001,
+        "type": "mixed",
+        "amount": 7605,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 157001,
+        "type": "mixed",
+        "amount": 7576,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 158001,
+        "type": "mixed",
+        "amount": 7681,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 159001,
+        "type": "mixed",
+        "amount": 7756,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 160001,
+        "type": "mixed",
+        "amount": 7751,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 161001,
+        "type": "mixed",
+        "amount": 7765,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 162001,
+        "type": "mixed",
+        "amount": 7804,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 163001,
+        "type": "mixed",
+        "amount": 7875,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 164001,
+        "type": "mixed",
+        "amount": 7827,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 165001,
+        "type": "mixed",
+        "amount": 7848,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 166001,
+        "type": "mixed",
+        "amount": 7758,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 167001,
+        "type": "mixed",
+        "amount": 7876,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 168001,
+        "type": "mixed",
+        "amount": 7986,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 169001,
+        "type": "mixed",
+        "amount": 8099,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 170001,
+        "type": "mixed",
+        "amount": 8073,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 171001,
+        "type": "mixed",
+        "amount": 8135,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 172001,
+        "type": "mixed",
+        "amount": 8303,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 173001,
+        "type": "mixed",
+        "amount": 9182,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 174001,
+        "type": "mixed",
+        "amount": 9346,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 175001,
+        "type": "mixed",
+        "amount": 9134,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 176001,
+        "type": "mixed",
+        "amount": 9333,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 177001,
+        "type": "mixed",
+        "amount": 9250,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 178001,
+        "type": "mixed",
+        "amount": 9225,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 179001,
+        "type": "mixed",
+        "amount": 9031,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 180001,
+        "type": "mixed",
+        "amount": 8570,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 181001,
+        "type": "mixed",
+        "amount": 8492,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 182001,
+        "type": "mixed",
+        "amount": 8452,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 183001,
+        "type": "mixed",
+        "amount": 8917,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 184001,
+        "type": "mixed",
+        "amount": 8991,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 185001,
+        "type": "mixed",
+        "amount": 9030,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 186001,
+        "type": "mixed",
+        "amount": 9078,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 187001,
+        "type": "mixed",
+        "amount": 9115,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 188001,
+        "type": "mixed",
+        "amount": 9205,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 189001,
+        "type": "mixed",
+        "amount": 9314,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 190001,
+        "type": "mixed",
+        "amount": 9115,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 191001,
+        "type": "mixed",
+        "amount": 9152,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 192001,
+        "type": "mixed",
+        "amount": 9295,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 193001,
+        "type": "mixed",
+        "amount": 9255,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 194001,
+        "type": "mixed",
+        "amount": 9158,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 195001,
+        "type": "mixed",
+        "amount": 9335,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 196001,
+        "type": "mixed",
+        "amount": 9692,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 197001,
+        "type": "mixed",
+        "amount": 9476,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 198001,
+        "type": "mixed",
+        "amount": 9475,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 199001,
+        "type": "mixed",
+        "amount": 9552,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 200001,
+        "type": "mixed",
+        "amount": 9672,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 201001,
+        "type": "mixed",
+        "amount": 9697,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 202001,
+        "type": "mixed",
+        "amount": 9692,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 203001,
+        "type": "mixed",
+        "amount": 9855,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 204001,
+        "type": "mixed",
+        "amount": 9956,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 205001,
+        "type": "mixed",
+        "amount": 10149,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 206001,
+        "type": "mixed",
+        "amount": 9951,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 207001,
+        "type": "mixed",
+        "amount": 10067,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 208001,
+        "type": "mixed",
+        "amount": 10248,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 209001,
+        "type": "mixed",
+        "amount": 10477,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 210001,
+        "type": "mixed",
+        "amount": 10342,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 211001,
+        "type": "mixed",
+        "amount": 10400,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 212001,
+        "type": "mixed",
+        "amount": 10357,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 213001,
+        "type": "mixed",
+        "amount": 10470,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 214001,
+        "type": "mixed",
+        "amount": 10624,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 215001,
+        "type": "mixed",
+        "amount": 10694,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 216001,
+        "type": "mixed",
+        "amount": 10758,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 217001,
+        "type": "mixed",
+        "amount": 10693,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 218001,
+        "type": "mixed",
+        "amount": 10849,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 219001,
+        "type": "mixed",
+        "amount": 10776,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 220001,
+        "type": "mixed",
+        "amount": 10857,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 221001,
+        "type": "mixed",
+        "amount": 10749,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 222001,
+        "type": "mixed",
+        "amount": 11047,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 223001,
+        "type": "mixed",
+        "amount": 11080,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 224001,
+        "type": "mixed",
+        "amount": 10936,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 225001,
+        "type": "mixed",
+        "amount": 11804,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 226001,
+        "type": "mixed",
+        "amount": 11275,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 227001,
+        "type": "mixed",
+        "amount": 11307,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 228001,
+        "type": "mixed",
+        "amount": 11353,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 229001,
+        "type": "mixed",
+        "amount": 11439,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 230001,
+        "type": "mixed",
+        "amount": 11454,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 231001,
+        "type": "mixed",
+        "amount": 11566,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 232001,
+        "type": "mixed",
+        "amount": 11646,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 233001,
+        "type": "mixed",
+        "amount": 11683,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 234001,
+        "type": "mixed",
+        "amount": 11620,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 235001,
+        "type": "mixed",
+        "amount": 11707,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 236001,
+        "type": "mixed",
+        "amount": 11720,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 237001,
+        "type": "mixed",
+        "amount": 11843,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 238001,
+        "type": "mixed",
+        "amount": 11818,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 239001,
+        "type": "mixed",
+        "amount": 11862,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 240001,
+        "type": "mixed",
+        "amount": 11871,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 241001,
+        "type": "mixed",
+        "amount": 11691,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 242001,
+        "type": "mixed",
+        "amount": 11921,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 243001,
+        "type": "mixed",
+        "amount": 12528,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 244001,
+        "type": "mixed",
+        "amount": 12010,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 245001,
+        "type": "mixed",
+        "amount": 12021,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 246001,
+        "type": "mixed",
+        "amount": 12006,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 247001,
+        "type": "mixed",
+        "amount": 12178,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 248001,
+        "type": "mixed",
+        "amount": 12122,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 249001,
+        "type": "mixed",
+        "amount": 12219,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 250001,
+        "type": "mixed",
+        "amount": 12393,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 251001,
+        "type": "mixed",
+        "amount": 12535,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 252001,
+        "type": "mixed",
+        "amount": 12663,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 253001,
+        "type": "mixed",
+        "amount": 12625,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 254001,
+        "type": "mixed",
+        "amount": 12696,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 255001,
+        "type": "mixed",
+        "amount": 12490,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 256001,
+        "type": "mixed",
+        "amount": 12453,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 257001,
+        "type": "mixed",
+        "amount": 13159,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 258001,
+        "type": "mixed",
+        "amount": 12805,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 259001,
+        "type": "mixed",
+        "amount": 12819,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 260001,
+        "type": "mixed",
+        "amount": 12917,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 261001,
+        "type": "mixed",
+        "amount": 12939,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 262001,
+        "type": "mixed",
+        "amount": 12790,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 263001,
+        "type": "mixed",
+        "amount": 13127,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 264001,
+        "type": "mixed",
+        "amount": 13111,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 265001,
+        "type": "mixed",
+        "amount": 13005,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 266001,
+        "type": "mixed",
+        "amount": 13149,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 267001,
+        "type": "mixed",
+        "amount": 13189,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 268001,
+        "type": "mixed",
+        "amount": 13079,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 269001,
+        "type": "mixed",
+        "amount": 13179,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 270001,
+        "type": "mixed",
+        "amount": 13455,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 271001,
+        "type": "mixed",
+        "amount": 13298,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 272001,
+        "type": "mixed",
+        "amount": 13547,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 273001,
+        "type": "mixed",
+        "amount": 13749,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 274001,
+        "type": "mixed",
+        "amount": 13710,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 275001,
+        "type": "mixed",
+        "amount": 13718,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 276001,
+        "type": "mixed",
+        "amount": 13756,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 277001,
+        "type": "mixed",
+        "amount": 13681,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 278001,
+        "type": "mixed",
+        "amount": 13831,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 279001,
+        "type": "mixed",
+        "amount": 13801,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 280001,
+        "type": "mixed",
+        "amount": 13748,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 281001,
+        "type": "mixed",
+        "amount": 13833,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 282001,
+        "type": "mixed",
+        "amount": 13871,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 283001,
+        "type": "mixed",
+        "amount": 13991,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 284001,
+        "type": "mixed",
+        "amount": 14112,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 285001,
+        "type": "mixed",
+        "amount": 14019,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 286001,
+        "type": "mixed",
+        "amount": 14361,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 287001,
+        "type": "mixed",
+        "amount": 14400,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 288001,
+        "type": "mixed",
+        "amount": 14233,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 289001,
+        "type": "mixed",
+        "amount": 14273,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 290001,
+        "type": "mixed",
+        "amount": 14231,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 291001,
+        "type": "mixed",
+        "amount": 14294,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 292001,
+        "type": "mixed",
+        "amount": 14437,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 293001,
+        "type": "mixed",
+        "amount": 14452,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 294001,
+        "type": "mixed",
+        "amount": 14500,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 295001,
+        "type": "mixed",
+        "amount": 14573,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 296001,
+        "type": "mixed",
+        "amount": 14483,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 297001,
+        "type": "mixed",
+        "amount": 14644,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 298001,
+        "type": "mixed",
+        "amount": 14709,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 299001,
+        "type": "mixed",
+        "amount": 14787,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 300001,
+        "type": "mixed",
+        "amount": 14972,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 301001,
+        "type": "mixed",
+        "amount": 14684,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 302001,
+        "type": "mixed",
+        "amount": 14831,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 303001,
+        "type": "mixed",
+        "amount": 15162,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 304001,
+        "type": "mixed",
+        "amount": 15260,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 305001,
+        "type": "mixed",
+        "amount": 15310,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 306001,
+        "type": "mixed",
+        "amount": 15204,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 307001,
+        "type": "mixed",
+        "amount": 15320,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 308001,
+        "type": "mixed",
+        "amount": 15389,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 309001,
+        "type": "mixed",
+        "amount": 15482,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 310001,
+        "type": "mixed",
+        "amount": 15523,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 311001,
+        "type": "mixed",
+        "amount": 15570,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 312001,
+        "type": "mixed",
+        "amount": 16097,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 313001,
+        "type": "mixed",
+        "amount": 15961,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 314001,
+        "type": "mixed",
+        "amount": 15660,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 315001,
+        "type": "mixed",
+        "amount": 15752,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 316001,
+        "type": "mixed",
+        "amount": 15769,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 317001,
+        "type": "mixed",
+        "amount": 15826,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 318001,
+        "type": "mixed",
+        "amount": 16057,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 319001,
+        "type": "mixed",
+        "amount": 15890,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 320001,
+        "type": "mixed",
+        "amount": 16144,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 321001,
+        "type": "mixed",
+        "amount": 16085,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 322001,
+        "type": "mixed",
+        "amount": 16028,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 323001,
+        "type": "mixed",
+        "amount": 16329,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 324001,
+        "type": "mixed",
+        "amount": 16077,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 325001,
+        "type": "mixed",
+        "amount": 16235,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 326001,
+        "type": "mixed",
+        "amount": 16314,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 327001,
+        "type": "mixed",
+        "amount": 16516,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 328001,
+        "type": "mixed",
+        "amount": 16348,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 329001,
+        "type": "mixed",
+        "amount": 16546,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 330001,
+        "type": "mixed",
+        "amount": 16602,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 331001,
+        "type": "mixed",
+        "amount": 16765,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 332001,
+        "type": "mixed",
+        "amount": 16749,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 333001,
+        "type": "mixed",
+        "amount": 16683,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 334001,
+        "type": "mixed",
+        "amount": 16764,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 335001,
+        "type": "mixed",
+        "amount": 16542,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 336001,
+        "type": "mixed",
+        "amount": 17023,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 337001,
+        "type": "mixed",
+        "amount": 17050,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 338001,
+        "type": "mixed",
+        "amount": 17036,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 339001,
+        "type": "mixed",
+        "amount": 17043,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 340001,
+        "type": "mixed",
+        "amount": 17081,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 341001,
+        "type": "mixed",
+        "amount": 17127,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 342001,
+        "type": "mixed",
+        "amount": 16920,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 343001,
+        "type": "mixed",
+        "amount": 17218,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 344001,
+        "type": "mixed",
+        "amount": 17261,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 345001,
+        "type": "mixed",
+        "amount": 17233,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 346001,
+        "type": "mixed",
+        "amount": 17347,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 347001,
+        "type": "mixed",
+        "amount": 17292,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 348001,
+        "type": "mixed",
+        "amount": 17437,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 349001,
+        "type": "mixed",
+        "amount": 17283,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 350001,
+        "type": "mixed",
+        "amount": 17432,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 351001,
+        "type": "mixed",
+        "amount": 17255,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 352001,
+        "type": "mixed",
+        "amount": 17391,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 353001,
+        "type": "mixed",
+        "amount": 17597,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 354001,
+        "type": "mixed",
+        "amount": 17522,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 355001,
+        "type": "mixed",
+        "amount": 17662,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 356001,
+        "type": "mixed",
+        "amount": 17680,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 357001,
+        "type": "mixed",
+        "amount": 17937,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 358001,
+        "type": "mixed",
+        "amount": 18204,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 359001,
+        "type": "mixed",
+        "amount": 18069,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 360001,
+        "type": "mixed",
+        "amount": 17918,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 361001,
+        "type": "mixed",
+        "amount": 17973,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 362001,
+        "type": "mixed",
+        "amount": 17916,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 363001,
+        "type": "mixed",
+        "amount": 18109,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 364001,
+        "type": "mixed",
+        "amount": 18234,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 365001,
+        "type": "mixed",
+        "amount": 18316,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 366001,
+        "type": "mixed",
+        "amount": 18252,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 367001,
+        "type": "mixed",
+        "amount": 18276,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 368001,
+        "type": "mixed",
+        "amount": 18433,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 369001,
+        "type": "mixed",
+        "amount": 18669,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 370001,
+        "type": "mixed",
+        "amount": 18675,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 371001,
+        "type": "mixed",
+        "amount": 18612,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 372001,
+        "type": "mixed",
+        "amount": 18888,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 373001,
+        "type": "mixed",
+        "amount": 18641,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 374001,
+        "type": "mixed",
+        "amount": 18857,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 375001,
+        "type": "mixed",
+        "amount": 18726,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 376001,
+        "type": "mixed",
+        "amount": 18833,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 377001,
+        "type": "mixed",
+        "amount": 18722,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 378001,
+        "type": "mixed",
+        "amount": 18980,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 379001,
+        "type": "mixed",
+        "amount": 18814,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 380001,
+        "type": "mixed",
+        "amount": 19067,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 381001,
+        "type": "mixed",
+        "amount": 18799,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 382001,
+        "type": "mixed",
+        "amount": 19002,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 383001,
+        "type": "mixed",
+        "amount": 18936,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 384001,
+        "type": "mixed",
+        "amount": 19220,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 385001,
+        "type": "mixed",
+        "amount": 19111,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 386001,
+        "type": "mixed",
+        "amount": 19378,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 387001,
+        "type": "mixed",
+        "amount": 19232,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 388001,
+        "type": "mixed",
+        "amount": 19454,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 389001,
+        "type": "mixed",
+        "amount": 19308,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 390001,
+        "type": "mixed",
+        "amount": 19400,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 391001,
+        "type": "mixed",
+        "amount": 19355,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 392001,
+        "type": "mixed",
+        "amount": 19469,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 393001,
+        "type": "mixed",
+        "amount": 19523,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 394001,
+        "type": "mixed",
+        "amount": 19695,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 395001,
+        "type": "mixed",
+        "amount": 19619,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 396001,
+        "type": "mixed",
+        "amount": 19652,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 397001,
+        "type": "mixed",
+        "amount": 19756,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 398001,
+        "type": "mixed",
+        "amount": 19989,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 399001,
+        "type": "mixed",
+        "amount": 19756,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 400001,
+        "type": "mixed",
+        "amount": 20163,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 401001,
+        "type": "mixed",
+        "amount": 19736,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 402001,
+        "type": "mixed",
+        "amount": 20162,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 403001,
+        "type": "mixed",
+        "amount": 19969,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 404001,
+        "type": "mixed",
+        "amount": 20054,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 405001,
+        "type": "mixed",
+        "amount": 20126,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 406001,
+        "type": "mixed",
+        "amount": 20186,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 407001,
+        "type": "mixed",
+        "amount": 20200,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 408001,
+        "type": "mixed",
+        "amount": 20214,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 409001,
+        "type": "mixed",
+        "amount": 20188,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 410001,
+        "type": "mixed",
+        "amount": 20432,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 411001,
+        "type": "mixed",
+        "amount": 20630,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 412001,
+        "type": "mixed",
+        "amount": 20651,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 413001,
+        "type": "mixed",
+        "amount": 20592,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 414001,
+        "type": "mixed",
+        "amount": 20738,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 415001,
+        "type": "mixed",
+        "amount": 20775,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 416001,
+        "type": "mixed",
+        "amount": 20732,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 417001,
+        "type": "mixed",
+        "amount": 20758,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 418001,
+        "type": "mixed",
+        "amount": 20851,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 419001,
+        "type": "mixed",
+        "amount": 21146,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 420001,
+        "type": "mixed",
+        "amount": 20835,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 421001,
+        "type": "mixed",
+        "amount": 21010,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 422001,
+        "type": "mixed",
+        "amount": 20970,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 423001,
+        "type": "mixed",
+        "amount": 21023,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 424001,
+        "type": "mixed",
+        "amount": 21014,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 425001,
+        "type": "mixed",
+        "amount": 21290,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 426001,
+        "type": "mixed",
+        "amount": 21062,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 427001,
+        "type": "mixed",
+        "amount": 21639,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 428001,
+        "type": "mixed",
+        "amount": 21288,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 429001,
+        "type": "mixed",
+        "amount": 21359,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 430001,
+        "type": "mixed",
+        "amount": 21364,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 431001,
+        "type": "mixed",
+        "amount": 21392,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 432001,
+        "type": "mixed",
+        "amount": 21419,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 433001,
+        "type": "mixed",
+        "amount": 21482,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 434001,
+        "type": "mixed",
+        "amount": 21616,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 435001,
+        "type": "mixed",
+        "amount": 21419,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 436001,
+        "type": "mixed",
+        "amount": 21714,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 437001,
+        "type": "mixed",
+        "amount": 21927,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 438001,
+        "type": "mixed",
+        "amount": 21798,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 439001,
+        "type": "mixed",
+        "amount": 21696,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 440001,
+        "type": "mixed",
+        "amount": 21790,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 441001,
+        "type": "mixed",
+        "amount": 21828,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 442001,
+        "type": "mixed",
+        "amount": 22124,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 443001,
+        "type": "mixed",
+        "amount": 22099,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 444001,
+        "type": "mixed",
+        "amount": 22066,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 445001,
+        "type": "mixed",
+        "amount": 22012,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 446001,
+        "type": "mixed",
+        "amount": 22037,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 447001,
+        "type": "mixed",
+        "amount": 22204,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 448001,
+        "type": "mixed",
+        "amount": 22176,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 449001,
+        "type": "mixed",
+        "amount": 22188,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 450001,
+        "type": "mixed",
+        "amount": 22367,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 451001,
+        "type": "mixed",
+        "amount": 22632,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 452001,
+        "type": "mixed",
+        "amount": 22462,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 453001,
+        "type": "mixed",
+        "amount": 22321,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 454001,
+        "type": "mixed",
+        "amount": 22718,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 455001,
+        "type": "mixed",
+        "amount": 22915,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 456001,
+        "type": "mixed",
+        "amount": 22656,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 457001,
+        "type": "mixed",
+        "amount": 22715,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 458001,
+        "type": "mixed",
+        "amount": 22659,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 459001,
+        "type": "mixed",
+        "amount": 23032,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 460001,
+        "type": "mixed",
+        "amount": 22923,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 461001,
+        "type": "mixed",
+        "amount": 23092,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 462001,
+        "type": "mixed",
+        "amount": 22977,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 463001,
+        "type": "mixed",
+        "amount": 23017,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 464001,
+        "type": "mixed",
+        "amount": 23414,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 465001,
+        "type": "mixed",
+        "amount": 23203,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 466001,
+        "type": "mixed",
+        "amount": 23184,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 467001,
+        "type": "mixed",
+        "amount": 23227,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 468001,
+        "type": "mixed",
+        "amount": 23414,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 469001,
+        "type": "mixed",
+        "amount": 23506,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 470001,
+        "type": "mixed",
+        "amount": 23401,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 471001,
+        "type": "mixed",
+        "amount": 23526,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 472001,
+        "type": "mixed",
+        "amount": 23932,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 473001,
+        "type": "mixed",
+        "amount": 23539,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 474001,
+        "type": "mixed",
+        "amount": 23865,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 475001,
+        "type": "mixed",
+        "amount": 23756,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 476001,
+        "type": "mixed",
+        "amount": 23771,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 477001,
+        "type": "mixed",
+        "amount": 23764,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 478001,
+        "type": "mixed",
+        "amount": 23862,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 479001,
+        "type": "mixed",
+        "amount": 24087,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 480001,
+        "type": "mixed",
+        "amount": 24267,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 481001,
+        "type": "mixed",
+        "amount": 24333,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 482001,
+        "type": "mixed",
+        "amount": 24254,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 483001,
+        "type": "mixed",
+        "amount": 24319,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 484001,
+        "type": "mixed",
+        "amount": 24500,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 485001,
+        "type": "mixed",
+        "amount": 24479,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 486001,
+        "type": "mixed",
+        "amount": 24377,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 487001,
+        "type": "mixed",
+        "amount": 24507,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 488001,
+        "type": "mixed",
+        "amount": 24747,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 489001,
+        "type": "mixed",
+        "amount": 24657,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 490001,
+        "type": "mixed",
+        "amount": 24868,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 491001,
+        "type": "mixed",
+        "amount": 24613,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 492001,
+        "type": "mixed",
+        "amount": 24767,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 493001,
+        "type": "mixed",
+        "amount": 24713,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 494001,
+        "type": "mixed",
+        "amount": 24896,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 495001,
+        "type": "mixed",
+        "amount": 24744,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 496001,
+        "type": "mixed",
+        "amount": 24876,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 497001,
+        "type": "mixed",
+        "amount": 24929,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 498001,
+        "type": "mixed",
+        "amount": 25008,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 499001,
+        "type": "mixed",
+        "amount": 24949,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 500001,
+        "type": "mixed",
+        "amount": 25227,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 501001,
+        "type": "mixed",
+        "amount": 25253,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 502001,
+        "type": "mixed",
+        "amount": 25069,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 503001,
+        "type": "mixed",
+        "amount": 25313,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 504001,
+        "type": "mixed",
+        "amount": 25504,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 505001,
+        "type": "mixed",
+        "amount": 25264,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 506001,
+        "type": "mixed",
+        "amount": 25478,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 507001,
+        "type": "mixed",
+        "amount": 25431,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 508001,
+        "type": "mixed",
+        "amount": 25379,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 509001,
+        "type": "mixed",
+        "amount": 25647,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 510001,
+        "type": "mixed",
+        "amount": 25478,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 511001,
+        "type": "mixed",
+        "amount": 25509,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 512001,
+        "type": "mixed",
+        "amount": 25816,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 513001,
+        "type": "mixed",
+        "amount": 25685,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 514001,
+        "type": "mixed",
+        "amount": 25678,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 515001,
+        "type": "mixed",
+        "amount": 25794,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 516001,
+        "type": "mixed",
+        "amount": 25718,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 517001,
+        "type": "mixed",
+        "amount": 25777,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 518001,
+        "type": "mixed",
+        "amount": 26089,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 519001,
+        "type": "mixed",
+        "amount": 26131,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 520001,
+        "type": "mixed",
+        "amount": 25829,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 521001,
+        "type": "mixed",
+        "amount": 26267,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 522001,
+        "type": "mixed",
+        "amount": 25915,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 523001,
+        "type": "mixed",
+        "amount": 26055,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 524001,
+        "type": "mixed",
+        "amount": 26060,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 525001,
+        "type": "mixed",
+        "amount": 26087,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 526001,
+        "type": "mixed",
+        "amount": 26260,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 527001,
+        "type": "mixed",
+        "amount": 26328,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 528001,
+        "type": "mixed",
+        "amount": 26473,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 529001,
+        "type": "mixed",
+        "amount": 26314,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 530001,
+        "type": "mixed",
+        "amount": 26622,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 531001,
+        "type": "mixed",
+        "amount": 26463,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 532001,
+        "type": "mixed",
+        "amount": 26526,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 533001,
+        "type": "mixed",
+        "amount": 26755,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 534001,
+        "type": "mixed",
+        "amount": 26853,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 535001,
+        "type": "mixed",
+        "amount": 26573,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 536001,
+        "type": "mixed",
+        "amount": 26885,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 537001,
+        "type": "mixed",
+        "amount": 26809,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 538001,
+        "type": "mixed",
+        "amount": 26686,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 539001,
+        "type": "mixed",
+        "amount": 26907,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 540001,
+        "type": "mixed",
+        "amount": 26955,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 541001,
+        "type": "mixed",
+        "amount": 26836,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 542001,
+        "type": "mixed",
+        "amount": 27078,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 543001,
+        "type": "mixed",
+        "amount": 27109,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 544001,
+        "type": "mixed",
+        "amount": 26865,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 545001,
+        "type": "mixed",
+        "amount": 27335,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 546001,
+        "type": "mixed",
+        "amount": 27171,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 547001,
+        "type": "mixed",
+        "amount": 27046,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 548001,
+        "type": "mixed",
+        "amount": 27612,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 549001,
+        "type": "mixed",
+        "amount": 27451,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 550001,
+        "type": "mixed",
+        "amount": 27776,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 551001,
+        "type": "mixed",
+        "amount": 27532,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 552001,
+        "type": "mixed",
+        "amount": 27388,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 553001,
+        "type": "mixed",
+        "amount": 27449,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 554001,
+        "type": "mixed",
+        "amount": 27731,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 555001,
+        "type": "mixed",
+        "amount": 27668,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 556001,
+        "type": "mixed",
+        "amount": 27806,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 557001,
+        "type": "mixed",
+        "amount": 27755,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 558001,
+        "type": "mixed",
+        "amount": 27673,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 559001,
+        "type": "mixed",
+        "amount": 27965,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 560001,
+        "type": "mixed",
+        "amount": 27878,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 561001,
+        "type": "mixed",
+        "amount": 27876,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 562001,
+        "type": "mixed",
+        "amount": 28096,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 563001,
+        "type": "mixed",
+        "amount": 28305,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 564001,
+        "type": "mixed",
+        "amount": 28081,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 565001,
+        "type": "mixed",
+        "amount": 28264,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 566001,
+        "type": "mixed",
+        "amount": 28136,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 567001,
+        "type": "mixed",
+        "amount": 28409,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 568001,
+        "type": "mixed",
+        "amount": 28282,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 569001,
+        "type": "mixed",
+        "amount": 28292,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 570001,
+        "type": "mixed",
+        "amount": 28626,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 571001,
+        "type": "mixed",
+        "amount": 28787,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 572001,
+        "type": "mixed",
+        "amount": 28703,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 573001,
+        "type": "mixed",
+        "amount": 28867,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 574001,
+        "type": "mixed",
+        "amount": 28834,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 575001,
+        "type": "mixed",
+        "amount": 28803,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 576001,
+        "type": "mixed",
+        "amount": 29205,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 577001,
+        "type": "mixed",
+        "amount": 29154,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 578001,
+        "type": "mixed",
+        "amount": 28929,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 579001,
+        "type": "mixed",
+        "amount": 29003,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 580001,
+        "type": "mixed",
+        "amount": 29020,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 581001,
+        "type": "mixed",
+        "amount": 29241,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 582001,
+        "type": "mixed",
+        "amount": 29065,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 583001,
+        "type": "mixed",
+        "amount": 29157,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 584001,
+        "type": "mixed",
+        "amount": 29009,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 585001,
+        "type": "mixed",
+        "amount": 29027,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 586001,
+        "type": "mixed",
+        "amount": 29164,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 587001,
+        "type": "mixed",
+        "amount": 29238,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 588001,
+        "type": "mixed",
+        "amount": 28926,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 589001,
+        "type": "mixed",
+        "amount": 29264,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 590001,
+        "type": "mixed",
+        "amount": 29502,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 591001,
+        "type": "mixed",
+        "amount": 29412,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 592001,
+        "type": "mixed",
+        "amount": 29523,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 593001,
+        "type": "mixed",
+        "amount": 29550,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 594001,
+        "type": "mixed",
+        "amount": 29652,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 595001,
+        "type": "mixed",
+        "amount": 29514,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 596001,
+        "type": "mixed",
+        "amount": 29465,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 597001,
+        "type": "mixed",
+        "amount": 29984,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 598001,
+        "type": "mixed",
+        "amount": 29747,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 599001,
+        "type": "mixed",
+        "amount": 29982,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 600001,
+        "type": "mixed",
+        "amount": 29957,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 601001,
+        "type": "mixed",
+        "amount": 29897,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 602001,
+        "type": "mixed",
+        "amount": 30169,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 603001,
+        "type": "mixed",
+        "amount": 30043,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 604001,
+        "type": "mixed",
+        "amount": 30178,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 605001,
+        "type": "mixed",
+        "amount": 30087,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 606001,
+        "type": "mixed",
+        "amount": 30027,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 607001,
+        "type": "mixed",
+        "amount": 30267,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 608001,
+        "type": "mixed",
+        "amount": 30340,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 609001,
+        "type": "mixed",
+        "amount": 30529,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 610001,
+        "type": "mixed",
+        "amount": 30350,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 611001,
+        "type": "mixed",
+        "amount": 30569,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 612001,
+        "type": "mixed",
+        "amount": 30333,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 613001,
+        "type": "mixed",
+        "amount": 30409,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 614001,
+        "type": "mixed",
+        "amount": 30446,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 615001,
+        "type": "mixed",
+        "amount": 30731,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 616001,
+        "type": "mixed",
+        "amount": 30572,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 617001,
+        "type": "mixed",
+        "amount": 30857,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 618001,
+        "type": "mixed",
+        "amount": 31085,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 619001,
+        "type": "mixed",
+        "amount": 30582,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 620001,
+        "type": "mixed",
+        "amount": 30958,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 621001,
+        "type": "mixed",
+        "amount": 30786,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 622001,
+        "type": "mixed",
+        "amount": 31024,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 623001,
+        "type": "mixed",
+        "amount": 31447,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 624001,
+        "type": "mixed",
+        "amount": 31191,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 625001,
+        "type": "mixed",
+        "amount": 31393,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 626001,
+        "type": "mixed",
+        "amount": 31389,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 627001,
+        "type": "mixed",
+        "amount": 31396,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 628001,
+        "type": "mixed",
+        "amount": 31831,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 629001,
+        "type": "mixed",
+        "amount": 31529,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 630001,
+        "type": "mixed",
+        "amount": 31534,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 631001,
+        "type": "mixed",
+        "amount": 31589,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 632001,
+        "type": "mixed",
+        "amount": 31873,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 633001,
+        "type": "mixed",
+        "amount": 31532,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 634001,
+        "type": "mixed",
+        "amount": 31577,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 635001,
+        "type": "mixed",
+        "amount": 31674,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 636001,
+        "type": "mixed",
+        "amount": 31803,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 637001,
+        "type": "mixed",
+        "amount": 32009,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 638001,
+        "type": "mixed",
+        "amount": 31739,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 639001,
+        "type": "mixed",
+        "amount": 32050,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 640001,
+        "type": "mixed",
+        "amount": 32504,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 641001,
+        "type": "mixed",
+        "amount": 31865,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 642001,
+        "type": "mixed",
+        "amount": 32076,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 643001,
+        "type": "mixed",
+        "amount": 31864,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 644001,
+        "type": "mixed",
+        "amount": 32171,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 645001,
+        "type": "mixed",
+        "amount": 32072,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 646001,
+        "type": "mixed",
+        "amount": 32123,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 647001,
+        "type": "mixed",
+        "amount": 32250,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 648001,
+        "type": "mixed",
+        "amount": 32367,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 649001,
+        "type": "mixed",
+        "amount": 32594,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 650001,
+        "type": "mixed",
+        "amount": 32319,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 651001,
+        "type": "mixed",
+        "amount": 32476,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 652001,
+        "type": "mixed",
+        "amount": 32929,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 653001,
+        "type": "mixed",
+        "amount": 32374,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 654001,
+        "type": "mixed",
+        "amount": 32739,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 655001,
+        "type": "mixed",
+        "amount": 32524,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 656001,
+        "type": "mixed",
+        "amount": 32842,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 657001,
+        "type": "mixed",
+        "amount": 32759,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 658001,
+        "type": "mixed",
+        "amount": 32841,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 659001,
+        "type": "mixed",
+        "amount": 32880,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 660001,
+        "type": "mixed",
+        "amount": 32732,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 661001,
+        "type": "mixed",
+        "amount": 33053,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 662001,
+        "type": "mixed",
+        "amount": 32961,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 663001,
+        "type": "mixed",
+        "amount": 33078,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 664001,
+        "type": "mixed",
+        "amount": 33167,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 665001,
+        "type": "mixed",
+        "amount": 33205,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 666001,
+        "type": "mixed",
+        "amount": 33432,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 667001,
+        "type": "mixed",
+        "amount": 33014,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 668001,
+        "type": "mixed",
+        "amount": 33335,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 669001,
+        "type": "mixed",
+        "amount": 33120,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 670001,
+        "type": "mixed",
+        "amount": 33551,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 671001,
+        "type": "mixed",
+        "amount": 33342,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 672001,
+        "type": "mixed",
+        "amount": 33628,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 673001,
+        "type": "mixed",
+        "amount": 33704,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 674001,
+        "type": "mixed",
+        "amount": 33573,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 675001,
+        "type": "mixed",
+        "amount": 33841,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 676001,
+        "type": "mixed",
+        "amount": 33742,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 677001,
+        "type": "mixed",
+        "amount": 33669,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 678001,
+        "type": "mixed",
+        "amount": 33660,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 679001,
+        "type": "mixed",
+        "amount": 33637,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 680001,
+        "type": "mixed",
+        "amount": 33796,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 681001,
+        "type": "mixed",
+        "amount": 33908,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 682001,
+        "type": "mixed",
+        "amount": 33980,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 683001,
+        "type": "mixed",
+        "amount": 33931,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 684001,
+        "type": "mixed",
+        "amount": 33954,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 685001,
+        "type": "mixed",
+        "amount": 33843,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 686001,
+        "type": "mixed",
+        "amount": 34570,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 687001,
+        "type": "mixed",
+        "amount": 34314,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 688001,
+        "type": "mixed",
+        "amount": 34354,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 689001,
+        "type": "mixed",
+        "amount": 34070,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 690001,
+        "type": "mixed",
+        "amount": 34314,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 691001,
+        "type": "mixed",
+        "amount": 34472,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 692001,
+        "type": "mixed",
+        "amount": 34087,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 693001,
+        "type": "mixed",
+        "amount": 34428,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 694001,
+        "type": "mixed",
+        "amount": 34122,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 695001,
+        "type": "mixed",
+        "amount": 34634,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 696001,
+        "type": "mixed",
+        "amount": 34489,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 697001,
+        "type": "mixed",
+        "amount": 34904,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 698001,
+        "type": "mixed",
+        "amount": 34710,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 699001,
+        "type": "mixed",
+        "amount": 34881,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 700001,
+        "type": "mixed",
+        "amount": 34697,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 701001,
+        "type": "mixed",
+        "amount": 34903,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 702001,
+        "type": "mixed",
+        "amount": 35205,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 703001,
+        "type": "mixed",
+        "amount": 34979,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 704001,
+        "type": "mixed",
+        "amount": 34906,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 705001,
+        "type": "mixed",
+        "amount": 34595,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 706001,
+        "type": "mixed",
+        "amount": 35139,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 707001,
+        "type": "mixed",
+        "amount": 34782,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 708001,
+        "type": "mixed",
+        "amount": 35399,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 709001,
+        "type": "mixed",
+        "amount": 34883,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 710001,
+        "type": "mixed",
+        "amount": 35141,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 711001,
+        "type": "mixed",
+        "amount": 35206,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 712001,
+        "type": "mixed",
+        "amount": 35248,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 713001,
+        "type": "mixed",
+        "amount": 35904,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 714001,
+        "type": "mixed",
+        "amount": 35209,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 715001,
+        "type": "mixed",
+        "amount": 35430,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 716001,
+        "type": "mixed",
+        "amount": 35386,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 717001,
+        "type": "mixed",
+        "amount": 35618,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 718001,
+        "type": "mixed",
+        "amount": 35183,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 719001,
+        "type": "mixed",
+        "amount": 36205,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 720001,
+        "type": "mixed",
+        "amount": 35526,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 721001,
+        "type": "mixed",
+        "amount": 35850,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 722001,
+        "type": "mixed",
+        "amount": 35682,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 723001,
+        "type": "mixed",
+        "amount": 35733,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 724001,
+        "type": "mixed",
+        "amount": 35742,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 725001,
+        "type": "mixed",
+        "amount": 36055,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 726001,
+        "type": "mixed",
+        "amount": 35932,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 727001,
+        "type": "mixed",
+        "amount": 36080,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 728001,
+        "type": "mixed",
+        "amount": 35925,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 729001,
+        "type": "mixed",
+        "amount": 36034,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 730001,
+        "type": "mixed",
+        "amount": 36179,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 731001,
+        "type": "mixed",
+        "amount": 36220,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 732001,
+        "type": "mixed",
+        "amount": 36167,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 733001,
+        "type": "mixed",
+        "amount": 36281,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 734001,
+        "type": "mixed",
+        "amount": 36207,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 735001,
+        "type": "mixed",
+        "amount": 36121,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 736001,
+        "type": "mixed",
+        "amount": 36382,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 737001,
+        "type": "mixed",
+        "amount": 36109,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 738001,
+        "type": "mixed",
+        "amount": 36386,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 739001,
+        "type": "mixed",
+        "amount": 36173,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 740001,
+        "type": "mixed",
+        "amount": 36991,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 741001,
+        "type": "mixed",
+        "amount": 36568,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 742001,
+        "type": "mixed",
+        "amount": 36608,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 743001,
+        "type": "mixed",
+        "amount": 36253,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 744001,
+        "type": "mixed",
+        "amount": 36684,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 745001,
+        "type": "mixed",
+        "amount": 36460,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 746001,
+        "type": "mixed",
+        "amount": 36821,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 747001,
+        "type": "mixed",
+        "amount": 36633,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 748001,
+        "type": "mixed",
+        "amount": 37007,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 749001,
+        "type": "mixed",
+        "amount": 36714,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 750001,
+        "type": "mixed",
+        "amount": 37113,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 751001,
+        "type": "mixed",
+        "amount": 36989,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 752001,
+        "type": "mixed",
+        "amount": 37060,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 753001,
+        "type": "mixed",
+        "amount": 37237,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 754001,
+        "type": "mixed",
+        "amount": 37127,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 755001,
+        "type": "mixed",
+        "amount": 37109,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 756001,
+        "type": "mixed",
+        "amount": 37213,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 757001,
+        "type": "mixed",
+        "amount": 37355,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 758001,
+        "type": "mixed",
+        "amount": 37379,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 759001,
+        "type": "mixed",
+        "amount": 37453,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 760001,
+        "type": "mixed",
+        "amount": 37647,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 761001,
+        "type": "mixed",
+        "amount": 37748,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 762001,
+        "type": "mixed",
+        "amount": 37535,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 763001,
+        "type": "mixed",
+        "amount": 37658,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 764001,
+        "type": "mixed",
+        "amount": 37607,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 765001,
+        "type": "mixed",
+        "amount": 37813,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 766001,
+        "type": "mixed",
+        "amount": 37792,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 767001,
+        "type": "mixed",
+        "amount": 37847,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 768001,
+        "type": "mixed",
+        "amount": 37896,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 769001,
+        "type": "mixed",
+        "amount": 37666,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 770001,
+        "type": "mixed",
+        "amount": 37789,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 771001,
+        "type": "mixed",
+        "amount": 37825,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 772001,
+        "type": "mixed",
+        "amount": 37978,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 773001,
+        "type": "mixed",
+        "amount": 37768,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 774001,
+        "type": "mixed",
+        "amount": 38187,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 775001,
+        "type": "mixed",
+        "amount": 37996,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 776001,
+        "type": "mixed",
+        "amount": 38258,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 777001,
+        "type": "mixed",
+        "amount": 38047,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 778001,
+        "type": "mixed",
+        "amount": 38369,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 779001,
+        "type": "mixed",
+        "amount": 38629,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 780001,
+        "type": "mixed",
+        "amount": 38981,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 781001,
+        "type": "mixed",
+        "amount": 38642,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 782001,
+        "type": "mixed",
+        "amount": 38371,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 783001,
+        "type": "mixed",
+        "amount": 38505,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 784001,
+        "type": "mixed",
+        "amount": 38553,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 785001,
+        "type": "mixed",
+        "amount": 38510,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 786001,
+        "type": "mixed",
+        "amount": 38557,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 787001,
+        "type": "mixed",
+        "amount": 38491,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 788001,
+        "type": "mixed",
+        "amount": 38960,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 789001,
+        "type": "mixed",
+        "amount": 38566,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 790001,
+        "type": "mixed",
+        "amount": 39518,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 791001,
+        "type": "mixed",
+        "amount": 38656,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 792001,
+        "type": "mixed",
+        "amount": 39017,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 793001,
+        "type": "mixed",
+        "amount": 38842,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 794001,
+        "type": "mixed",
+        "amount": 39210,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 795001,
+        "type": "mixed",
+        "amount": 38903,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 796001,
+        "type": "mixed",
+        "amount": 39431,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 797001,
+        "type": "mixed",
+        "amount": 39086,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 798001,
+        "type": "mixed",
+        "amount": 39232,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 799001,
+        "type": "mixed",
+        "amount": 39115,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 800001,
+        "type": "mixed",
+        "amount": 39508,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 801001,
+        "type": "mixed",
+        "amount": 39617,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 802001,
+        "type": "mixed",
+        "amount": 39390,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 803001,
+        "type": "mixed",
+        "amount": 39846,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 804001,
+        "type": "mixed",
+        "amount": 39459,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 805001,
+        "type": "mixed",
+        "amount": 39584,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 806001,
+        "type": "mixed",
+        "amount": 39848,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 807001,
+        "type": "mixed",
+        "amount": 39821,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 808001,
+        "type": "mixed",
+        "amount": 39607,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 809001,
+        "type": "mixed",
+        "amount": 40416,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 810001,
+        "type": "mixed",
+        "amount": 39628,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 811001,
+        "type": "mixed",
+        "amount": 40134,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 812001,
+        "type": "mixed",
+        "amount": 39798,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 813001,
+        "type": "mixed",
+        "amount": 40075,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 814001,
+        "type": "mixed",
+        "amount": 39910,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 815001,
+        "type": "mixed",
+        "amount": 40463,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 816001,
+        "type": "mixed",
+        "amount": 40322,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 817001,
+        "type": "mixed",
+        "amount": 40368,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 818001,
+        "type": "mixed",
+        "amount": 40925,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 819001,
+        "type": "mixed",
+        "amount": 40300,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 820001,
+        "type": "mixed",
+        "amount": 40497,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 821001,
+        "type": "mixed",
+        "amount": 40262,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 822001,
+        "type": "mixed",
+        "amount": 40571,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 823001,
+        "type": "mixed",
+        "amount": 40476,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 824001,
+        "type": "mixed",
+        "amount": 40767,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 825001,
+        "type": "mixed",
+        "amount": 40521,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 826001,
+        "type": "mixed",
+        "amount": 40642,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 827001,
+        "type": "mixed",
+        "amount": 40725,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 828001,
+        "type": "mixed",
+        "amount": 41103,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 829001,
+        "type": "mixed",
+        "amount": 40796,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 830001,
+        "type": "mixed",
+        "amount": 40732,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 831001,
+        "type": "mixed",
+        "amount": 41000,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 832001,
+        "type": "mixed",
+        "amount": 40885,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 833001,
+        "type": "mixed",
+        "amount": 41248,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 834001,
+        "type": "mixed",
+        "amount": 41036,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 835001,
+        "type": "mixed",
+        "amount": 40881,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 836001,
+        "type": "mixed",
+        "amount": 40911,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 837001,
+        "type": "mixed",
+        "amount": 41079,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 838001,
+        "type": "mixed",
+        "amount": 41362,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 839001,
+        "type": "mixed",
+        "amount": 41108,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 840001,
+        "type": "mixed",
+        "amount": 41302,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 841001,
+        "type": "mixed",
+        "amount": 41138,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 842001,
+        "type": "mixed",
+        "amount": 41474,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 843001,
+        "type": "mixed",
+        "amount": 42440,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 844001,
+        "type": "mixed",
+        "amount": 41451,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 845001,
+        "type": "mixed",
+        "amount": 41763,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 846001,
+        "type": "mixed",
+        "amount": 41675,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 847001,
+        "type": "mixed",
+        "amount": 41869,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 848001,
+        "type": "mixed",
+        "amount": 41903,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 849001,
+        "type": "mixed",
+        "amount": 42261,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 850001,
+        "type": "mixed",
+        "amount": 41766,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 851001,
+        "type": "mixed",
+        "amount": 42019,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 852001,
+        "type": "mixed",
+        "amount": 42030,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 853001,
+        "type": "mixed",
+        "amount": 41949,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 854001,
+        "type": "mixed",
+        "amount": 42449,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 855001,
+        "type": "mixed",
+        "amount": 42103,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 856001,
+        "type": "mixed",
+        "amount": 42320,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 857001,
+        "type": "mixed",
+        "amount": 42136,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 858001,
+        "type": "mixed",
+        "amount": 42293,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 859001,
+        "type": "mixed",
+        "amount": 42271,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 860001,
+        "type": "mixed",
+        "amount": 42172,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 861001,
+        "type": "mixed",
+        "amount": 42499,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 862001,
+        "type": "mixed",
+        "amount": 42102,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 863001,
+        "type": "mixed",
+        "amount": 42711,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 864001,
+        "type": "mixed",
+        "amount": 42329,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 865001,
+        "type": "mixed",
+        "amount": 42588,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 866001,
+        "type": "mixed",
+        "amount": 42964,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 867001,
+        "type": "mixed",
+        "amount": 42446,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 868001,
+        "type": "mixed",
+        "amount": 42919,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 869001,
+        "type": "mixed",
+        "amount": 42548,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 870001,
+        "type": "mixed",
+        "amount": 42951,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 871001,
+        "type": "mixed",
+        "amount": 42568,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 872001,
+        "type": "mixed",
+        "amount": 43186,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 873001,
+        "type": "mixed",
+        "amount": 42977,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 874001,
+        "type": "mixed",
+        "amount": 42643,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 875001,
+        "type": "mixed",
+        "amount": 43265,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 876001,
+        "type": "mixed",
+        "amount": 42987,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 877001,
+        "type": "mixed",
+        "amount": 43282,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 878001,
+        "type": "mixed",
+        "amount": 43230,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 879001,
+        "type": "mixed",
+        "amount": 43227,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 880001,
+        "type": "mixed",
+        "amount": 43625,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 881001,
+        "type": "mixed",
+        "amount": 43066,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 882001,
+        "type": "mixed",
+        "amount": 43595,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 883001,
+        "type": "mixed",
+        "amount": 43160,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 884001,
+        "type": "mixed",
+        "amount": 43103,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 885001,
+        "type": "mixed",
+        "amount": 43342,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 886001,
+        "type": "mixed",
+        "amount": 43397,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 887001,
+        "type": "mixed",
+        "amount": 43469,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 888001,
+        "type": "mixed",
+        "amount": 43284,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 889001,
+        "type": "mixed",
+        "amount": 43808,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 890001,
+        "type": "mixed",
+        "amount": 43748,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 891001,
+        "type": "mixed",
+        "amount": 43411,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 892001,
+        "type": "mixed",
+        "amount": 43825,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 893001,
+        "type": "mixed",
+        "amount": 43518,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 894001,
+        "type": "mixed",
+        "amount": 43683,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 895001,
+        "type": "mixed",
+        "amount": 43897,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 896001,
+        "type": "mixed",
+        "amount": 43617,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 897001,
+        "type": "mixed",
+        "amount": 44498,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 898001,
+        "type": "mixed",
+        "amount": 43812,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 899001,
+        "type": "mixed",
+        "amount": 43986,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 900001,
+        "type": "mixed",
+        "amount": 44004,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 901001,
+        "type": "mixed",
+        "amount": 43715,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 902001,
+        "type": "mixed",
+        "amount": 44130,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 903001,
+        "type": "mixed",
+        "amount": 44026,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 904001,
+        "type": "mixed",
+        "amount": 43868,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 905001,
+        "type": "mixed",
+        "amount": 44313,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 906001,
+        "type": "mixed",
+        "amount": 44187,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 907001,
+        "type": "mixed",
+        "amount": 44499,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 908001,
+        "type": "mixed",
+        "amount": 43974,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 909001,
+        "type": "mixed",
+        "amount": 44291,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 910001,
+        "type": "mixed",
+        "amount": 44412,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 911001,
+        "type": "mixed",
+        "amount": 44185,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 912001,
+        "type": "mixed",
+        "amount": 44457,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 913001,
+        "type": "mixed",
+        "amount": 44339,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 914001,
+        "type": "mixed",
+        "amount": 44478,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 915001,
+        "type": "mixed",
+        "amount": 44634,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 916001,
+        "type": "mixed",
+        "amount": 44261,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 917001,
+        "type": "mixed",
+        "amount": 44668,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 918001,
+        "type": "mixed",
+        "amount": 45243,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 919001,
+        "type": "mixed",
+        "amount": 47896,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 920001,
+        "type": "mixed",
+        "amount": 45286,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 921001,
+        "type": "mixed",
+        "amount": 45042,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 922001,
+        "type": "mixed",
+        "amount": 44736,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 923001,
+        "type": "mixed",
+        "amount": 44796,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 924001,
+        "type": "mixed",
+        "amount": 44707,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 925001,
+        "type": "mixed",
+        "amount": 44692,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 926001,
+        "type": "mixed",
+        "amount": 44691,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 927001,
+        "type": "mixed",
+        "amount": 45121,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 928001,
+        "type": "mixed",
+        "amount": 45521,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 929001,
+        "type": "mixed",
+        "amount": 45178,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 930001,
+        "type": "mixed",
+        "amount": 45377,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 931001,
+        "type": "mixed",
+        "amount": 45248,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 932001,
+        "type": "mixed",
+        "amount": 45324,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 933001,
+        "type": "mixed",
+        "amount": 45359,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 934001,
+        "type": "mixed",
+        "amount": 45423,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 935001,
+        "type": "mixed",
+        "amount": 45387,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 936001,
+        "type": "mixed",
+        "amount": 45538,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 937001,
+        "type": "mixed",
+        "amount": 45307,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 938001,
+        "type": "mixed",
+        "amount": 45845,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 939001,
+        "type": "mixed",
+        "amount": 45784,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 940001,
+        "type": "mixed",
+        "amount": 45554,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 941001,
+        "type": "mixed",
+        "amount": 45797,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 942001,
+        "type": "mixed",
+        "amount": 45738,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 943001,
+        "type": "mixed",
+        "amount": 45632,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 944001,
+        "type": "mixed",
+        "amount": 45964,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 945001,
+        "type": "mixed",
+        "amount": 45644,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 946001,
+        "type": "mixed",
+        "amount": 45731,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 947001,
+        "type": "mixed",
+        "amount": 46040,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 948001,
+        "type": "mixed",
+        "amount": 46048,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 949001,
+        "type": "mixed",
+        "amount": 46154,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 950001,
+        "type": "mixed",
+        "amount": 46199,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 951001,
+        "type": "mixed",
+        "amount": 46312,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 952001,
+        "type": "mixed",
+        "amount": 46303,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 953001,
+        "type": "mixed",
+        "amount": 46471,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 954001,
+        "type": "mixed",
+        "amount": 46431,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 955001,
+        "type": "mixed",
+        "amount": 46785,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 956001,
+        "type": "mixed",
+        "amount": 46754,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 957001,
+        "type": "mixed",
+        "amount": 46608,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 958001,
+        "type": "mixed",
+        "amount": 47035,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 959001,
+        "type": "mixed",
+        "amount": 46686,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 960001,
+        "type": "mixed",
+        "amount": 46860,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 961001,
+        "type": "mixed",
+        "amount": 47267,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 962001,
+        "type": "mixed",
+        "amount": 46830,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 963001,
+        "type": "mixed",
+        "amount": 47041,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 964001,
+        "type": "mixed",
+        "amount": 47129,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 965001,
+        "type": "mixed",
+        "amount": 46974,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 966001,
+        "type": "mixed",
+        "amount": 47467,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 967001,
+        "type": "mixed",
+        "amount": 47222,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 968001,
+        "type": "mixed",
+        "amount": 47190,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 969001,
+        "type": "mixed",
+        "amount": 47599,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 970001,
+        "type": "mixed",
+        "amount": 47390,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 971001,
+        "type": "mixed",
+        "amount": 47269,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 972001,
+        "type": "mixed",
+        "amount": 47495,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 973001,
+        "type": "mixed",
+        "amount": 47678,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 974001,
+        "type": "mixed",
+        "amount": 47626,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 975001,
+        "type": "mixed",
+        "amount": 47784,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 976001,
+        "type": "mixed",
+        "amount": 47831,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 977001,
+        "type": "mixed",
+        "amount": 47803,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 978001,
+        "type": "mixed",
+        "amount": 48161,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 979001,
+        "type": "mixed",
+        "amount": 48127,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 980001,
+        "type": "mixed",
+        "amount": 48054,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 981001,
+        "type": "mixed",
+        "amount": 48126,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 982001,
+        "type": "mixed",
+        "amount": 48369,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 983001,
+        "type": "mixed",
+        "amount": 48063,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 984001,
+        "type": "mixed",
+        "amount": 48726,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 985001,
+        "type": "mixed",
+        "amount": 48536,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 986001,
+        "type": "mixed",
+        "amount": 48290,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 987001,
+        "type": "mixed",
+        "amount": 48650,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 988001,
+        "type": "mixed",
+        "amount": 48743,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 989001,
+        "type": "mixed",
+        "amount": 48330,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 990001,
+        "type": "mixed",
+        "amount": 48670,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 991001,
+        "type": "mixed",
+        "amount": 49445,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 992001,
+        "type": "mixed",
+        "amount": 48766,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 993001,
+        "type": "mixed",
+        "amount": 48863,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 994001,
+        "type": "mixed",
+        "amount": 48865,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 995001,
+        "type": "mixed",
+        "amount": 48524,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 996001,
+        "type": "mixed",
+        "amount": 48801,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 997001,
+        "type": "mixed",
+        "amount": 49056,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 998001,
+        "type": "mixed",
+        "amount": 49024,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 999001,
+        "type": "mixed",
+        "amount": 49024,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      },
+      {
+        "structure-unit-size": 1000000,
+        "type": "mixed",
+        "amount": 49302,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "subtype": "time delta"
+      }
+    ],
+    "models": [
+      {
+        "r_square": 0.0,
+        "method": "full",
+        "model": "constant",
+        "coeffs": [
+          {
+            "name": "b0",
+            "value": 24745.756243756245
+          },
+          {
+            "name": "b1",
+            "value": 0.0
+          }
+        ],
+        "x_interval_end": 1000000,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "x_interval_start": 1
+      },
+      {
+        "r_square": 0.7966921409207554,
+        "method": "full",
+        "model": "exponential",
+        "coeffs": [
+          {
+            "name": "b0",
+            "value": 4378.563459396814
+          },
+          {
+            "name": "b1",
+            "value": 1.0000028865370754
+          }
+        ],
+        "x_interval_end": 1000000,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "x_interval_start": 1
+      },
+      {
+        "r_square": 0.9995002079669725,
+        "method": "full",
+        "model": "linear",
+        "coeffs": [
+          {
+            "name": "b0",
+            "value": 238.58887318973535
+          },
+          {
+            "name": "b1",
+            "value": 0.04901423681058994
+          }
+        ],
+        "x_interval_end": 1000000,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "x_interval_start": 1
+      },
+      {
+        "r_square": 0.6865137664881328,
+        "method": "full",
+        "model": "logarithmic",
+        "coeffs": [
+          {
+            "name": "b0",
+            "value": -116475.45893247022
+          },
+          {
+            "name": "b1",
+            "value": 11026.804911263713
+          }
+        ],
+        "x_interval_end": 1000000,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "x_interval_start": 1
+      },
+      {
+        "r_square": 0.9602803912407135,
+        "method": "full",
+        "model": "power",
+        "coeffs": [
+          {
+            "name": "b0",
+            "value": 0.3043596984029334
+          },
+          {
+            "name": "b1",
+            "value": 0.8602497252317243
+          }
+        ],
+        "x_interval_end": 1000000,
+        "uid": "skiplistSearch(skiplist*, int)",
+        "x_interval_start": 1
+      },
+      {
+        "model": "quadratic",
+        "x_interval_start": 1,
+        "x_interval_end": 1000000,
+        "method": "full",
+        "r_square": 0.817765837402249,
+        "coeffs": [
+          {
+            "name": "b0",
+            "value": -1655.374071976648
+          },
+          {
+            "name": "b1",
+            "value": 0.09124812715569887
+          },
+          {
+            "name": "b2",
+            "value": -5.764408927477766e-08
+          }
+        ],
+        "uid": "skiplistSearch(skiplist*, int)"
+      }
+    ],
+    "time": "18.484409s"
+  }
+}

--- a/tests/tmp_files/list1.ref
+++ b/tests/tmp_files/list1.ref
@@ -1,0 +1,5 @@
+Total size of all temporary files: [32m 436.1 KiB[0m
+[32m 185.9 KiB[0m[31m | [0m[31mprotected[0m  [31m | [0m[32mdegradations/results/[0mdata.out
+[32m 199.0 KiB[0m[31m | [0munprotected[31m | [0m[32mdegradations/results/[0mdata2.out
+[32m  51.1 KiB[0m[31m | [0munprotected[31m | [0m[32mtrace/data/[0mrecords.data
+[32m    19 B  [0m[31m | [0m[31mprotected[0m  [31m | [0m[32mtrace/[0mlock.txt

--- a/tests/tmp_files/list2.ref
+++ b/tests/tmp_files/list2.ref
@@ -1,0 +1,5 @@
+Total size of all temporary files:  436.1 KiB
+degradations/results/data.out
+degradations/results/data2.out
+trace/data/records.data
+trace/lock.txt

--- a/tests/tmp_files/list3.ref
+++ b/tests/tmp_files/list3.ref
@@ -1,0 +1,5 @@
+Total size of all temporary files:  436.1 KiB
+ 199.0 KiB | unprotected | degradations/results/data2.out
+ 185.9 KiB | protected   | degradations/results/data.out
+  51.1 KiB | unprotected | trace/data/records.data
+    19 B   | protected   | trace/lock.txt

--- a/tests/tmp_files/list4.ref
+++ b/tests/tmp_files/list4.ref
@@ -1,0 +1,5 @@
+Total size of all temporary files:  436.1 KiB
+ 185.9 KiB | protected   | degradations/results/data.out
+    19 B   | protected   | trace/lock.txt
+ 199.0 KiB | unprotected | degradations/results/data2.out
+  51.1 KiB | unprotected | trace/data/records.data

--- a/tests/tmp_files/list5.ref
+++ b/tests/tmp_files/list5.ref
@@ -1,0 +1,3 @@
+Total size of all temporary files:  185.9 KiB
+ 185.9 KiB | protected   | degradations/results/data.out
+    19 B   | protected   | trace/lock.txt

--- a/tests/tmp_files/list6.ref
+++ b/tests/tmp_files/list6.ref
@@ -1,0 +1,3 @@
+Total size of all temporary files:  250.1 KiB
+ 199.0 KiB | unprotected | degradations/results/data2.out
+  51.1 KiB | unprotected | trace/data/records.data

--- a/tests/tmp_files/tst_stap_record.txt
+++ b/tests/tmp_files/tst_stap_record.txt
@@ -1,0 +1,1454 @@
+begin /home/jirka/perun/experiments/quicksort
+0      0 quicksort(14060):main
+3      8 quicksort(14060):BEFORE_CYCLE
+2     15 quicksort(14060): INSIDE_CYCLE
+0     32 quicksort(14060): _Z12QuickSortBadPii
+0     48 quicksort(14060):  _Z12BadPartitionPiii
+0     63 quicksort(14060):   _Z4SwapRiS_
+1     73 quicksort(14060):   
+1     79 quicksort(14060):  
+0     90 quicksort(14060):  _Z12BadPartitionPiii
+0    105 quicksort(14060):   _Z4SwapRiS_
+1    115 quicksort(14060):   
+0    125 quicksort(14060):   _Z4SwapRiS_
+1    134 quicksort(14060):   
+0    146 quicksort(14060):   _Z4SwapRiS_
+1    154 quicksort(14060):   
+0    165 quicksort(14060):   _Z4SwapRiS_
+1    174 quicksort(14060):   
+1    179 quicksort(14060):  
+0    190 quicksort(14060):  _Z12BadPartitionPiii
+0    204 quicksort(14060):   _Z4SwapRiS_
+1    213 quicksort(14060):   
+1    218 quicksort(14060):  
+0    229 quicksort(14060):  _Z12BadPartitionPiii
+0    244 quicksort(14060):   _Z4SwapRiS_
+1    252 quicksort(14060):   
+0    264 quicksort(14060):   _Z4SwapRiS_
+1    272 quicksort(14060):   
+1    277 quicksort(14060):  
+1    287 quicksort(14060): 
+2    293 quicksort(14060): INSIDE_CYCLE
+0    305 quicksort(14060): _Z12QuickSortBadPii
+0    320 quicksort(14060):  _Z12BadPartitionPiii
+0    334 quicksort(14060):   _Z4SwapRiS_
+1    342 quicksort(14060):   
+1    347 quicksort(14060):  
+0    358 quicksort(14060):  _Z12BadPartitionPiii
+0    396 quicksort(14060):   _Z4SwapRiS_
+1    405 quicksort(14060):   
+0    415 quicksort(14060):   _Z4SwapRiS_
+1    423 quicksort(14060):   
+0    435 quicksort(14060):   _Z4SwapRiS_
+1    444 quicksort(14060):   
+0    454 quicksort(14060):   _Z4SwapRiS_
+1    462 quicksort(14060):   
+0    473 quicksort(14060):   _Z4SwapRiS_
+1    481 quicksort(14060):   
+0    492 quicksort(14060):   _Z4SwapRiS_
+1    501 quicksort(14060):   
+0    511 quicksort(14060):   _Z4SwapRiS_
+1    520 quicksort(14060):   
+0    531 quicksort(14060):   _Z4SwapRiS_
+1    539 quicksort(14060):   
+0    550 quicksort(14060):   _Z4SwapRiS_
+1    559 quicksort(14060):   
+1    564 quicksort(14060):  
+0    574 quicksort(14060):  _Z12BadPartitionPiii
+0    588 quicksort(14060):   _Z4SwapRiS_
+1    596 quicksort(14060):   
+1    600 quicksort(14060):  
+0    610 quicksort(14060):  _Z12BadPartitionPiii
+0    625 quicksort(14060):   _Z4SwapRiS_
+1    634 quicksort(14060):   
+0    645 quicksort(14060):   _Z4SwapRiS_
+1    653 quicksort(14060):   
+0    663 quicksort(14060):   _Z4SwapRiS_
+1    671 quicksort(14060):   
+0    683 quicksort(14060):   _Z4SwapRiS_
+1    692 quicksort(14060):   
+0    703 quicksort(14060):   _Z4SwapRiS_
+1    712 quicksort(14060):   
+0    722 quicksort(14060):   _Z4SwapRiS_
+1    731 quicksort(14060):   
+0    741 quicksort(14060):   _Z4SwapRiS_
+1    749 quicksort(14060):   
+1    753 quicksort(14060):  
+0    764 quicksort(14060):  _Z12BadPartitionPiii
+0    778 quicksort(14060):   _Z4SwapRiS_
+1    787 quicksort(14060):   
+1    791 quicksort(14060):  
+0    802 quicksort(14060):  _Z12BadPartitionPiii
+0    816 quicksort(14060):   _Z4SwapRiS_
+1    825 quicksort(14060):   
+0    834 quicksort(14060):   _Z4SwapRiS_
+1    840 quicksort(14060):   
+0    848 quicksort(14060):   _Z4SwapRiS_
+1    855 quicksort(14060):   
+0    863 quicksort(14060):   _Z4SwapRiS_
+1    869 quicksort(14060):   
+0    878 quicksort(14060):   _Z4SwapRiS_
+1    886 quicksort(14060):   
+1    891 quicksort(14060):  
+0    901 quicksort(14060):  _Z12BadPartitionPiii
+0    915 quicksort(14060):   _Z4SwapRiS_
+1    922 quicksort(14060):   
+1    928 quicksort(14060):  
+0    938 quicksort(14060):  _Z12BadPartitionPiii
+0    952 quicksort(14060):   _Z4SwapRiS_
+1    961 quicksort(14060):   
+0    972 quicksort(14060):   _Z4SwapRiS_
+1    980 quicksort(14060):   
+0    991 quicksort(14060):   _Z4SwapRiS_
+1   1000 quicksort(14060):   
+1   1006 quicksort(14060):  
+0   1017 quicksort(14060):  _Z12BadPartitionPiii
+0   1032 quicksort(14060):   _Z4SwapRiS_
+1   1041 quicksort(14060):   
+1   1046 quicksort(14060):  
+1   1053 quicksort(14060): 
+2   1060 quicksort(14060): INSIDE_CYCLE
+0   1073 quicksort(14060): _Z12QuickSortBadPii
+0   1089 quicksort(14060):  _Z12BadPartitionPiii
+0   1105 quicksort(14060):   _Z4SwapRiS_
+1   1114 quicksort(14060):   
+1   1120 quicksort(14060):  
+0   1131 quicksort(14060):  _Z12BadPartitionPiii
+0   1147 quicksort(14060):   _Z4SwapRiS_
+1   1155 quicksort(14060):   
+0   1165 quicksort(14060):   _Z4SwapRiS_
+1   1174 quicksort(14060):   
+0   1185 quicksort(14060):   _Z4SwapRiS_
+1   1193 quicksort(14060):   
+0   1203 quicksort(14060):   _Z4SwapRiS_
+1   1211 quicksort(14060):   
+0   1221 quicksort(14060):   _Z4SwapRiS_
+1   1229 quicksort(14060):   
+0   1240 quicksort(14060):   _Z4SwapRiS_
+1   1248 quicksort(14060):   
+0   1259 quicksort(14060):   _Z4SwapRiS_
+1   1266 quicksort(14060):   
+0   1277 quicksort(14060):   _Z4SwapRiS_
+1   1284 quicksort(14060):   
+0   1295 quicksort(14060):   _Z4SwapRiS_
+1   1302 quicksort(14060):   
+0   1313 quicksort(14060):   _Z4SwapRiS_
+1   1321 quicksort(14060):   
+0   1332 quicksort(14060):   _Z4SwapRiS_
+1   1340 quicksort(14060):   
+0   1350 quicksort(14060):   _Z4SwapRiS_
+1   1358 quicksort(14060):   
+0   1368 quicksort(14060):   _Z4SwapRiS_
+1   1376 quicksort(14060):   
+0   1386 quicksort(14060):   _Z4SwapRiS_
+1   1394 quicksort(14060):   
+1   1398 quicksort(14060):  
+0   1409 quicksort(14060):  _Z12BadPartitionPiii
+0   1423 quicksort(14060):   _Z4SwapRiS_
+1   1432 quicksort(14060):   
+1   1437 quicksort(14060):  
+0   1448 quicksort(14060):  _Z12BadPartitionPiii
+0   1461 quicksort(14060):   _Z4SwapRiS_
+1   1470 quicksort(14060):   
+0   1480 quicksort(14060):   _Z4SwapRiS_
+1   1487 quicksort(14060):   
+0   1497 quicksort(14060):   _Z4SwapRiS_
+1   1506 quicksort(14060):   
+0   1516 quicksort(14060):   _Z4SwapRiS_
+1   1525 quicksort(14060):   
+0   1536 quicksort(14060):   _Z4SwapRiS_
+1   1544 quicksort(14060):   
+0   1555 quicksort(14060):   _Z4SwapRiS_
+1   1563 quicksort(14060):   
+0   1574 quicksort(14060):   _Z4SwapRiS_
+1   1582 quicksort(14060):   
+0   1593 quicksort(14060):   _Z4SwapRiS_
+1   1601 quicksort(14060):   
+0   1612 quicksort(14060):   _Z4SwapRiS_
+1   1621 quicksort(14060):   
+0   1632 quicksort(14060):   _Z4SwapRiS_
+1   1640 quicksort(14060):   
+0   1650 quicksort(14060):   _Z4SwapRiS_
+1   1658 quicksort(14060):   
+0   1668 quicksort(14060):   _Z4SwapRiS_
+1   1676 quicksort(14060):   
+1   1681 quicksort(14060):  
+0   1692 quicksort(14060):  _Z12BadPartitionPiii
+0   1706 quicksort(14060):   _Z4SwapRiS_
+1   1714 quicksort(14060):   
+1   1719 quicksort(14060):  
+0   1730 quicksort(14060):  _Z12BadPartitionPiii
+0   1745 quicksort(14060):   _Z4SwapRiS_
+1   1752 quicksort(14060):   
+0   1763 quicksort(14060):   _Z4SwapRiS_
+1   1772 quicksort(14060):   
+0   1783 quicksort(14060):   _Z4SwapRiS_
+1   1791 quicksort(14060):   
+0   1801 quicksort(14060):   _Z4SwapRiS_
+1   1809 quicksort(14060):   
+0   1820 quicksort(14060):   _Z4SwapRiS_
+1   1843 quicksort(14060):   
+0   1854 quicksort(14060):   _Z4SwapRiS_
+1   1863 quicksort(14060):   
+0   1876 quicksort(14060):   _Z4SwapRiS_
+1   1884 quicksort(14060):   
+0   1895 quicksort(14060):   _Z4SwapRiS_
+1   1908 quicksort(14060):   
+0   1917 quicksort(14060):   _Z4SwapRiS_
+1   1923 quicksort(14060):   
+0   1932 quicksort(14060):   _Z4SwapRiS_
+1   1939 quicksort(14060):   
+1   1943 quicksort(14060):  
+0   1952 quicksort(14060):  _Z12BadPartitionPiii
+0   1963 quicksort(14060):   _Z4SwapRiS_
+1   1970 quicksort(14060):   
+1   1974 quicksort(14060):  
+0   1983 quicksort(14060):  _Z12BadPartitionPiii
+0   1994 quicksort(14060):   _Z4SwapRiS_
+1   2000 quicksort(14060):   
+0   2009 quicksort(14060):   _Z4SwapRiS_
+1   2016 quicksort(14060):   
+0   2025 quicksort(14060):   _Z4SwapRiS_
+1   2031 quicksort(14060):   
+0   2040 quicksort(14060):   _Z4SwapRiS_
+1   2047 quicksort(14060):   
+0   2055 quicksort(14060):   _Z4SwapRiS_
+1   2062 quicksort(14060):   
+0   2070 quicksort(14060):   _Z4SwapRiS_
+1   2077 quicksort(14060):   
+0   2085 quicksort(14060):   _Z4SwapRiS_
+1   2092 quicksort(14060):   
+0   2100 quicksort(14060):   _Z4SwapRiS_
+1   2107 quicksort(14060):   
+1   2110 quicksort(14060):  
+0   2119 quicksort(14060):  _Z12BadPartitionPiii
+0   2130 quicksort(14060):   _Z4SwapRiS_
+1   2137 quicksort(14060):   
+1   2141 quicksort(14060):  
+0   2149 quicksort(14060):  _Z12BadPartitionPiii
+0   2161 quicksort(14060):   _Z4SwapRiS_
+1   2167 quicksort(14060):   
+0   2176 quicksort(14060):   _Z4SwapRiS_
+1   2183 quicksort(14060):   
+0   2192 quicksort(14060):   _Z4SwapRiS_
+1   2201 quicksort(14060):   
+0   2217 quicksort(14060):   _Z4SwapRiS_
+1   2225 quicksort(14060):   
+0   2236 quicksort(14060):   _Z4SwapRiS_
+1   2245 quicksort(14060):   
+0   2253 quicksort(14060):   _Z4SwapRiS_
+1   2260 quicksort(14060):   
+1   2264 quicksort(14060):  
+0   2276 quicksort(14060):  _Z12BadPartitionPiii
+0   2294 quicksort(14060):   _Z4SwapRiS_
+1   2301 quicksort(14060):   
+1   2304 quicksort(14060):  
+0   2313 quicksort(14060):  _Z12BadPartitionPiii
+0   2325 quicksort(14060):   _Z4SwapRiS_
+1   2331 quicksort(14060):   
+0   2340 quicksort(14060):   _Z4SwapRiS_
+1   2346 quicksort(14060):   
+0   2355 quicksort(14060):   _Z4SwapRiS_
+1   2362 quicksort(14060):   
+0   2370 quicksort(14060):   _Z4SwapRiS_
+1   2377 quicksort(14060):   
+1   2381 quicksort(14060):  
+0   2390 quicksort(14060):  _Z12BadPartitionPiii
+0   2405 quicksort(14060):   _Z4SwapRiS_
+1   2415 quicksort(14060):   
+1   2419 quicksort(14060):  
+0   2430 quicksort(14060):  _Z12BadPartitionPiii
+0   2445 quicksort(14060):   _Z4SwapRiS_
+1   2455 quicksort(14060):   
+0   2465 quicksort(14060):   _Z4SwapRiS_
+1   2473 quicksort(14060):   
+1   2478 quicksort(14060):  
+1   2484 quicksort(14060): 
+2   2491 quicksort(14060): INSIDE_CYCLE
+0   2521 quicksort(14060): _Z12QuickSortBadPii
+0   2537 quicksort(14060):  _Z12BadPartitionPiii
+0   2552 quicksort(14060):   _Z4SwapRiS_
+1   2569 quicksort(14060):   
+1   2571 quicksort(14060):  
+0   2576 quicksort(14060):  _Z12BadPartitionPiii
+0   2583 quicksort(14060):   _Z4SwapRiS_
+1   2586 quicksort(14060):   
+0   2591 quicksort(14060):   _Z4SwapRiS_
+1   2595 quicksort(14060):   
+0   2600 quicksort(14060):   _Z4SwapRiS_
+1   2604 quicksort(14060):   
+0   2609 quicksort(14060):   _Z4SwapRiS_
+1   2613 quicksort(14060):   
+0   2618 quicksort(14060):   _Z4SwapRiS_
+1   2622 quicksort(14060):   
+0   2626 quicksort(14060):   _Z4SwapRiS_
+1   2630 quicksort(14060):   
+0   2635 quicksort(14060):   _Z4SwapRiS_
+1   2640 quicksort(14060):   
+0   2645 quicksort(14060):   _Z4SwapRiS_
+1   2649 quicksort(14060):   
+0   2654 quicksort(14060):   _Z4SwapRiS_
+1   2658 quicksort(14060):   
+0   2663 quicksort(14060):   _Z4SwapRiS_
+1   2667 quicksort(14060):   
+0   2673 quicksort(14060):   _Z4SwapRiS_
+1   2677 quicksort(14060):   
+0   2681 quicksort(14060):   _Z4SwapRiS_
+1   2684 quicksort(14060):   
+0   2688 quicksort(14060):   _Z4SwapRiS_
+1   2691 quicksort(14060):   
+0   2695 quicksort(14060):   _Z4SwapRiS_
+1   2698 quicksort(14060):   
+0   2702 quicksort(14060):   _Z4SwapRiS_
+1   2705 quicksort(14060):   
+0   2709 quicksort(14060):   _Z4SwapRiS_
+1   2712 quicksort(14060):   
+0   2716 quicksort(14060):   _Z4SwapRiS_
+1   2719 quicksort(14060):   
+0   2723 quicksort(14060):   _Z4SwapRiS_
+1   2726 quicksort(14060):   
+0   2730 quicksort(14060):   _Z4SwapRiS_
+1   2733 quicksort(14060):   
+1   2735 quicksort(14060):  
+0   2739 quicksort(14060):  _Z12BadPartitionPiii
+0   2744 quicksort(14060):   _Z4SwapRiS_
+1   2747 quicksort(14060):   
+1   2749 quicksort(14060):  
+0   2753 quicksort(14060):  _Z12BadPartitionPiii
+0   2758 quicksort(14060):   _Z4SwapRiS_
+1   2761 quicksort(14060):   
+0   2765 quicksort(14060):   _Z4SwapRiS_
+1   2768 quicksort(14060):   
+0   2772 quicksort(14060):   _Z4SwapRiS_
+1   2775 quicksort(14060):   
+0   2779 quicksort(14060):   _Z4SwapRiS_
+1   2782 quicksort(14060):   
+0   2786 quicksort(14060):   _Z4SwapRiS_
+1   2789 quicksort(14060):   
+0   2793 quicksort(14060):   _Z4SwapRiS_
+1   2796 quicksort(14060):   
+0   2800 quicksort(14060):   _Z4SwapRiS_
+1   2803 quicksort(14060):   
+0   2807 quicksort(14060):   _Z4SwapRiS_
+1   2810 quicksort(14060):   
+0   2814 quicksort(14060):   _Z4SwapRiS_
+1   2817 quicksort(14060):   
+0   2821 quicksort(14060):   _Z4SwapRiS_
+1   2824 quicksort(14060):   
+0   2828 quicksort(14060):   _Z4SwapRiS_
+1   2831 quicksort(14060):   
+0   2835 quicksort(14060):   _Z4SwapRiS_
+1   2838 quicksort(14060):   
+0   2842 quicksort(14060):   _Z4SwapRiS_
+1   2845 quicksort(14060):   
+0   2849 quicksort(14060):   _Z4SwapRiS_
+1   2852 quicksort(14060):   
+0   2856 quicksort(14060):   _Z4SwapRiS_
+1   2859 quicksort(14060):   
+0   2863 quicksort(14060):   _Z4SwapRiS_
+1   2866 quicksort(14060):   
+0   2870 quicksort(14060):   _Z4SwapRiS_
+1   2873 quicksort(14060):   
+1   2875 quicksort(14060):  
+0   2879 quicksort(14060):  _Z12BadPartitionPiii
+0   2884 quicksort(14060):   _Z4SwapRiS_
+1   2887 quicksort(14060):   
+1   2889 quicksort(14060):  
+0   2893 quicksort(14060):  _Z12BadPartitionPiii
+0   2898 quicksort(14060):   _Z4SwapRiS_
+1   2901 quicksort(14060):   
+0   2905 quicksort(14060):   _Z4SwapRiS_
+1   2908 quicksort(14060):   
+0   2912 quicksort(14060):   _Z4SwapRiS_
+1   2915 quicksort(14060):   
+0   2919 quicksort(14060):   _Z4SwapRiS_
+1   2922 quicksort(14060):   
+0   2926 quicksort(14060):   _Z4SwapRiS_
+1   2929 quicksort(14060):   
+0   2933 quicksort(14060):   _Z4SwapRiS_
+1   2936 quicksort(14060):   
+0   2940 quicksort(14060):   _Z4SwapRiS_
+1   2943 quicksort(14060):   
+0   2947 quicksort(14060):   _Z4SwapRiS_
+1   2950 quicksort(14060):   
+0   2954 quicksort(14060):   _Z4SwapRiS_
+1   2957 quicksort(14060):   
+0   2961 quicksort(14060):   _Z4SwapRiS_
+1   2964 quicksort(14060):   
+0   2968 quicksort(14060):   _Z4SwapRiS_
+1   2971 quicksort(14060):   
+0   2975 quicksort(14060):   _Z4SwapRiS_
+1   2978 quicksort(14060):   
+0   2982 quicksort(14060):   _Z4SwapRiS_
+1   2985 quicksort(14060):   
+0   2989 quicksort(14060):   _Z4SwapRiS_
+1   2992 quicksort(14060):   
+0   2996 quicksort(14060):   _Z4SwapRiS_
+1   2999 quicksort(14060):   
+1   3001 quicksort(14060):  
+0   3005 quicksort(14060):  _Z12BadPartitionPiii
+0   3010 quicksort(14060):   _Z4SwapRiS_
+1   3013 quicksort(14060):   
+1   3015 quicksort(14060):  
+0   3019 quicksort(14060):  _Z12BadPartitionPiii
+0   3024 quicksort(14060):   _Z4SwapRiS_
+1   3027 quicksort(14060):   
+0   3031 quicksort(14060):   _Z4SwapRiS_
+1   3034 quicksort(14060):   
+0   3038 quicksort(14060):   _Z4SwapRiS_
+1   3041 quicksort(14060):   
+0   3045 quicksort(14060):   _Z4SwapRiS_
+1   3048 quicksort(14060):   
+0   3052 quicksort(14060):   _Z4SwapRiS_
+1   3055 quicksort(14060):   
+0   3059 quicksort(14060):   _Z4SwapRiS_
+1   3062 quicksort(14060):   
+0   3066 quicksort(14060):   _Z4SwapRiS_
+1   3069 quicksort(14060):   
+0   3073 quicksort(14060):   _Z4SwapRiS_
+1   3076 quicksort(14060):   
+0   3080 quicksort(14060):   _Z4SwapRiS_
+1   3083 quicksort(14060):   
+0   3087 quicksort(14060):   _Z4SwapRiS_
+1   3090 quicksort(14060):   
+0   3094 quicksort(14060):   _Z4SwapRiS_
+1   3097 quicksort(14060):   
+0   3101 quicksort(14060):   _Z4SwapRiS_
+1   3104 quicksort(14060):   
+0   3108 quicksort(14060):   _Z4SwapRiS_
+1   3111 quicksort(14060):   
+1   3113 quicksort(14060):  
+0   3117 quicksort(14060):  _Z12BadPartitionPiii
+0   3122 quicksort(14060):   _Z4SwapRiS_
+1   3125 quicksort(14060):   
+1   3127 quicksort(14060):  
+0   3131 quicksort(14060):  _Z12BadPartitionPiii
+0   3136 quicksort(14060):   _Z4SwapRiS_
+1   3139 quicksort(14060):   
+0   3143 quicksort(14060):   _Z4SwapRiS_
+1   3146 quicksort(14060):   
+0   3150 quicksort(14060):   _Z4SwapRiS_
+1   3153 quicksort(14060):   
+0   3157 quicksort(14060):   _Z4SwapRiS_
+1   3160 quicksort(14060):   
+0   3164 quicksort(14060):   _Z4SwapRiS_
+1   3167 quicksort(14060):   
+0   3171 quicksort(14060):   _Z4SwapRiS_
+1   3174 quicksort(14060):   
+0   3178 quicksort(14060):   _Z4SwapRiS_
+1   3181 quicksort(14060):   
+0   3185 quicksort(14060):   _Z4SwapRiS_
+1   3188 quicksort(14060):   
+0   3192 quicksort(14060):   _Z4SwapRiS_
+1   3195 quicksort(14060):   
+0   3199 quicksort(14060):   _Z4SwapRiS_
+1   3202 quicksort(14060):   
+0   3206 quicksort(14060):   _Z4SwapRiS_
+1   3209 quicksort(14060):   
+1   3210 quicksort(14060):  
+0   3214 quicksort(14060):  _Z12BadPartitionPiii
+0   3220 quicksort(14060):   _Z4SwapRiS_
+1   3223 quicksort(14060):   
+1   3225 quicksort(14060):  
+0   3229 quicksort(14060):  _Z12BadPartitionPiii
+0   3234 quicksort(14060):   _Z4SwapRiS_
+1   3237 quicksort(14060):   
+0   3241 quicksort(14060):   _Z4SwapRiS_
+1   3244 quicksort(14060):   
+0   3248 quicksort(14060):   _Z4SwapRiS_
+1   3251 quicksort(14060):   
+0   3255 quicksort(14060):   _Z4SwapRiS_
+1   3258 quicksort(14060):   
+0   3262 quicksort(14060):   _Z4SwapRiS_
+1   3265 quicksort(14060):   
+0   3269 quicksort(14060):   _Z4SwapRiS_
+1   3272 quicksort(14060):   
+0   3276 quicksort(14060):   _Z4SwapRiS_
+1   3279 quicksort(14060):   
+0   3283 quicksort(14060):   _Z4SwapRiS_
+1   3286 quicksort(14060):   
+0   3290 quicksort(14060):   _Z4SwapRiS_
+1   3293 quicksort(14060):   
+1   3295 quicksort(14060):  
+0   3299 quicksort(14060):  _Z12BadPartitionPiii
+0   3304 quicksort(14060):   _Z4SwapRiS_
+1   3307 quicksort(14060):   
+1   3309 quicksort(14060):  
+0   3313 quicksort(14060):  _Z12BadPartitionPiii
+0   3318 quicksort(14060):   _Z4SwapRiS_
+1   3321 quicksort(14060):   
+0   3325 quicksort(14060):   _Z4SwapRiS_
+1   3328 quicksort(14060):   
+0   3332 quicksort(14060):   _Z4SwapRiS_
+1   3335 quicksort(14060):   
+0   3339 quicksort(14060):   _Z4SwapRiS_
+1   3342 quicksort(14060):   
+0   3346 quicksort(14060):   _Z4SwapRiS_
+1   3349 quicksort(14060):   
+0   3353 quicksort(14060):   _Z4SwapRiS_
+1   3356 quicksort(14060):   
+0   3360 quicksort(14060):   _Z4SwapRiS_
+1   3363 quicksort(14060):   
+1   3365 quicksort(14060):  
+0   3369 quicksort(14060):  _Z12BadPartitionPiii
+0   3374 quicksort(14060):   _Z4SwapRiS_
+1   3377 quicksort(14060):   
+1   3379 quicksort(14060):  
+0   3383 quicksort(14060):  _Z12BadPartitionPiii
+0   3388 quicksort(14060):   _Z4SwapRiS_
+1   3392 quicksort(14060):   
+0   3396 quicksort(14060):   _Z4SwapRiS_
+1   3399 quicksort(14060):   
+0   3403 quicksort(14060):   _Z4SwapRiS_
+1   3406 quicksort(14060):   
+0   3410 quicksort(14060):   _Z4SwapRiS_
+1   3413 quicksort(14060):   
+0   3417 quicksort(14060):   _Z4SwapRiS_
+1   3420 quicksort(14060):   
+1   3421 quicksort(14060):  
+0   3427 quicksort(14060):  _Z12BadPartitionPiii
+0   3432 quicksort(14060):   _Z4SwapRiS_
+1   3435 quicksort(14060):   
+1   3437 quicksort(14060):  
+0   3441 quicksort(14060):  _Z12BadPartitionPiii
+0   3446 quicksort(14060):   _Z4SwapRiS_
+1   3449 quicksort(14060):   
+0   3453 quicksort(14060):   _Z4SwapRiS_
+1   3456 quicksort(14060):   
+0   3460 quicksort(14060):   _Z4SwapRiS_
+1   3464 quicksort(14060):   
+1   3466 quicksort(14060):  
+0   3470 quicksort(14060):  _Z12BadPartitionPiii
+0   3475 quicksort(14060):   _Z4SwapRiS_
+1   3478 quicksort(14060):   
+1   3480 quicksort(14060):  
+1   3482 quicksort(14060): 
+2   3484 quicksort(14060): INSIDE_CYCLE
+0   3489 quicksort(14060): _Z12QuickSortBadPii
+0   3494 quicksort(14060):  _Z12BadPartitionPiii
+0   3500 quicksort(14060):   _Z4SwapRiS_
+1   3503 quicksort(14060):   
+1   3504 quicksort(14060):  
+0   3508 quicksort(14060):  _Z12BadPartitionPiii
+0   3514 quicksort(14060):   _Z4SwapRiS_
+1   3517 quicksort(14060):   
+0   3521 quicksort(14060):   _Z4SwapRiS_
+1   3524 quicksort(14060):   
+0   3528 quicksort(14060):   _Z4SwapRiS_
+1   3531 quicksort(14060):   
+0   3535 quicksort(14060):   _Z4SwapRiS_
+1   3538 quicksort(14060):   
+0   3542 quicksort(14060):   _Z4SwapRiS_
+1   3545 quicksort(14060):   
+0   3549 quicksort(14060):   _Z4SwapRiS_
+1   3552 quicksort(14060):   
+0   3556 quicksort(14060):   _Z4SwapRiS_
+1   3559 quicksort(14060):   
+0   3563 quicksort(14060):   _Z4SwapRiS_
+1   3566 quicksort(14060):   
+0   3570 quicksort(14060):   _Z4SwapRiS_
+1   3573 quicksort(14060):   
+0   3577 quicksort(14060):   _Z4SwapRiS_
+1   3580 quicksort(14060):   
+0   3584 quicksort(14060):   _Z4SwapRiS_
+1   3587 quicksort(14060):   
+0   3591 quicksort(14060):   _Z4SwapRiS_
+1   3594 quicksort(14060):   
+0   3598 quicksort(14060):   _Z4SwapRiS_
+1   3601 quicksort(14060):   
+0   3605 quicksort(14060):   _Z4SwapRiS_
+1   3608 quicksort(14060):   
+0   3612 quicksort(14060):   _Z4SwapRiS_
+1   3615 quicksort(14060):   
+0   3619 quicksort(14060):   _Z4SwapRiS_
+1   3622 quicksort(14060):   
+0   3626 quicksort(14060):   _Z4SwapRiS_
+1   3629 quicksort(14060):   
+0   3633 quicksort(14060):   _Z4SwapRiS_
+1   3636 quicksort(14060):   
+0   3640 quicksort(14060):   _Z4SwapRiS_
+1   3643 quicksort(14060):   
+0   3647 quicksort(14060):   _Z4SwapRiS_
+1   3650 quicksort(14060):   
+0   3654 quicksort(14060):   _Z4SwapRiS_
+1   3657 quicksort(14060):   
+0   3660 quicksort(14060):   _Z4SwapRiS_
+1   3664 quicksort(14060):   
+0   3667 quicksort(14060):   _Z4SwapRiS_
+1   3670 quicksort(14060):   
+0   3674 quicksort(14060):   _Z4SwapRiS_
+1   3677 quicksort(14060):   
+1   3679 quicksort(14060):  
+0   3683 quicksort(14060):  _Z12BadPartitionPiii
+0   3689 quicksort(14060):   _Z4SwapRiS_
+1   3692 quicksort(14060):   
+1   3693 quicksort(14060):  
+0   3697 quicksort(14060):  _Z12BadPartitionPiii
+0   3703 quicksort(14060):   _Z4SwapRiS_
+1   3706 quicksort(14060):   
+0   3710 quicksort(14060):   _Z4SwapRiS_
+1   3713 quicksort(14060):   
+0   3717 quicksort(14060):   _Z4SwapRiS_
+1   3720 quicksort(14060):   
+0   3724 quicksort(14060):   _Z4SwapRiS_
+1   3727 quicksort(14060):   
+0   3731 quicksort(14060):   _Z4SwapRiS_
+1   3734 quicksort(14060):   
+0   3738 quicksort(14060):   _Z4SwapRiS_
+1   3741 quicksort(14060):   
+0   3745 quicksort(14060):   _Z4SwapRiS_
+1   3748 quicksort(14060):   
+0   3752 quicksort(14060):   _Z4SwapRiS_
+1   3755 quicksort(14060):   
+0   3759 quicksort(14060):   _Z4SwapRiS_
+1   3762 quicksort(14060):   
+0   3766 quicksort(14060):   _Z4SwapRiS_
+1   3769 quicksort(14060):   
+0   3773 quicksort(14060):   _Z4SwapRiS_
+1   3776 quicksort(14060):   
+0   3780 quicksort(14060):   _Z4SwapRiS_
+1   3783 quicksort(14060):   
+0   3787 quicksort(14060):   _Z4SwapRiS_
+1   3790 quicksort(14060):   
+0   3794 quicksort(14060):   _Z4SwapRiS_
+1   3797 quicksort(14060):   
+0   3801 quicksort(14060):   _Z4SwapRiS_
+1   3804 quicksort(14060):   
+0   3808 quicksort(14060):   _Z4SwapRiS_
+1   3811 quicksort(14060):   
+0   3815 quicksort(14060):   _Z4SwapRiS_
+1   3818 quicksort(14060):   
+0   3822 quicksort(14060):   _Z4SwapRiS_
+1   3825 quicksort(14060):   
+0   3829 quicksort(14060):   _Z4SwapRiS_
+1   3832 quicksort(14060):   
+0   3836 quicksort(14060):   _Z4SwapRiS_
+1   3839 quicksort(14060):   
+0   3843 quicksort(14060):   _Z4SwapRiS_
+1   3846 quicksort(14060):   
+0   3850 quicksort(14060):   _Z4SwapRiS_
+1   3853 quicksort(14060):   
+1   3854 quicksort(14060):  
+0   3859 quicksort(14060):  _Z12BadPartitionPiii
+0   3866 quicksort(14060):   _Z4SwapRiS_
+1   3870 quicksort(14060):   
+1   3872 quicksort(14060):  
+0   3877 quicksort(14060):  _Z12BadPartitionPiii
+0   3883 quicksort(14060):   _Z4SwapRiS_
+1   3887 quicksort(14060):   
+0   3892 quicksort(14060):   _Z4SwapRiS_
+1   3896 quicksort(14060):   
+0   3901 quicksort(14060):   _Z4SwapRiS_
+1   3904 quicksort(14060):   
+0   3909 quicksort(14060):   _Z4SwapRiS_
+1   3913 quicksort(14060):   
+0   3918 quicksort(14060):   _Z4SwapRiS_
+1   3922 quicksort(14060):   
+0   3927 quicksort(14060):   _Z4SwapRiS_
+1   3930 quicksort(14060):   
+0   3936 quicksort(14060):   _Z4SwapRiS_
+1   3940 quicksort(14060):   
+0   3945 quicksort(14060):   _Z4SwapRiS_
+1   3949 quicksort(14060):   
+0   3954 quicksort(14060):   _Z4SwapRiS_
+1   3958 quicksort(14060):   
+0   3963 quicksort(14060):   _Z4SwapRiS_
+1   3967 quicksort(14060):   
+0   3972 quicksort(14060):   _Z4SwapRiS_
+1   3976 quicksort(14060):   
+0   3981 quicksort(14060):   _Z4SwapRiS_
+1   3985 quicksort(14060):   
+0   3990 quicksort(14060):   _Z4SwapRiS_
+1   3994 quicksort(14060):   
+0   3999 quicksort(14060):   _Z4SwapRiS_
+1   4003 quicksort(14060):   
+0   4008 quicksort(14060):   _Z4SwapRiS_
+1   4012 quicksort(14060):   
+0   4017 quicksort(14060):   _Z4SwapRiS_
+1   4021 quicksort(14060):   
+0   4026 quicksort(14060):   _Z4SwapRiS_
+1   4028 quicksort(14060):   
+0   4032 quicksort(14060):   _Z4SwapRiS_
+1   4035 quicksort(14060):   
+0   4039 quicksort(14060):   _Z4SwapRiS_
+1   4042 quicksort(14060):   
+0   4046 quicksort(14060):   _Z4SwapRiS_
+1   4049 quicksort(14060):   
+1   4051 quicksort(14060):  
+0   4055 quicksort(14060):  _Z12BadPartitionPiii
+0   4061 quicksort(14060):   _Z4SwapRiS_
+1   4064 quicksort(14060):   
+1   4065 quicksort(14060):  
+0   4069 quicksort(14060):  _Z12BadPartitionPiii
+0   4075 quicksort(14060):   _Z4SwapRiS_
+1   4078 quicksort(14060):   
+0   4082 quicksort(14060):   _Z4SwapRiS_
+1   4085 quicksort(14060):   
+0   4089 quicksort(14060):   _Z4SwapRiS_
+1   4092 quicksort(14060):   
+0   4096 quicksort(14060):   _Z4SwapRiS_
+1   4099 quicksort(14060):   
+0   4103 quicksort(14060):   _Z4SwapRiS_
+1   4106 quicksort(14060):   
+0   4110 quicksort(14060):   _Z4SwapRiS_
+1   4113 quicksort(14060):   
+0   4117 quicksort(14060):   _Z4SwapRiS_
+1   4120 quicksort(14060):   
+0   4124 quicksort(14060):   _Z4SwapRiS_
+1   4127 quicksort(14060):   
+0   4131 quicksort(14060):   _Z4SwapRiS_
+1   4134 quicksort(14060):   
+0   4138 quicksort(14060):   _Z4SwapRiS_
+1   4141 quicksort(14060):   
+0   4144 quicksort(14060):   _Z4SwapRiS_
+1   4148 quicksort(14060):   
+0   4151 quicksort(14060):   _Z4SwapRiS_
+1   4154 quicksort(14060):   
+0   4158 quicksort(14060):   _Z4SwapRiS_
+1   4161 quicksort(14060):   
+0   4165 quicksort(14060):   _Z4SwapRiS_
+1   4168 quicksort(14060):   
+0   4172 quicksort(14060):   _Z4SwapRiS_
+1   4175 quicksort(14060):   
+0   4179 quicksort(14060):   _Z4SwapRiS_
+1   4182 quicksort(14060):   
+0   4186 quicksort(14060):   _Z4SwapRiS_
+1   4189 quicksort(14060):   
+0   4193 quicksort(14060):   _Z4SwapRiS_
+1   4196 quicksort(14060):   
+1   4198 quicksort(14060):  
+0   4202 quicksort(14060):  _Z12BadPartitionPiii
+0   4207 quicksort(14060):   _Z4SwapRiS_
+1   4210 quicksort(14060):   
+1   4212 quicksort(14060):  
+0   4216 quicksort(14060):  _Z12BadPartitionPiii
+0   4221 quicksort(14060):   _Z4SwapRiS_
+1   4224 quicksort(14060):   
+0   4228 quicksort(14060):   _Z4SwapRiS_
+1   4231 quicksort(14060):   
+0   4235 quicksort(14060):   _Z4SwapRiS_
+1   4238 quicksort(14060):   
+0   4242 quicksort(14060):   _Z4SwapRiS_
+1   4245 quicksort(14060):   
+0   4249 quicksort(14060):   _Z4SwapRiS_
+1   4252 quicksort(14060):   
+0   4267 quicksort(14060):   _Z4SwapRiS_
+1   4269 quicksort(14060):   
+0   4272 quicksort(14060):   _Z4SwapRiS_
+1   4274 quicksort(14060):   
+0   4276 quicksort(14060):   _Z4SwapRiS_
+1   4278 quicksort(14060):   
+0   4281 quicksort(14060):   _Z4SwapRiS_
+1   4282 quicksort(14060):   
+0   4285 quicksort(14060):   _Z4SwapRiS_
+1   4287 quicksort(14060):   
+0   4289 quicksort(14060):   _Z4SwapRiS_
+1   4291 quicksort(14060):   
+0   4294 quicksort(14060):   _Z4SwapRiS_
+1   4296 quicksort(14060):   
+0   4298 quicksort(14060):   _Z4SwapRiS_
+1   4300 quicksort(14060):   
+0   4303 quicksort(14060):   _Z4SwapRiS_
+1   4305 quicksort(14060):   
+0   4307 quicksort(14060):   _Z4SwapRiS_
+1   4309 quicksort(14060):   
+0   4312 quicksort(14060):   _Z4SwapRiS_
+1   4314 quicksort(14060):   
+1   4315 quicksort(14060):  
+0   4317 quicksort(14060):  _Z12BadPartitionPiii
+0   4321 quicksort(14060):   _Z4SwapRiS_
+1   4322 quicksort(14060):   
+1   4324 quicksort(14060):  
+0   4326 quicksort(14060):  _Z12BadPartitionPiii
+0   4329 quicksort(14060):   _Z4SwapRiS_
+1   4331 quicksort(14060):   
+0   4334 quicksort(14060):   _Z4SwapRiS_
+1   4336 quicksort(14060):   
+0   4338 quicksort(14060):   _Z4SwapRiS_
+1   4340 quicksort(14060):   
+0   4343 quicksort(14060):   _Z4SwapRiS_
+1   4345 quicksort(14060):   
+0   4347 quicksort(14060):   _Z4SwapRiS_
+1   4349 quicksort(14060):   
+0   4352 quicksort(14060):   _Z4SwapRiS_
+1   4354 quicksort(14060):   
+0   4356 quicksort(14060):   _Z4SwapRiS_
+1   4358 quicksort(14060):   
+0   4361 quicksort(14060):   _Z4SwapRiS_
+1   4362 quicksort(14060):   
+0   4398 quicksort(14060):   _Z4SwapRiS_
+1   4400 quicksort(14060):   
+0   4403 quicksort(14060):   _Z4SwapRiS_
+1   4405 quicksort(14060):   
+0   4408 quicksort(14060):   _Z4SwapRiS_
+1   4410 quicksort(14060):   
+0   4423 quicksort(14060):   _Z4SwapRiS_
+1   4425 quicksort(14060):   
+0   4428 quicksort(14060):   _Z4SwapRiS_
+1   4429 quicksort(14060):   
+0   4432 quicksort(14060):   _Z4SwapRiS_
+1   4434 quicksort(14060):   
+1   4435 quicksort(14060):  
+0   4438 quicksort(14060):  _Z12BadPartitionPiii
+0   4441 quicksort(14060):   _Z4SwapRiS_
+1   4443 quicksort(14060):   
+1   4444 quicksort(14060):  
+0   4447 quicksort(14060):  _Z12BadPartitionPiii
+0   4450 quicksort(14060):   _Z4SwapRiS_
+1   4452 quicksort(14060):   
+0   4454 quicksort(14060):   _Z4SwapRiS_
+1   4456 quicksort(14060):   
+0   4459 quicksort(14060):   _Z4SwapRiS_
+1   4461 quicksort(14060):   
+0   4463 quicksort(14060):   _Z4SwapRiS_
+1   4465 quicksort(14060):   
+0   4468 quicksort(14060):   _Z4SwapRiS_
+1   4470 quicksort(14060):   
+0   4472 quicksort(14060):   _Z4SwapRiS_
+1   4474 quicksort(14060):   
+0   4477 quicksort(14060):   _Z4SwapRiS_
+1   4479 quicksort(14060):   
+0   4481 quicksort(14060):   _Z4SwapRiS_
+1   4483 quicksort(14060):   
+0   4486 quicksort(14060):   _Z4SwapRiS_
+1   4488 quicksort(14060):   
+0   4490 quicksort(14060):   _Z4SwapRiS_
+1   4492 quicksort(14060):   
+0   4495 quicksort(14060):   _Z4SwapRiS_
+1   4497 quicksort(14060):   
+0   4499 quicksort(14060):   _Z4SwapRiS_
+1   4501 quicksort(14060):   
+1   4502 quicksort(14060):  
+0   4505 quicksort(14060):  _Z12BadPartitionPiii
+0   4508 quicksort(14060):   _Z4SwapRiS_
+1   4510 quicksort(14060):   
+1   4511 quicksort(14060):  
+0   4514 quicksort(14060):  _Z12BadPartitionPiii
+0   4517 quicksort(14060):   _Z4SwapRiS_
+1   4519 quicksort(14060):   
+0   4522 quicksort(14060):   _Z4SwapRiS_
+1   4523 quicksort(14060):   
+0   4526 quicksort(14060):   _Z4SwapRiS_
+1   4528 quicksort(14060):   
+0   4530 quicksort(14060):   _Z4SwapRiS_
+1   4532 quicksort(14060):   
+0   4535 quicksort(14060):   _Z4SwapRiS_
+1   4537 quicksort(14060):   
+0   4539 quicksort(14060):   _Z4SwapRiS_
+1   4541 quicksort(14060):   
+0   4544 quicksort(14060):   _Z4SwapRiS_
+1   4546 quicksort(14060):   
+0   4548 quicksort(14060):   _Z4SwapRiS_
+1   4550 quicksort(14060):   
+0   4553 quicksort(14060):   _Z4SwapRiS_
+1   4555 quicksort(14060):   
+0   4557 quicksort(14060):   _Z4SwapRiS_
+1   4559 quicksort(14060):   
+1   4560 quicksort(14060):  
+0   4563 quicksort(14060):  _Z12BadPartitionPiii
+0   4566 quicksort(14060):   _Z4SwapRiS_
+1   4568 quicksort(14060):   
+1   4569 quicksort(14060):  
+0   4572 quicksort(14060):  _Z12BadPartitionPiii
+0   4575 quicksort(14060):   _Z4SwapRiS_
+1   4577 quicksort(14060):   
+0   4580 quicksort(14060):   _Z4SwapRiS_
+1   4581 quicksort(14060):   
+0   4584 quicksort(14060):   _Z4SwapRiS_
+1   4586 quicksort(14060):   
+0   4588 quicksort(14060):   _Z4SwapRiS_
+1   4590 quicksort(14060):   
+0   4593 quicksort(14060):   _Z4SwapRiS_
+1   4595 quicksort(14060):   
+0   4597 quicksort(14060):   _Z4SwapRiS_
+1   4599 quicksort(14060):   
+0   4602 quicksort(14060):   _Z4SwapRiS_
+1   4604 quicksort(14060):   
+0   4606 quicksort(14060):   _Z4SwapRiS_
+1   4608 quicksort(14060):   
+1   4609 quicksort(14060):  
+0   4612 quicksort(14060):  _Z12BadPartitionPiii
+0   4615 quicksort(14060):   _Z4SwapRiS_
+1   4617 quicksort(14060):   
+1   4618 quicksort(14060):  
+0   4621 quicksort(14060):  _Z12BadPartitionPiii
+0   4624 quicksort(14060):   _Z4SwapRiS_
+1   4626 quicksort(14060):   
+0   4628 quicksort(14060):   _Z4SwapRiS_
+1   4630 quicksort(14060):   
+0   4633 quicksort(14060):   _Z4SwapRiS_
+1   4635 quicksort(14060):   
+0   4637 quicksort(14060):   _Z4SwapRiS_
+1   4639 quicksort(14060):   
+0   4642 quicksort(14060):   _Z4SwapRiS_
+1   4644 quicksort(14060):   
+0   4646 quicksort(14060):   _Z4SwapRiS_
+1   4648 quicksort(14060):   
+1   4649 quicksort(14060):  
+0   4652 quicksort(14060):  _Z12BadPartitionPiii
+0   4655 quicksort(14060):   _Z4SwapRiS_
+1   4657 quicksort(14060):   
+1   4658 quicksort(14060):  
+0   4661 quicksort(14060):  _Z12BadPartitionPiii
+0   4664 quicksort(14060):   _Z4SwapRiS_
+1   4666 quicksort(14060):   
+0   4669 quicksort(14060):   _Z4SwapRiS_
+1   4671 quicksort(14060):   
+0   4673 quicksort(14060):   _Z4SwapRiS_
+1   4675 quicksort(14060):   
+0   4677 quicksort(14060):   _Z4SwapRiS_
+1   4679 quicksort(14060):   
+1   4680 quicksort(14060):  
+0   4683 quicksort(14060):  _Z12BadPartitionPiii
+0   4686 quicksort(14060):   _Z4SwapRiS_
+1   4688 quicksort(14060):   
+1   4689 quicksort(14060):  
+0   4692 quicksort(14060):  _Z12BadPartitionPiii
+0   4695 quicksort(14060):   _Z4SwapRiS_
+1   4697 quicksort(14060):   
+0   4700 quicksort(14060):   _Z4SwapRiS_
+1   4702 quicksort(14060):   
+1   4703 quicksort(14060):  
+1   4704 quicksort(14060): 
+2   4706 quicksort(14060): INSIDE_CYCLE
+0   4709 quicksort(14060): _Z12QuickSortBadPii
+0   4712 quicksort(14060):  _Z12BadPartitionPiii
+0   4715 quicksort(14060):   _Z4SwapRiS_
+1   4717 quicksort(14060):   
+1   4718 quicksort(14060):  
+0   4721 quicksort(14060):  _Z12BadPartitionPiii
+0   4724 quicksort(14060):   _Z4SwapRiS_
+1   4726 quicksort(14060):   
+0   4729 quicksort(14060):   _Z4SwapRiS_
+1   4731 quicksort(14060):   
+0   4733 quicksort(14060):   _Z4SwapRiS_
+1   4735 quicksort(14060):   
+0   4738 quicksort(14060):   _Z4SwapRiS_
+1   4740 quicksort(14060):   
+0   4742 quicksort(14060):   _Z4SwapRiS_
+1   4744 quicksort(14060):   
+0   4747 quicksort(14060):   _Z4SwapRiS_
+1   4749 quicksort(14060):   
+0   4751 quicksort(14060):   _Z4SwapRiS_
+1   4753 quicksort(14060):   
+0   4755 quicksort(14060):   _Z4SwapRiS_
+1   4757 quicksort(14060):   
+0   4760 quicksort(14060):   _Z4SwapRiS_
+1   4762 quicksort(14060):   
+0   4764 quicksort(14060):   _Z4SwapRiS_
+1   4766 quicksort(14060):   
+0   4769 quicksort(14060):   _Z4SwapRiS_
+1   4771 quicksort(14060):   
+0   4773 quicksort(14060):   _Z4SwapRiS_
+1   4775 quicksort(14060):   
+0   4778 quicksort(14060):   _Z4SwapRiS_
+1   4780 quicksort(14060):   
+0   4783 quicksort(14060):   _Z4SwapRiS_
+1   4784 quicksort(14060):   
+0   4787 quicksort(14060):   _Z4SwapRiS_
+1   4789 quicksort(14060):   
+0   4791 quicksort(14060):   _Z4SwapRiS_
+1   4793 quicksort(14060):   
+0   4796 quicksort(14060):   _Z4SwapRiS_
+1   4798 quicksort(14060):   
+0   4800 quicksort(14060):   _Z4SwapRiS_
+1   4802 quicksort(14060):   
+0   4805 quicksort(14060):   _Z4SwapRiS_
+1   4807 quicksort(14060):   
+0   4809 quicksort(14060):   _Z4SwapRiS_
+1   4811 quicksort(14060):   
+0   4814 quicksort(14060):   _Z4SwapRiS_
+1   4816 quicksort(14060):   
+0   4818 quicksort(14060):   _Z4SwapRiS_
+1   4820 quicksort(14060):   
+0   4823 quicksort(14060):   _Z4SwapRiS_
+1   4825 quicksort(14060):   
+0   4827 quicksort(14060):   _Z4SwapRiS_
+1   4829 quicksort(14060):   
+0   4832 quicksort(14060):   _Z4SwapRiS_
+1   4834 quicksort(14060):   
+0   4836 quicksort(14060):   _Z4SwapRiS_
+1   4838 quicksort(14060):   
+0   4840 quicksort(14060):   _Z4SwapRiS_
+1   4842 quicksort(14060):   
+0   4845 quicksort(14060):   _Z4SwapRiS_
+1   4847 quicksort(14060):   
+0   4849 quicksort(14060):   _Z4SwapRiS_
+1   4851 quicksort(14060):   
+1   4852 quicksort(14060):  
+0   4855 quicksort(14060):  _Z12BadPartitionPiii
+0   4858 quicksort(14060):   _Z4SwapRiS_
+1   4860 quicksort(14060):   
+1   4861 quicksort(14060):  
+0   4864 quicksort(14060):  _Z12BadPartitionPiii
+0   4867 quicksort(14060):   _Z4SwapRiS_
+1   4870 quicksort(14060):   
+0   4872 quicksort(14060):   _Z4SwapRiS_
+1   4874 quicksort(14060):   
+0   4877 quicksort(14060):   _Z4SwapRiS_
+1   4879 quicksort(14060):   
+0   4881 quicksort(14060):   _Z4SwapRiS_
+1   4883 quicksort(14060):   
+0   4886 quicksort(14060):   _Z4SwapRiS_
+1   4888 quicksort(14060):   
+0   4890 quicksort(14060):   _Z4SwapRiS_
+1   4892 quicksort(14060):   
+0   4895 quicksort(14060):   _Z4SwapRiS_
+1   4896 quicksort(14060):   
+0   4899 quicksort(14060):   _Z4SwapRiS_
+1   4901 quicksort(14060):   
+0   4904 quicksort(14060):   _Z4SwapRiS_
+1   4905 quicksort(14060):   
+0   4908 quicksort(14060):   _Z4SwapRiS_
+1   4910 quicksort(14060):   
+0   4913 quicksort(14060):   _Z4SwapRiS_
+1   4914 quicksort(14060):   
+0   4917 quicksort(14060):   _Z4SwapRiS_
+1   4919 quicksort(14060):   
+0   4921 quicksort(14060):   _Z4SwapRiS_
+1   4923 quicksort(14060):   
+0   4926 quicksort(14060):   _Z4SwapRiS_
+1   4928 quicksort(14060):   
+0   4930 quicksort(14060):   _Z4SwapRiS_
+1   4932 quicksort(14060):   
+0   4935 quicksort(14060):   _Z4SwapRiS_
+1   4937 quicksort(14060):   
+0   4939 quicksort(14060):   _Z4SwapRiS_
+1   4941 quicksort(14060):   
+0   4944 quicksort(14060):   _Z4SwapRiS_
+1   4946 quicksort(14060):   
+0   4949 quicksort(14060):   _Z4SwapRiS_
+1   4951 quicksort(14060):   
+0   4954 quicksort(14060):   _Z4SwapRiS_
+1   4956 quicksort(14060):   
+0   4958 quicksort(14060):   _Z4SwapRiS_
+1   4960 quicksort(14060):   
+0   4962 quicksort(14060):   _Z4SwapRiS_
+1   4964 quicksort(14060):   
+0   4967 quicksort(14060):   _Z4SwapRiS_
+1   4969 quicksort(14060):   
+0   4971 quicksort(14060):   _Z4SwapRiS_
+1   4973 quicksort(14060):   
+0   4976 quicksort(14060):   _Z4SwapRiS_
+1   4978 quicksort(14060):   
+0   4981 quicksort(14060):   _Z4SwapRiS_
+1   4983 quicksort(14060):   
+0   4986 quicksort(14060):   _Z4SwapRiS_
+1   4990 quicksort(14060):   
+1   4991 quicksort(14060):  
+0   4995 quicksort(14060):  _Z12BadPartitionPiii
+0   4999 quicksort(14060):   _Z4SwapRiS_
+1   5001 quicksort(14060):   
+1   5002 quicksort(14060):  
+0   5004 quicksort(14060):  _Z12BadPartitionPiii
+0   5008 quicksort(14060):   _Z4SwapRiS_
+1   5010 quicksort(14060):   
+0   5012 quicksort(14060):   _Z4SwapRiS_
+1   5014 quicksort(14060):   
+0   5017 quicksort(14060):   _Z4SwapRiS_
+1   5019 quicksort(14060):   
+0   5021 quicksort(14060):   _Z4SwapRiS_
+1   5023 quicksort(14060):   
+0   5026 quicksort(14060):   _Z4SwapRiS_
+1   5027 quicksort(14060):   
+0   5030 quicksort(14060):   _Z4SwapRiS_
+1   5032 quicksort(14060):   
+0   5034 quicksort(14060):   _Z4SwapRiS_
+1   5036 quicksort(14060):   
+0   5039 quicksort(14060):   _Z4SwapRiS_
+1   5041 quicksort(14060):   
+0   5043 quicksort(14060):   _Z4SwapRiS_
+1   5045 quicksort(14060):   
+0   5048 quicksort(14060):   _Z4SwapRiS_
+1   5050 quicksort(14060):   
+0   5052 quicksort(14060):   _Z4SwapRiS_
+1   5054 quicksort(14060):   
+0   5057 quicksort(14060):   _Z4SwapRiS_
+1   5059 quicksort(14060):   
+0   5061 quicksort(14060):   _Z4SwapRiS_
+1   5063 quicksort(14060):   
+0   5066 quicksort(14060):   _Z4SwapRiS_
+1   5067 quicksort(14060):   
+0   5070 quicksort(14060):   _Z4SwapRiS_
+1   5072 quicksort(14060):   
+0   5074 quicksort(14060):   _Z4SwapRiS_
+1   5076 quicksort(14060):   
+0   5079 quicksort(14060):   _Z4SwapRiS_
+1   5081 quicksort(14060):   
+0   5083 quicksort(14060):   _Z4SwapRiS_
+1   5085 quicksort(14060):   
+0   5088 quicksort(14060):   _Z4SwapRiS_
+1   5090 quicksort(14060):   
+0   5092 quicksort(14060):   _Z4SwapRiS_
+1   5094 quicksort(14060):   
+0   5097 quicksort(14060):   _Z4SwapRiS_
+1   5099 quicksort(14060):   
+0   5101 quicksort(14060):   _Z4SwapRiS_
+1   5103 quicksort(14060):   
+0   5106 quicksort(14060):   _Z4SwapRiS_
+1   5108 quicksort(14060):   
+0   5110 quicksort(14060):   _Z4SwapRiS_
+1   5112 quicksort(14060):   
+0   5114 quicksort(14060):   _Z4SwapRiS_
+1   5116 quicksort(14060):   
+1   5117 quicksort(14060):  
+0   5120 quicksort(14060):  _Z12BadPartitionPiii
+0   5123 quicksort(14060):   _Z4SwapRiS_
+1   5125 quicksort(14060):   
+1   5127 quicksort(14060):  
+0   5129 quicksort(14060):  _Z12BadPartitionPiii
+0   5133 quicksort(14060):   _Z4SwapRiS_
+1   5135 quicksort(14060):   
+0   5137 quicksort(14060):   _Z4SwapRiS_
+1   5139 quicksort(14060):   
+0   5141 quicksort(14060):   _Z4SwapRiS_
+1   5143 quicksort(14060):   
+0   5146 quicksort(14060):   _Z4SwapRiS_
+1   5148 quicksort(14060):   
+0   5150 quicksort(14060):   _Z4SwapRiS_
+1   5152 quicksort(14060):   
+0   5155 quicksort(14060):   _Z4SwapRiS_
+1   5157 quicksort(14060):   
+0   5159 quicksort(14060):   _Z4SwapRiS_
+1   5161 quicksort(14060):   
+0   5164 quicksort(14060):   _Z4SwapRiS_
+1   5166 quicksort(14060):   
+0   5168 quicksort(14060):   _Z4SwapRiS_
+1   5170 quicksort(14060):   
+0   5173 quicksort(14060):   _Z4SwapRiS_
+1   5174 quicksort(14060):   
+0   5177 quicksort(14060):   _Z4SwapRiS_
+1   5179 quicksort(14060):   
+0   5181 quicksort(14060):   _Z4SwapRiS_
+1   5183 quicksort(14060):   
+0   5186 quicksort(14060):   _Z4SwapRiS_
+1   5188 quicksort(14060):   
+0   5190 quicksort(14060):   _Z4SwapRiS_
+1   5192 quicksort(14060):   
+0   5195 quicksort(14060):   _Z4SwapRiS_
+1   5197 quicksort(14060):   
+0   5199 quicksort(14060):   _Z4SwapRiS_
+1   5201 quicksort(14060):   
+0   5204 quicksort(14060):   _Z4SwapRiS_
+1   5206 quicksort(14060):   
+0   5208 quicksort(14060):   _Z4SwapRiS_
+1   5210 quicksort(14060):   
+0   5213 quicksort(14060):   _Z4SwapRiS_
+1   5214 quicksort(14060):   
+0   5217 quicksort(14060):   _Z4SwapRiS_
+1   5219 quicksort(14060):   
+0   5221 quicksort(14060):   _Z4SwapRiS_
+1   5223 quicksort(14060):   
+0   5226 quicksort(14060):   _Z4SwapRiS_
+1   5228 quicksort(14060):   
+0   5230 quicksort(14060):   _Z4SwapRiS_
+1   5232 quicksort(14060):   
+1   5233 quicksort(14060):  
+0   5236 quicksort(14060):  _Z12BadPartitionPiii
+0   5240 quicksort(14060):   _Z4SwapRiS_
+1   5241 quicksort(14060):   
+1   5243 quicksort(14060):  
+0   5245 quicksort(14060):  _Z12BadPartitionPiii
+0   5249 quicksort(14060):   _Z4SwapRiS_
+1   5251 quicksort(14060):   
+0   5254 quicksort(14060):   _Z4SwapRiS_
+1   5256 quicksort(14060):   
+0   5258 quicksort(14060):   _Z4SwapRiS_
+1   5260 quicksort(14060):   
+0   5262 quicksort(14060):   _Z4SwapRiS_
+1   5264 quicksort(14060):   
+0   5267 quicksort(14060):   _Z4SwapRiS_
+1   5269 quicksort(14060):   
+0   5271 quicksort(14060):   _Z4SwapRiS_
+1   5273 quicksort(14060):   
+0   5276 quicksort(14060):   _Z4SwapRiS_
+1   5278 quicksort(14060):   
+0   5280 quicksort(14060):   _Z4SwapRiS_
+1   5282 quicksort(14060):   
+0   5285 quicksort(14060):   _Z4SwapRiS_
+1   5287 quicksort(14060):   
+0   5289 quicksort(14060):   _Z4SwapRiS_
+1   5291 quicksort(14060):   
+0   5294 quicksort(14060):   _Z4SwapRiS_
+1   5296 quicksort(14060):   
+0   5298 quicksort(14060):   _Z4SwapRiS_
+1   5300 quicksort(14060):   
+0   5303 quicksort(14060):   _Z4SwapRiS_
+1   5305 quicksort(14060):   
+0   5307 quicksort(14060):   _Z4SwapRiS_
+1   5309 quicksort(14060):   
+0   5312 quicksort(14060):   _Z4SwapRiS_
+1   5314 quicksort(14060):   
+0   5316 quicksort(14060):   _Z4SwapRiS_
+1   5318 quicksort(14060):   
+0   5321 quicksort(14060):   _Z4SwapRiS_
+1   5323 quicksort(14060):   
+0   5325 quicksort(14060):   _Z4SwapRiS_
+1   5327 quicksort(14060):   
+0   5330 quicksort(14060):   _Z4SwapRiS_
+1   5332 quicksort(14060):   
+0   5334 quicksort(14060):   _Z4SwapRiS_
+1   5337 quicksort(14060):   
+0   5339 quicksort(14060):   _Z4SwapRiS_
+1   5341 quicksort(14060):   
+1   5342 quicksort(14060):  
+0   5345 quicksort(14060):  _Z12BadPartitionPiii
+0   5348 quicksort(14060):   _Z4SwapRiS_
+1   5350 quicksort(14060):   
+1   5351 quicksort(14060):  
+0   5354 quicksort(14060):  _Z12BadPartitionPiii
+0   5357 quicksort(14060):   _Z4SwapRiS_
+1   5359 quicksort(14060):   
+0   5361 quicksort(14060):   _Z4SwapRiS_
+1   5363 quicksort(14060):   
+0   5366 quicksort(14060):   _Z4SwapRiS_
+1   5368 quicksort(14060):   
+0   5370 quicksort(14060):   _Z4SwapRiS_
+1   5372 quicksort(14060):   
+0   5375 quicksort(14060):   _Z4SwapRiS_
+1   5377 quicksort(14060):   
+0   5379 quicksort(14060):   _Z4SwapRiS_
+1   5381 quicksort(14060):   
+0   5384 quicksort(14060):   _Z4SwapRiS_
+1   5385 quicksort(14060):   
+0   5388 quicksort(14060):   _Z4SwapRiS_
+1   5390 quicksort(14060):   
+0   5392 quicksort(14060):   _Z4SwapRiS_
+1   5394 quicksort(14060):   
+0   5397 quicksort(14060):   _Z4SwapRiS_
+1   5399 quicksort(14060):   
+0   5401 quicksort(14060):   _Z4SwapRiS_
+1   5403 quicksort(14060):   
+0   5406 quicksort(14060):   _Z4SwapRiS_
+1   5408 quicksort(14060):   
+0   5410 quicksort(14060):   _Z4SwapRiS_
+1   5412 quicksort(14060):   
+0   5415 quicksort(14060):   _Z4SwapRiS_
+1   5417 quicksort(14060):   
+0   5419 quicksort(14060):   _Z4SwapRiS_
+1   5421 quicksort(14060):   
+0   5423 quicksort(14060):   _Z4SwapRiS_
+1   5425 quicksort(14060):   
+0   5428 quicksort(14060):   _Z4SwapRiS_
+1   5430 quicksort(14060):   
+0   5432 quicksort(14060):   _Z4SwapRiS_
+1   5434 quicksort(14060):   
+0   5437 quicksort(14060):   _Z4SwapRiS_
+1   5439 quicksort(14060):   
+1   5440 quicksort(14060):  
+0   5442 quicksort(14060):  _Z12BadPartitionPiii
+0   5446 quicksort(14060):   _Z4SwapRiS_
+1   5448 quicksort(14060):   
+1   5449 quicksort(14060):  
+0   5451 quicksort(14060):  _Z12BadPartitionPiii
+0   5455 quicksort(14060):   _Z4SwapRiS_
+1   5457 quicksort(14060):   
+0   5459 quicksort(14060):   _Z4SwapRiS_
+1   5461 quicksort(14060):   
+0   5464 quicksort(14060):   _Z4SwapRiS_
+1   5466 quicksort(14060):   
+0   5468 quicksort(14060):   _Z4SwapRiS_
+1   5470 quicksort(14060):   
+0   5473 quicksort(14060):   _Z4SwapRiS_
+1   5474 quicksort(14060):   
+0   5477 quicksort(14060):   _Z4SwapRiS_
+1   5479 quicksort(14060):   
+0   5482 quicksort(14060):   _Z4SwapRiS_
+1   5483 quicksort(14060):   
+0   5486 quicksort(14060):   _Z4SwapRiS_
+1   5488 quicksort(14060):   
+0   5490 quicksort(14060):   _Z4SwapRiS_
+1   5492 quicksort(14060):   
+0   5495 quicksort(14060):   _Z4SwapRiS_
+1   5497 quicksort(14060):   
+0   5499 quicksort(14060):   _Z4SwapRiS_
+1   5501 quicksort(14060):   
+0   5504 quicksort(14060):   _Z4SwapRiS_
+1   5506 quicksort(14060):   
+0   5508 quicksort(14060):   _Z4SwapRiS_
+1   5510 quicksort(14060):   
+0   5513 quicksort(14060):   _Z4SwapRiS_
+1   5515 quicksort(14060):   
+0   5517 quicksort(14060):   _Z4SwapRiS_
+1   5519 quicksort(14060):   
+0   5522 quicksort(14060):   _Z4SwapRiS_
+1   5524 quicksort(14060):   
+0   5526 quicksort(14060):   _Z4SwapRiS_
+1   5528 quicksort(14060):   
+1   5529 quicksort(14060):  
+0   5532 quicksort(14060):  _Z12BadPartitionPiii
+0   5535 quicksort(14060):   _Z4SwapRiS_
+1   5537 quicksort(14060):   
+1   5538 quicksort(14060):  
+0   5541 quicksort(14060):  _Z12BadPartitionPiii
+0   5544 quicksort(14060):   _Z4SwapRiS_
+1   5546 quicksort(14060):   
+0   5549 quicksort(14060):   _Z4SwapRiS_
+1   5550 quicksort(14060):   
+0   5553 quicksort(14060):   _Z4SwapRiS_
+1   5555 quicksort(14060):   
+0   5557 quicksort(14060):   _Z4SwapRiS_
+1   5559 quicksort(14060):   
+0   5562 quicksort(14060):   _Z4SwapRiS_
+1   5564 quicksort(14060):   
+0   5566 quicksort(14060):   _Z4SwapRiS_
+1   5568 quicksort(14060):   
+0   5571 quicksort(14060):   _Z4SwapRiS_
+1   5573 quicksort(14060):   
+0   5575 quicksort(14060):   _Z4SwapRiS_
+1   5577 quicksort(14060):   
+0   5580 quicksort(14060):   _Z4SwapRiS_
+1   5582 quicksort(14060):   
+0   5584 quicksort(14060):   _Z4SwapRiS_
+1   5586 quicksort(14060):   
+0   5589 quicksort(14060):   _Z4SwapRiS_
+1   5590 quicksort(14060):   
+0   5593 quicksort(14060):   _Z4SwapRiS_
+1   5595 quicksort(14060):   
+0   5597 quicksort(14060):   _Z4SwapRiS_
+1   5599 quicksort(14060):   
+0   5602 quicksort(14060):   _Z4SwapRiS_
+1   5604 quicksort(14060):   
+0   5606 quicksort(14060):   _Z4SwapRiS_
+1   5608 quicksort(14060):   
+1   5609 quicksort(14060):  
+0   5612 quicksort(14060):  _Z12BadPartitionPiii
+0   5615 quicksort(14060):   _Z4SwapRiS_
+1   5617 quicksort(14060):   
+1   5618 quicksort(14060):  
+0   5621 quicksort(14060):  _Z12BadPartitionPiii
+0   5624 quicksort(14060):   _Z4SwapRiS_
+1   5626 quicksort(14060):   
+0   5629 quicksort(14060):   _Z4SwapRiS_
+1   5631 quicksort(14060):   
+0   5633 quicksort(14060):   _Z4SwapRiS_
+1   5635 quicksort(14060):   
+0   5638 quicksort(14060):   _Z4SwapRiS_
+1   5639 quicksort(14060):   
+0   5642 quicksort(14060):   _Z4SwapRiS_
+1   5644 quicksort(14060):   
+0   5646 quicksort(14060):   _Z4SwapRiS_
+1   5648 quicksort(14060):   
+0   5651 quicksort(14060):   _Z4SwapRiS_
+1   5653 quicksort(14060):   
+0   5655 quicksort(14060):   _Z4SwapRiS_
+1   5657 quicksort(14060):   
+0   5660 quicksort(14060):   _Z4SwapRiS_
+1   5662 quicksort(14060):   
+0   5664 quicksort(14060):   _Z4SwapRiS_
+1   5666 quicksort(14060):   
+0   5669 quicksort(14060):   _Z4SwapRiS_
+1   5671 quicksort(14060):   
+0   5673 quicksort(14060):   _Z4SwapRiS_
+1   5675 quicksort(14060):   
+0   5678 quicksort(14060):   _Z4SwapRiS_
+1   5679 quicksort(14060):   
+1   5681 quicksort(14060):  
+0   5683 quicksort(14060):  _Z12BadPartitionPiii
+0   5686 quicksort(14060):   _Z4SwapRiS_
+1   5688 quicksort(14060):   
+1   5689 quicksort(14060):  
+0   5692 quicksort(14060):  _Z12BadPartitionPiii
+0   5695 quicksort(14060):   _Z4SwapRiS_
+1   5697 quicksort(14060):   
+0   5700 quicksort(14060):   _Z4SwapRiS_
+1   5702 quicksort(14060):   
+0   5704 quicksort(14060):   _Z4SwapRiS_
+1   5706 quicksort(14060):   
+0   5709 quicksort(14060):   _Z4SwapRiS_
+1   5711 quicksort(14060):   
+0   5713 quicksort(14060):   _Z4SwapRiS_
+1   5715 quicksort(14060):   
+0   5718 quicksort(14060):   _Z4SwapRiS_
+1   5719 quicksort(14060):   
+0   5722 quicksort(14060):   _Z4SwapRiS_
+1   5724 quicksort(14060):   
+0   5726 quicksort(14060):   _Z4SwapRiS_
+1   5728 quicksort(14060):   
+0   5731 quicksort(14060):   _Z4SwapRiS_
+1   5733 quicksort(14060):   
+0   5736 quicksort(14060):   _Z4SwapRiS_
+1   5738 quicksort(14060):   
+0   5740 quicksort(14060):   _Z4SwapRiS_
+1   5742 quicksort(14060):   
+1   5743 quicksort(14060):  
+0   5746 quicksort(14060):  _Z12BadPartitionPiii
+0   5749 quicksort(14060):   _Z4SwapRiS_
+1   5751 quicksort(14060):   
+1   5752 quicksort(14060):  
+0   5755 quicksort(14060):  _Z12BadPartitionPiii
+0   5758 quicksort(14060):   _Z4SwapRiS_
+1   5760 quicksort(14060):   
+0   5763 quicksort(14060):   _Z4SwapRiS_
+1   5765 quicksort(14060):   
+0   5768 quicksort(14060):   _Z4SwapRiS_
+1   5770 quicksort(14060):   
+0   5772 quicksort(14060):   _Z4SwapRiS_
+1   5774 quicksort(14060):   
+0   5777 quicksort(14060):   _Z4SwapRiS_
+1   5779 quicksort(14060):   
+0   5781 quicksort(14060):   _Z4SwapRiS_
+1   5783 quicksort(14060):   
+0   5786 quicksort(14060):   _Z4SwapRiS_
+1   5788 quicksort(14060):   
+0   5790 quicksort(14060):   _Z4SwapRiS_
+1   5792 quicksort(14060):   
+0   5795 quicksort(14060):   _Z4SwapRiS_
+1   5797 quicksort(14060):   
+1   5798 quicksort(14060):  
+0   5800 quicksort(14060):  _Z12BadPartitionPiii
+0   5804 quicksort(14060):   _Z4SwapRiS_
+1   5806 quicksort(14060):   
+1   5807 quicksort(14060):  
+0   5809 quicksort(14060):  _Z12BadPartitionPiii
+0   5813 quicksort(14060):   _Z4SwapRiS_
+1   5815 quicksort(14060):   
+0   5817 quicksort(14060):   _Z4SwapRiS_
+1   5819 quicksort(14060):   
+0   5822 quicksort(14060):   _Z4SwapRiS_
+1   5823 quicksort(14060):   
+0   5826 quicksort(14060):   _Z4SwapRiS_
+1   5828 quicksort(14060):   
+0   5830 quicksort(14060):   _Z4SwapRiS_
+1   5832 quicksort(14060):   
+0   5835 quicksort(14060):   _Z4SwapRiS_
+1   5837 quicksort(14060):   
+0   5839 quicksort(14060):   _Z4SwapRiS_
+1   5841 quicksort(14060):   
+1   5842 quicksort(14060):  
+0   5845 quicksort(14060):  _Z12BadPartitionPiii
+0   5848 quicksort(14060):   _Z4SwapRiS_
+1   5850 quicksort(14060):   
+1   5851 quicksort(14060):  
+0   5854 quicksort(14060):  _Z12BadPartitionPiii
+0   5857 quicksort(14060):   _Z4SwapRiS_
+1   5859 quicksort(14060):   
+0   5862 quicksort(14060):   _Z4SwapRiS_
+1   5863 quicksort(14060):   
+0   5866 quicksort(14060):   _Z4SwapRiS_
+1   5868 quicksort(14060):   
+0   5870 quicksort(14060):   _Z4SwapRiS_
+1   5872 quicksort(14060):   
+0   5875 quicksort(14060):   _Z4SwapRiS_
+1   5877 quicksort(14060):   
+1   5878 quicksort(14060):  
+0   5880 quicksort(14060):  _Z12BadPartitionPiii
+0   5884 quicksort(14060):   _Z4SwapRiS_
+1   5886 quicksort(14060):   
+1   5887 quicksort(14060):  
+0   5889 quicksort(14060):  _Z12BadPartitionPiii
+0   5893 quicksort(14060):   _Z4SwapRiS_
+1   5895 quicksort(14060):   
+0   5897 quicksort(14060):   _Z4SwapRiS_
+1   5899 quicksort(14060):   
+0   5902 quicksort(14060):   _Z4SwapRiS_
+1   5904 quicksort(14060):   
+1   5905 quicksort(14060):  
+0   5907 quicksort(14060):  _Z12BadPartitionPiii
+0   5910 quicksort(14060):   _Z4SwapRiS_
+1   5912 quicksort(14060):   
+1   5913 quicksort(14060):  
+1   5915 quicksort(14060): 
+4   5916 quicksort(14060):BEFORE_CYCLE_end
+1   5965 quicksort(14060):
+end /home/jirka/perun/experiments/quicksort


### PR DESCRIPTION
This PR will add new internal perun storage at '.perun/tmp/' for various temporary data or files that are used during collection, postprocessing etc. The module is expected to be used mostly internally by the developers - however, the module also offers some CLI for other users, so that they can clean or list the contents in a comfortable way.