### PR TITLE
Remove demandimport module

### DIFF
--- a/perun/collect/trace/configuration.py
+++ b/perun/collect/trace/configuration.py
@@ -11,10 +11,7 @@ from perun.collect.trace.values import OutputHandling
 
 from perun.utils.exceptions import InvalidBinaryException
 from perun.utils import find_executable
-import perun.logic.temp as temp
-
-# Import on demand since eBPF support is optional
-import perun.collect.trace.ebpf.engine as bpf
+from perun.logic import temp
 
 
 class Configuration:
@@ -113,6 +110,8 @@ class Configuration:
         if self.engine == 'stap':
             self.engine = SystemTapEngine(self)
         else:
+            # Import on demand since eBPF support is optional
+            import perun.collect.trace.ebpf.engine as bpf
             self.engine = bpf.BpfEngine(self)
 
     def get_functions(self):

--- a/perun/collect/trace/configuration.py
+++ b/perun/collect/trace/configuration.py
@@ -3,7 +3,6 @@
 
 import os
 import time
-import demandimport
 
 from perun.collect.trace.collect_engine import CollectEngine
 from perun.collect.trace.systemtap.engine import SystemTapEngine
@@ -15,8 +14,7 @@ from perun.utils import find_executable
 import perun.logic.temp as temp
 
 # Import on demand since eBPF support is optional
-with demandimport.enabled():
-    import perun.collect.trace.ebpf.engine as bpf
+import perun.collect.trace.ebpf.engine as bpf
 
 
 class Configuration:

--- a/perun/fuzz/interpret.py
+++ b/perun/fuzz/interpret.py
@@ -1,12 +1,10 @@
 """ Module contains a set of functions for fuzzing results interpretation."""
 from __future__ import annotations
 
-import demandimport
 import os.path as path
 import difflib
 import scipy.stats.mstats as stats
-with demandimport.enabled():
-    import matplotlib.pyplot as plt
+import matplotlib.pyplot as plt
 
 from typing import TextIO, Optional
 

--- a/perun/logic/store.py
+++ b/perun/logic/store.py
@@ -11,7 +11,6 @@ import os
 import string
 import struct
 import zlib
-import demandimport
 
 from typing import BinaryIO, Optional
 
@@ -22,8 +21,7 @@ from perun.utils.structs import PerformanceChange, DegradationInfo
 from perun.utils.exceptions import IncorrectProfileFormatException
 from perun.profile.factory import Profile
 
-with demandimport.enabled():
-    import hashlib
+import hashlib
 
 
 INDEX_TAG_REGEX = re.compile(r"^(\d+)@i$")

--- a/perun/profile/convert.py
+++ b/perun/profile/convert.py
@@ -25,10 +25,8 @@ import perun.utils.helpers as helpers
 import perun.profile.query as query
 import perun.postprocess.regression_analysis.transform as transform
 
-import demandimport
-with demandimport.enabled():
-    import numpy
-    import pandas
+import numpy
+import pandas
 
 
 

--- a/perun/utils/view_helpers.py
+++ b/perun/utils/view_helpers.py
@@ -6,13 +6,11 @@ from types import ModuleType
 from collections.abc import MutableMapping, Iterable
 
 from enum import Enum
-import demandimport
 
-with demandimport.enabled():
-    from bokeh.plotting import show, output_file
-    import bokeh.palettes as bk_palettes
-    import bokeh.themes.theme as bk_theme
-    import holoviews as hv
+from bokeh.plotting import show, output_file
+import bokeh.palettes as bk_palettes
+import bokeh.themes.theme as bk_theme
+import holoviews as hv
 
 import perun.profile.helpers as profiles
 from perun.utils import log

--- a/perun/view/bars/factory.py
+++ b/perun/view/bars/factory.py
@@ -3,10 +3,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import demandimport
-
-with demandimport.enabled():
-    import holoviews as hv
+import holoviews as hv
 
 from perun.profile import convert
 from perun.utils import view_helpers

--- a/perun/view/flow/factory.py
+++ b/perun/view/flow/factory.py
@@ -3,10 +3,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Hashable, cast, Protocol
 
-import demandimport
-
-with demandimport.enabled():
-    import holoviews as hv
+import holoviews as hv
 
 from perun.profile import convert
 from perun.utils import view_helpers

--- a/perun/view/scatter/factory.py
+++ b/perun/view/scatter/factory.py
@@ -6,13 +6,10 @@ from collections.abc import Iterator
 
 from operator import itemgetter
 
-import demandimport
-
-with demandimport.enabled():
-    import numpy as np
-    import numpy.typing as npt
-    import holoviews as hv
-    from bokeh import palettes
+import numpy as np
+import numpy.typing as npt
+import holoviews as hv
+from bokeh import palettes
 
 from perun.utils import view_helpers
 from perun.profile import query, convert

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,9 +28,6 @@ dependencies = [
     "GitPython>=3.1.30",
     "gitdb>=4.0.10",
 
-    # Lazy imports
-    "demandimport>=0.3.4",
-
     # String / text utilities
     "Faker>=19.3",
     "ruamel.yaml>=0.17",
@@ -140,7 +137,6 @@ module = [
     "scipy.*",
     "sklearn.*",
     "statsmodels.*",
-    "demandimport.*",
     "holoviews.*",
     "bcc.*",
     "binaryornot.*",


### PR DESCRIPTION
The demandimport module relies on the imp module which has been deprecated in Python 3.4[0] and then removed in Python 3.12[1]. Remove it as it is no longer maintained (last commit in 2019), the performance benefit is marginal and optional imports can be managed in alternative ways (such as using try/expect or by utilising a build system).

[0] https://bugs.python.org/issue17177
[1] https://docs.python.org/dev/whatsnew/3.12.html#imp
[2] https://github.com/bwesterb/py-demandimport/commit/ca9c11635407b4b012c4b70f6fe03729b924eacd