### PR TITLE
Move a helper function to prevent circular dependency

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,4 +2,5 @@ ignore:
   - "perun/collect/trace"
   - "perun/thirdparty"
   - "tests/test_tracer"
+  - "tests/sources"
 

--- a/perun/collect/trace/optimizations/optimization.py
+++ b/perun/collect/trace/optimizations/optimization.py
@@ -3,8 +3,7 @@
 
 import collections
 
-from perun.profile.helpers import sanitize_filepart
-from perun.utils.helpers import SuppressedExceptions
+from perun.utils.helpers import (SuppressedExceptions, sanitize_filepart)
 from perun.collect.trace.optimizations.structs import Optimizations, Pipeline, Parameters, \
     CallGraphTypes, ParametersManager, CGShapingMode
 import perun.collect.trace.optimizations.resources.manager as resources

--- a/perun/logic/runner.py
+++ b/perun/logic/runner.py
@@ -469,7 +469,7 @@ def generate_jobs_on_current_working_dir(
     :param int number_of_jobs: number of jobs that will be run
     :return: status, generated profile, and associated job
     """
-    workload_generators_specs = workloads.load_generator_specifications()
+    workload_generators_specs: dict[str, GeneratorSpec] = workloads.load_generator_specifications()
 
     log.print_job_progress.current_job = 1
     collective_status = CollectStatus.OK

--- a/perun/profile/helpers.py
+++ b/perun/profile/helpers.py
@@ -38,6 +38,7 @@ from perun.utils import get_module
 from perun.utils.exceptions import (
     InvalidParameterException, MissingConfigSectionException, TagOutOfRangeException
 )
+from perun.utils.helpers import sanitize_filepart
 from perun.utils.structs import Unit, Executable, Job
 
 
@@ -56,16 +57,6 @@ def lookup_value(container: dict[str, str] | profiles.Profile, key: str, missing
     :return:
     """
     return str(container.get(key, missing)) or missing
-
-
-def sanitize_filepart(part: str) -> str:
-    """Helper function for sanitization of part of the filenames
-
-    :param part: part of the filename, that needs to be sanitized, i.e. we are removing invalid characters
-    :return: sanitized string representation of the part
-    """
-    invalid_characters = r"# %&{}\<>*?/ $!'\":@"
-    return "".join('_' if c in invalid_characters else c for c in str(part))
 
 
 def lookup_param(profile: profiles.Profile, unit: str, param: str) -> str:

--- a/perun/utils/helpers.py
+++ b/perun/utils/helpers.py
@@ -438,3 +438,13 @@ def safe_match(pattern: re.Pattern[str], searched_string: str, default: str) -> 
     """
     match = pattern.search(searched_string)
     return match.group() if match else default
+
+
+def sanitize_filepart(part: str) -> str:
+    """Helper function for sanitization of part of the filenames
+
+    :param part: part of the filename, that needs to be sanitized, i.e. we are removing invalid characters
+    :return: sanitized string representation of the part
+    """
+    invalid_characters = r"# %&{}\<>*?/ $!'\":@"
+    return "".join("_" if c in invalid_characters else c for c in str(part))

--- a/perun/view/scatter/run.py
+++ b/perun/view/scatter/run.py
@@ -5,7 +5,7 @@ import click
 
 from typing import Any
 
-import perun.profile.helpers as profiles
+from perun.utils.helpers import sanitize_filepart
 import perun.view.scatter.factory as scatter_factory
 from perun.profile.factory import pass_profile, Profile
 from perun.utils import cli_helpers, view_helpers
@@ -105,5 +105,5 @@ def scatter(profile: Profile, filename: str, view_in_browser: bool, **kwargs: An
     # Temporary solution for plotting multiple graphs from one command
     graphs = scatter_factory.create_from_params(profile, **kwargs)
     for uid, graph in graphs:
-        filename_uid = f"{filename}_{profiles.sanitize_filepart(uid)}.html"
+        filename_uid = f"{filename}_{sanitize_filepart(uid)}.html"
         view_helpers.save_view_graph(graph, filename_uid, view_in_browser)


### PR DESCRIPTION
Since the `sanitize_filepart` function does not rely on anything in the `perun.profile` module, it can be safely moved out into a more neutral module.

I encountered the following traceback while playing around with Perun.

```
Traceback (most recent call last):                                                                                                                                                                                                                            
  File "/var/home/marty/.local/bin/perun", line 5, in <module>                                                                                                                                                                                                
    from perun.cli import launch_cli                                                                                                                                                                                                                          
  File "/var/home/marty/Documents/projects/perun/perun/cli.py", line 55, in <module>                                                                                                                                                                          
    import perun.fuzz.factory as fuzz                                                                                                                                                                                                                         
  File "/var/home/marty/Documents/projects/perun/perun/fuzz/factory.py", line 27, in <module>                                                                                                                                                                 
    import perun.fuzz.evaluate.by_perun as evaluate_workloads_by_perun                                                                                                                                                                                        
  File "/var/home/marty/Documents/projects/perun/perun/fuzz/evaluate/by_perun.py", line 8, in <module>                                                                                                                                                        
    import perun.check.factory as check                                                                                                                                                                                                                       
  File "/var/home/marty/Documents/projects/perun/perun/check/factory.py", line 15, in <module>                                                                                                                                                                
    from perun.profile.helpers import ProfileInfo                                                                                                                                                                                                             
  File "/var/home/marty/Documents/projects/perun/perun/profile/helpers.py", line 29, in <module>                                                                                                                                                              
    import perun.logic.store as store                                                                                                                                                                                                                         
  File "/var/home/marty/Documents/projects/perun/perun/logic/store.py", line 22, in <module>                                                                                                                                                                  
    from perun.profile.factory import Profile                                                                                                                                                                                                                 
  File "/var/home/marty/Documents/projects/perun/perun/profile/factory.py", line 25, in <module>                                                                                                                                                              
    from perun.check.general_detection import get_filtered_best_models_of                                                                                                                                                                                     
  File "/var/home/marty/Documents/projects/perun/perun/check/general_detection.py", line 24, in <module>                                                                                                                                                      
    import perun.check.fast_check as fast_check                                                                                                                                                                                                               
  File "/var/home/marty/Documents/projects/perun/perun/check/fast_check.py", line 13, in <module>                                                                                                                                                             
    import perun.logic.runner as runner                                                                                                                                                                                                                       
  File "/var/home/marty/Documents/projects/perun/perun/logic/runner.py", line 27, in <module>                                                                                                                                                                 
    import perun.collect.trace.optimizations.optimization                                                                                                                                                                                                     
  File "/var/home/marty/Documents/projects/perun/perun/collect/trace/optimizations/optimization.py", line 6, in <module>                                                                                                                                      
    from perun.profile.helpers import sanitize_filepart                                                                                                                                                                                                       
ImportError: cannot import name 'sanitize_filepart' from partially initialized module 'perun.profile.helpers' (most likely due to a circular import) (/var/home/marty/Documents/projects/perun/perun/profile/helpers.py)
```