### PR TITLE
tests: Use init.defaultBranch over 'master' as the default branch name

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -248,6 +248,9 @@ def full_profiles():
 def pcs_with_degradations():
     """
     """
+    git_config_parser = git.config.GitConfigParser()
+    git_default_branch_name = git_config_parser.get_value('init', 'defaultBranch', 'master')
+
     pool_path = os.path.join(os.path.split(__file__)[0], 'profiles', 'degradation_profiles')
     profiles = [
         os.path.join(pool_path, 'linear_base.perf'),
@@ -279,7 +282,7 @@ def pcs_with_degradations():
     middle_head = repo.index.commit("second commit")
 
     # Create third commit
-    repo.git.checkout('master')
+    repo.git.checkout(git_default_branch_name)
     file3 = os.path.join(pcs_path, "file3")
     helpers.touch_file(file3)
     repo.index.add([file3])

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -102,6 +102,9 @@ def test_add_on_empty_repo(pcs_with_empty_git, valid_profile_pool, capsys):
 
     Expecting an error and system exist as there is no commit, so nothing can be add.
     """
+    git_config_parser = git.config.GitConfigParser()
+    git_default_branch_name = git_config_parser.get_value('init', 'defaultBranch', 'master')
+
     assert os.getcwd() == os.path.split(pcs_with_empty_git.get_path())[0]
     before_count = test_utils.count_contents_on_path(pcs_with_empty_git.get_path())
 
@@ -116,7 +119,7 @@ def test_add_on_empty_repo(pcs_with_empty_git, valid_profile_pool, capsys):
     # Assert that the error message is OK
     _, err = capsys.readouterr()
     expected = "fatal: while fetching head minor version: " \
-               "Reference at 'refs/heads/master' does not exist"
+               f"Reference at 'refs/heads/{git_default_branch_name}' does not exist"
     assert err.strip() == termcolor.colored(expected, 'red', force_color=True)
 
 

--- a/tests/test_vcs.py
+++ b/tests/test_vcs.py
@@ -22,16 +22,19 @@ def test_major_versions(pcs_full):
 
     Expecting correct behaviour and no error
     """
+    git_config_parser = git.config.GitConfigParser()
+    git_default_branch_name = git_config_parser.get_value('init', 'defaultBranch', 'master')
+
     major_versions = list(vcs.walk_major_versions())
 
     assert len(major_versions) == 1
     major_version = major_versions[0]
-    assert major_version.name == 'master'
+    assert major_version.name == git_default_branch_name
     assert store.is_sha1(major_version.head)
 
     head_major = vcs.get_head_major_version()
     assert not store.is_sha1(str(head_major))
-    assert str(head_major) == 'master'
+    assert str(head_major) == git_default_branch_name
 
     prev_commit = vcs.get_minor_version_info(vcs.get_minor_head()).parents[0]
     git_repo = git.Repo(pcs_full.get_vcs_path())


### PR DESCRIPTION
In git 2.28 it became possible to set the default branch name[0] and having it set to a different value than 'master' can cause issues. Get the default value from the config and if not set, fall back to 'master'.

[0] https://github.com/git/git/blob/master/Documentation/RelNotes/2.28.0.txt
[1] https://sfconservancy.org/news/2020/jun/23/gitbranchname