### PR TITLE
Remove the Codecov token from workflow.

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -52,8 +52,6 @@ jobs:
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           flags: coverage-${{ matrix.python-version }}
           verbose: true


### PR DESCRIPTION
Repository secrets are not working properly for GH Actions triggered by PRs from forked repositories. Although we might need to retry the Codecov upload from time to time due to an upload error, it is still the better solution than to hard-code the token or miss a coverage upload from new contributors.

Sources:
- https://community.codecov.com/t/upload-issues-unable-to-locate-build-via-github-actions-api/3954/15
- https://github.com/codecov/feedback/issues/126