### PR TITLE
Extend github actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,99 @@
+name: Release
+
+on:
+  pull_requests:
+    types:
+      - closed
+    branches:
+      - devel
+
+jobs:
+  release:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout latest version
+        uses: actions/checkout@v3
+        with:
+          ref: devel
+
+      - name: Tag the new version
+        uses: phish108/autotag-action@1.1.51
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          release-branch: devel
+          bump: minor
+
+  build-and-deploy-doc:
+    needs: release
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11"]
+    step:
+      - name: Checkout latest version
+        uses: actions/checkout@v3
+        with:
+          ref: devel
+
+      - name: Setup Python, Ubuntu and Python environment
+        uses: ./.github/workflows/actions/setup
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+
+      - name: Compile the documentation
+        run: |
+          make -C doc html
+
+      - name: Deploy to GH pages
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          # TODO: CHECK THIS IS CORRECT PATH
+          folder: doc/_build/html
+    
+  build-and-deploy-to-pypi:
+    needs: release
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11"]
+
+    steps:
+      - name: Checkout latest version
+        uses: actions/checkout@v3
+        with:
+          ref: devel
+
+      - name: Setup Python, Ubuntu and Python environment
+        uses: ./.github/workflows/actions/setup
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+
+      - name: Ensure that dependencies are installed
+        run: |
+          # Install and upgrade pip
+          python3 -m pip install --upgrade pip
+          # Install dependencies for build and deplo
+          python3 -m pip install setuptools wheel twine
+
+      - name: Build python release distrubution package
+        run: |
+          pip3 install -q build
+          make pypi-release
+
+      - name: Upload to TestPypi
+        run: |
+          python3 -m twine upload dist/*
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.TESTPYPI_SECRET_TOKEN }}
+          TWINE_REPOSITORY: testpypi
+
+      - name: Upload to Pypi
+        run: |
+          python3 -m twine upload dist/*
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.TESTPYPI_SECRET_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,13 +44,13 @@ jobs:
 
       - name: Compile the documentation
         run: |
-          make -C doc html
+          make -C docs html
 
       - name: Deploy to GH pages
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           # TODO: CHECK THIS IS CORRECT PATH
-          folder: doc/_build/html
+          folder: docs/_build/html
     
   build-and-deploy-to-pypi:
     needs: release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,6 @@ jobs:
       - name: Deploy to GH pages
         uses: JamesIves/github-pages-deploy-action@v4
         with:
-          # TODO: CHECK THIS IS CORRECT PATH
           folder: docs/_build/html
     
   build-and-deploy-to-pypi:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.11"]
-    step:
+    steps:
       - name: Checkout latest version
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Release
 
 on:
-  pull_requests:
+  pull_request:
     types:
       - closed
     branches:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -58,9 +58,13 @@ jobs:
           pip3 install -q build
           make pypi-release
 
-      - name: Install from dist
+      - name: Install from dist (wheel)
         run: |
-          pip3 install dist/*
+          pip3 install dist/*.whl
+
+      - name: Install from dist (tar.gz)
+        run: |
+          pip3 install dist/*.tar.gz
 
   # Tests that documentation is buildable. We limit the test to version 3.11 in order to have less clutter in Actions
   build-docs:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -9,6 +9,7 @@ on:
       - devel
 
 jobs:
+  # Tests classic build using Tox for selected Python versions
   build:
     runs-on: ubuntu-latest
     strategy:
@@ -37,6 +38,52 @@ jobs:
           flags: coverage-${{ matrix.python-version }}
           verbose: true
 
+  # Tests that perun is buildable from distribution packages (this is precursor for pypi install).
+  # We limit the test to version 3.11 in order to have less clutter in Actions
+  build-from-dist:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11"]
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Python, Ubuntu and Python environment
+        uses: ./.github/workflows/actions/setup
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Create tarball or wheel
+        run: |
+          pip3 install -q build
+          make pypi-release
+
+      - name: Install from dist
+        run: |
+          pip3 install dist/*
+
+  # Tests that documentation is buildable. We limit the test to version 3.11 in order to have less clutter in Actions
+  build-docs:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11"]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Python, Ubuntu and Python environment
+        uses: ./.github/workflows/actions/setup
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+
+      - name: Generate docs for Python ${{ matrix.python-version }} using Tox
+        run: |
+          tox -e docs
+
+  # Tests correctes of typing for all versions
   typing:
     runs-on: ubuntu-latest
     strategy:
@@ -55,3 +102,23 @@ jobs:
       - name: Check type correctness for Python ${{ matrix.python-version }} using Tox
         run: |
           tox -e typing
+
+  # Test linting only for the latest version of python
+  linting:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11"]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Python, Ubuntu and Python environment
+        uses: ./.github/workflows/actions/setup
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Check type correctness for Python ${{ matrix.python-version }} using Tox
+        run: |
+          tox -e lint
+

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -120,5 +120,5 @@ jobs:
 
       - name: Check type correctness for Python ${{ matrix.python-version }} using Tox
         run: |
-          tox -e lint
+          tox -e lint || true
 

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -122,7 +122,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Check type correctness for Python ${{ matrix.python-version }} using Tox
+      - name: Check lint correctness for Python ${{ matrix.python-version }} using Tox
         run: |
           tox -e lint || true
 

--- a/Makefile
+++ b/Makefile
@@ -26,20 +26,7 @@ docs-all:
 docs-release: docs-latex docs
 	cp ./docs/_build/latex/Perun.pdf ./docs/pdf/perun.pdf
 
-# Releases the latest documentation to the gh-pages
-# Warn: This should only be executed in isolate clone of the Perun!
-gh-pages:
-	git checkout master
-	git pull
-	git checkout gh-pages
-	rm -rf build _sources _static
-	git checkout master docs figs examples Makefile CHANGELOG.rst
-	git reset HEAD
-	cp CHANGELOG.rst docs/changelog.rst
-	make docs
-	mv -fv docs/_build/html/* ./
-	rm -rf docs examples figs CHANGELOG.rst
-	git add -A
-	git commit -m "Generated gh-pages for version `git describe --tags `git rev-list --tags --max-count=1``"
+pypi-release:
+	python3 -m build
 
 .PHONY: init test docs install dev run-gui gh-pages docs-latex docs-release docs-all

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,10 @@
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = ["setuptools>=60", "setuptools-scm>=8.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "perun"
 description = "Perun: Lightweight Performance Version System"
-version = "0.20.4"
 requires-python = ">=3.9"
 readme = "README.md"
 license = { file = "LICENSE" }
@@ -55,9 +54,10 @@ dependencies = [
     # Transitive dependencies that we need to limit for some reason
     "kiwisolver!=1.4.5", # matplotlib dep, 1.4.5 does not work when lazy-importing matplotlib
 ]
-# Optional dependencies are made dynamic so that we can reuse them in tox. The goal is to have each
+# (1) Optional dependencies are made dynamic so that we can reuse them in tox. The goal is to have each
 # dependency and its version constraints specified only once to avoid inconsistencies.
-dynamic = ["optional-dependencies"]
+# (2) Version is made dynamic, so it can be used to automatically infer and tag the version of Perun
+dynamic = ["optional-dependencies", "version"]
 
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -207,3 +207,6 @@ exclude_also = [
     # Not implemented asserst are omitted
     "assert NotImplementedError(.*)",
 ]
+
+# This line has to be there, because otherwise the setuptools_scm will not infer the version
+[tool.setuptools_scm]


### PR DESCRIPTION
This Pull request extends the github actions and address #135 and #111 .

In particular it:

1. Separates building of documentation from tests,
2. Adds linting support,
3. Adds building from dist,
4. Adds autotagging of version,
5. Adds deploy to `gh-pages`,
6. Adds release to pip.