### PR TITLE
Update the GH Actions branches after the rename.

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -3,10 +3,10 @@ name: Ubuntu (build-&-test)
 on:
   push:
     branches:
-      - develop
+      - devel
   pull_request:
     branches:
-      - develop
+      - devel
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Perun: Lightweight Performance Version System
 =============================================
 
 ![build status](https://github.com/Perfexionists/perun/actions/workflows/ubuntu.yml/badge.svg)
-[![codecov](https://codecov.io/gh/Perfexionists/perun/branch/master/graph/badge.svg)](https://codecov.io/gh/Perfexionists/perun)
+[![codecov](https://codecov.io/gh/Perfexionists/perun/branch/devel/graph/badge.svg)](https://codecov.io/gh/Perfexionists/perun)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/c4002ae488f54aabb77920a0cc90b6f5)](https://www.codacy.com/app/tfiedor/perun?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=tfiedor/perun&amp;utm_campaign=Badge_Grade)
 [![Maintainability](https://api.codeclimate.com/v1/badges/1e47ad63527d8d2e14c3/maintainability)](https://codeclimate.com/github/Perfexionists/perun/maintainability)
 [![GitHub tag](https://img.shields.io/github/tag/Perfexionists/perun.svg)](https://github.com/Perfexionists/perun)
@@ -357,7 +357,7 @@ Links
            this project!
    -   Project documentation:
        - Online: <https://tfiedor.github.io/perun/>
-       - Latest Typeset: <https://github.com/tfiedor/perun/blob/master/docs/pdf/perun.pdf>
+       - Latest Typeset: <https://github.com/tfiedor/perun/blob/devel/docs/pdf/perun.pdf>
      
 Unrelated links:
 


### PR DESCRIPTION
The `develop` branch has been renamed to `devel`, so the GH Actions had to be updated accordingly.