### PR TITLE
Add logging to commands

### DIFF
--- a/perun/cli.py
+++ b/perun/cli.py
@@ -119,7 +119,7 @@ DEV_MODE = False
     "-ld",
     type=click.Path(resolve_path=True, writable=True),
     callback=cli_kit.set_config_option_from_flag(
-        pcs.local_config, "path.logs", cli_kit.process_target_dir
+        perun_config.runtime, "path.logs", cli_kit.process_target_dir
     ),
     help="Ouputs logs to different directory (default=`.perun/logs`).",
 )

--- a/perun/cli.py
+++ b/perun/cli.py
@@ -107,6 +107,23 @@ DEV_MODE = False
     help="Disables the colored output.",
 )
 @click.option(
+    "--log",
+    "-l",
+    "log_output",
+    default=False,
+    is_flag=True,
+    help="Logs output of commands to log directory.",
+)
+@click.option(
+    "--log-dir",
+    "-ld",
+    type=click.Path(resolve_path=True, writable=True),
+    callback=cli_kit.set_config_option_from_flag(
+        pcs.local_config, "path.logs", cli_kit.process_target_dir
+    ),
+    help="Ouputs logs to different directory (default=`.perun/logs`).",
+)
+@click.option(
     "--say-yes", "-y", default=False, is_flag=True, help="Says yes to every confirmation prompt"
 )
 @click.option(
@@ -140,13 +157,14 @@ DEV_MODE = False
 )
 @click.pass_context
 def cli(
-    ctx: click.Context,
+    _: click.Context,
     dev_mode: bool = False,
     no_color: bool = False,
     say_yes: bool = False,
+    log_output: bool = False,
     verbose: int = 0,
     no_pager: bool = False,
-    **_: Any,
+    **__: Any,
 ) -> None:
     """Perun is an open source light-weight Performance Versioning System.
 
@@ -177,6 +195,7 @@ def cli(
     common_kit.ALWAYS_CONFIRM = say_yes
     perun_log.SUPPRESS_PAGING = no_pager
     perun_log.COLOR_OUTPUT = not no_color
+    perun_log.LOGGING = log_output
 
     # set the verbosity level of the log
     if perun_log.VERBOSITY < verbose:

--- a/perun/utils/common/cli_kit.py
+++ b/perun/utils/common/cli_kit.py
@@ -50,6 +50,16 @@ def print_version(_: click.Context, __: click.Option, value: bool) -> None:
         exit(0)
 
 
+def process_target_dir(value: str) -> str:
+    """Helper function for processing target dir and creating subdirs
+
+    :param value: passed value
+    :retrun: valid path with created directories
+    """
+    common_kit.touch_dir(value)
+    return value
+
+
 def process_bokeh_axis_title(
     ctx: click.Context, param: click.Option, value: Optional[str]
 ) -> Optional[str]:

--- a/perun/utils/external/commands.py
+++ b/perun/utils/external/commands.py
@@ -11,6 +11,7 @@ from collections import defaultdict
 import os
 import shlex
 import subprocess
+import time
 
 # Third-Party Imports
 
@@ -30,7 +31,12 @@ def save_output_of_command(command: str, content: bytes, extension: str = "out")
     :param extension: extension of the saved log (to differentiated between stderr and stdout)
     """
     if log.LOGGING:
-        log_directory = config.lookup_key_recursively("path.logs", default=pcs.get_log_directory())
+        log_directory = config.lookup_key_recursively("path.logs", "")
+        if log_directory == "":
+            log_directory = os.path.join(
+                pcs.get_log_directory(), time.strftime("%Y-%m-%d-%H-%M-%S", time.gmtime())
+            )
+            common_kit.touch_dir(log_directory)
         log_file = common_kit.sanitize_filepart(command.split()[0])
         log_file_cache[f"{log_file}.{extension}"] += 1
         log_no = log_file_cache[f"{log_file}.{extension}"]

--- a/perun/utils/log.py
+++ b/perun/utils/log.py
@@ -24,7 +24,6 @@ import termcolor
 from perun.utils import decorators
 from perun.utils.common import common_kit
 from perun.utils.common.common_kit import (
-    COLLECT_PHASE_ATTRS,
     DEGRADATION_ICON,
     OPTIMIZATION_ICON,
     CHANGE_CMD_COLOUR,
@@ -46,6 +45,7 @@ if TYPE_CHECKING:
 
 
 VERBOSITY: int = 0
+LOGGING: bool = False
 COLOR_OUTPUT: bool = True
 CURRENT_INDENT: int = 0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ dependencies = [
     "pandas>=2.0",
     "statsmodels>=0.14",
     "scikit-learn>=1.3",
-    "scipy>=1.10", # 1.11+ dropped support for Python 3.8
+    "scipy>=1.10,<1.14", # 1.11+ dropped support for Python 3.8
     "networkx>=3.1",
 
     # Plotting / visualization / output

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -525,6 +525,7 @@ def setup():
 
     # Reset the verbosity to release
     log.VERBOSITY = 0
+    log.LOGGING = False
     log.CURRENT_INDENT = 0
     log.SUPPRESS_PAGING = True
     # We disable the metrics by default, since they might slow down tests

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1412,6 +1412,25 @@ def test_collect_correct(pcs_with_root):
     result = runner.invoke(cli.collect, ["-c echo", "-w hello", "bounds", "-s", f"{src_file}"])
     asserts.predicate_from_cli(result, result.exit_code == 0)
 
+    assert len(os.listdir(os.path.join(".perun", "logs"))) == 0
+    result = runner.invoke(
+        cli.cli,
+        [
+            "--log",
+            "collect",
+            "-c echo",
+            "-w hello",
+            "-o",
+            "prof3.perf",
+            "time",
+            "--repeat=1",
+            "--warmup=1",
+        ],
+    )
+    asserts.predicate_from_cli(result, result.exit_code == 0)
+    assert "prof3.perf" in os.listdir(".")
+    assert len(os.listdir(os.path.join(".perun", "logs"))) == 1
+
     assert "log" not in os.listdir(".")
     result = runner.invoke(
         cli.cli,
@@ -1423,14 +1442,14 @@ def test_collect_correct(pcs_with_root):
             "-c echo",
             "-w hello",
             "-o",
-            "prof.perf",
+            "prof2.perf",
             "time",
             "--repeat=1",
             "--warmup=1",
         ],
     )
     asserts.predicate_from_cli(result, result.exit_code == 0)
-    assert "prof.perf" in os.listdir(".")
+    assert "prof2.perf" in os.listdir(".")
     assert "log" in os.listdir(".")
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1412,6 +1412,27 @@ def test_collect_correct(pcs_with_root):
     result = runner.invoke(cli.collect, ["-c echo", "-w hello", "bounds", "-s", f"{src_file}"])
     asserts.predicate_from_cli(result, result.exit_code == 0)
 
+    assert "log" not in os.listdir(".")
+    result = runner.invoke(
+        cli.cli,
+        [
+            "--log",
+            "--log-dir",
+            "./log",
+            "collect",
+            "-c echo",
+            "-w hello",
+            "-o",
+            "prof.perf",
+            "time",
+            "--repeat=1",
+            "--warmup=1",
+        ],
+    )
+    asserts.predicate_from_cli(result, result.exit_code == 0)
+    assert "prof.perf" in os.listdir(".")
+    assert "log" in os.listdir(".")
+
 
 def test_show_help(pcs_with_root):
     """Test running show to see if there are registered modules for showing


### PR DESCRIPTION
This PR adds to core comman following options:

1. Adds `--log` option for logging output of commands to directory
2. Adds `--log-dir` option for chaning the directory of logs.

By default, we save the logs to `.perun/logs/DATE` directory.