### PR TITLE
Update the README badges links.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 Perun: Lightweight Performance Version System
 =============================================
 
-![image](https://travis-ci.org/tfiedor/perun.svg?branch=master)
-[![codecov](https://codecov.io/gh/tfiedor/perun/branch/master/graph/badge.svg)](https://codecov.io/gh/tfiedor/perun)
+![build status](https://github.com/Perfexionists/perun/actions/workflows/ubuntu.yml/badge.svg)
+[![codecov](https://codecov.io/gh/Perfexionists/perun/branch/master/graph/badge.svg)](https://codecov.io/gh/Perfexionists/perun)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/c4002ae488f54aabb77920a0cc90b6f5)](https://www.codacy.com/app/tfiedor/perun?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=tfiedor/perun&amp;utm_campaign=Badge_Grade)
-[![Maintainability](https://api.codeclimate.com/v1/badges/233e3e1a434815fee154/maintainability)](https://codeclimate.com/github/tfiedor/perun/maintainability)
-[![GitHub tag](https://img.shields.io/github/tag/tfiedor/perun.svg)](https://github.com/tfiedor/perun)
+[![Maintainability](https://api.codeclimate.com/v1/badges/1e47ad63527d8d2e14c3/maintainability)](https://codeclimate.com/github/Perfexionists/perun/maintainability)
+[![GitHub tag](https://img.shields.io/github/tag/Perfexionists/perun.svg)](https://github.com/Perfexionists/perun)
 
 
 <p align="center">


### PR DESCRIPTION
With the change of ownership of Perun repo to Perfexionists, most of the README badges became out of date.

I managed to fix all of the badges except Codacy, which fails during the attempt to add the repository in the web UI with error `The API responded with an error code 500. The result was not properly formed by the API.` This will likely need to be fixed by @tfiedor?