### PR TITLE
Add SVS version control system

### DIFF
--- a/docs/_static/templates/supported_module_names.py
+++ b/docs/_static/templates/supported_module_names.py
@@ -3,7 +3,7 @@ def get_supported_module_names(package):
     if package not in ("vcs", "collect", "postprocess", "view"):
         error(f"trying to call get_supported_module_names with incorrect package '{package}'")
     return {
-        "vcs": ["git"],
+        "vcs": ["git", "svs"],
         "collect": ["trace", "memory", "time"],
         "postprocess": [
             "moving-average",

--- a/docs/_static/templates/supported_module_names_collectors.py
+++ b/docs/_static/templates/supported_module_names_collectors.py
@@ -3,7 +3,7 @@ def get_supported_module_names(package):
     if package not in ("vcs", "collect", "postprocess", "view"):
         error(f"trying to call get_supported_module_names with incorrect package '{package}'")
     return {
-        "vcs": ["git"],
+        "vcs": ["git", "svs"],
         "collect": ["trace", "memory", "time", "mycollector"],
         "postprocess": [
             "moving-average",

--- a/docs/_static/templates/supported_module_names_vcs.py
+++ b/docs/_static/templates/supported_module_names_vcs.py
@@ -3,7 +3,7 @@ def get_supported_module_names(package):
     if package not in ("vcs", "collect", "postprocess", "view"):
         error(f"trying to call get_supported_module_names with incorrect package '{package}'")
     return {
-        "vcs": ["git", "myvcs"],
+        "vcs": ["git", "svs", "myvcs"],
         "collect": ["trace", "memory", "time"],
         "postprocess": [
             "moving-average",

--- a/docs/_static/templates/supported_module_names_views.py
+++ b/docs/_static/templates/supported_module_names_views.py
@@ -3,7 +3,7 @@ def get_supported_module_names(package):
     if package not in ("vcs", "collect", "postprocess", "view"):
         error(f"trying to call get_supported_module_names with incorrect package '{package}'")
     return {
-        "vcs": ["git"],
+        "vcs": ["git", "svs"],
         "collect": ["trace", "memory", "time"],
         "postprocess": [
             "moving-average",

--- a/perun/cli.py
+++ b/perun/cli.py
@@ -218,11 +218,11 @@ def configure_local_perun(perun_path: str) -> None:
 @click.option(
     "--vcs-type",
     metavar="<type>",
-    default="git",
+    default="svs",
     type=click.Choice(cli_kit.get_supported_module_names("vcs")),
     help=(
         "In parallel to initialization of Perun, initialize the vcs"
-        " of <type> as well (by default ``git``)."
+        " of <type> as well (by default ``svs``)."
     ),
 )
 @click.option(

--- a/perun/logic/pcs.py
+++ b/perun/logic/pcs.py
@@ -20,6 +20,7 @@ from perun.utils import decorators
 from perun.utils.common import common_kit
 from perun.utils.exceptions import NotPerunRepositoryException, UnsupportedModuleException
 from perun.vcs.abstract_repository import AbstractRepository
+from perun.vcs.svs_repository import SvsRepository
 from perun.vcs.git_repository import GitRepository
 
 
@@ -57,6 +58,8 @@ def vcs() -> AbstractRepository:
     vcs_type, vcs_url = get_vcs_type_and_url()
     if vcs_type == "git":
         return GitRepository(vcs_url)
+    elif vcs_type == "svs":
+        return SvsRepository(vcs_url)
     raise UnsupportedModuleException(vcs_type)
 
 

--- a/perun/utils/common/cli_kit.py
+++ b/perun/utils/common/cli_kit.py
@@ -924,7 +924,7 @@ def get_supported_module_names(package: str) -> list[str]:
     if package not in ("vcs", "collect", "postprocess", "view"):
         log.error(f"trying to call get_supported_module_names with incorrect package '{package}'")
     return {
-        "vcs": ["git"],
+        "vcs": ["git", "svs"],
         "collect": ["trace", "memory", "time", "complexity", "bounds", "kperf"],
         "postprocess": [
             "clusterizer",

--- a/perun/utils/mapping.py
+++ b/perun/utils/mapping.py
@@ -22,9 +22,17 @@ def get_readable_key(key: str) -> str:
     """
     profiles = config.runtime().get("context.profiles")
     if key == "amount":
-        if all(p.get("collector_info", {}).get("name") == "kperf" for p in profiles):
+        if all(
+            p.get("collector_info", {}).get("name") == "kperf"
+            for p in profiles
+            if "collector_info" in p
+        ):
             return "Inclusive Samples [#]"
-        if all(p.get("collector_info", {}).get("name") == "memory" for p in profiles):
+        if all(
+            p.get("collector_info", {}).get("name") == "memory"
+            for p in profiles
+            if "collector_info" in p
+        ):
             return "Allocated Memory [B]"
     if key == "ncalls":
         return "Number of Calls [#]"

--- a/perun/vcs/meson.build
+++ b/perun/vcs/meson.build
@@ -4,6 +4,7 @@ perun_vcs_files = files(
     '__init__.py',
     'abstract_repository.py',
     'git_repository.py',
+    'svs_repository.py',
     'vcs_kit.py'
 )
 

--- a/perun/vcs/svs_repository.py
+++ b/perun/vcs/svs_repository.py
@@ -1,0 +1,103 @@
+"""SVS is a dummy Single Version System, which tracks the results as a single version, nothing more
+
+Contains concrete implementation of the functions needed by Perun to work without any version control system,
+like GIT, SVN, or other.
+"""
+
+from __future__ import annotations
+
+# Standard Imports
+from typing import Any, Iterator
+import getpass
+import os
+import socket
+import sys
+import time
+
+
+# Third-Party Imports
+
+# Perun Imports
+from perun.utils.structs import MajorVersion, MinorVersion
+from perun.vcs.abstract_repository import AbstractRepository
+
+SINGLE_VERSION_BRANCH: str = "master"
+SINGLE_VERSION_TAG: str = "HEAD"
+
+
+def get_time_of_creation(path: str) -> str:
+    return time.ctime(
+        os.path.getctime(path) if sys.platform.startswith("win") else os.stat(path).st_ctime
+    )
+
+
+class SvsRepository(AbstractRepository):
+    def __init__(self, vcs_path: str) -> None:
+        super().__init__()
+        self.vcs_path: str = vcs_path
+
+    def get_minor_head(self) -> str:
+        """Returns always single version tag --- the same version"""
+        return SINGLE_VERSION_TAG
+
+    def init(self, _: dict[str, Any]) -> bool:
+        """Svs is always initialized"""
+        return True
+
+    def walk_minor_versions(self, _: str) -> Iterator[MinorVersion]:
+        """Yield single version"""
+        yield self.get_minor_version_info(SINGLE_VERSION_TAG)
+
+    def walk_major_versions(self) -> Iterator[MajorVersion]:
+        """Yields single branch with single version"""
+        yield MajorVersion(SINGLE_VERSION_BRANCH, SINGLE_VERSION_TAG)
+
+    def get_minor_version_info(self, minor_version: str) -> MinorVersion:
+        """Returns valid minor version info only for a SINGLE_VERSION TAG"""
+        assert minor_version == SINGLE_VERSION_TAG, f"unknown version `{minor_version}`"
+        return MinorVersion(
+            get_time_of_creation(self.vcs_path),
+            getpass.getuser(),
+            f"{getpass.getuser()}@{socket.gethostname()}",
+            SINGLE_VERSION_TAG,
+            "Singleton version",
+            [],
+        )
+
+    def minor_versions_diff(self, baseline_minor_version: str, target_minor_version: str) -> str:
+        """There is no diff, as there is single version"""
+        assert (
+            baseline_minor_version == target_minor_version
+        ), f"{baseline_minor_version} or {target_minor_version} is unsupported"
+        assert (
+            baseline_minor_version == SINGLE_VERSION_TAG
+        ), f"{baseline_minor_version} is unsupported"
+        return ""
+
+    def get_head_major_version(self) -> str:
+        """Returns single branch"""
+        return SINGLE_VERSION_BRANCH
+
+    def check_minor_version_validity(self, minor_version: str) -> None:
+        """Only SINGLE_VERSION_TAG is valid minor version in SVS"""
+        assert minor_version == SINGLE_VERSION_TAG, f"invalid minor version {minor_version}"
+
+    def massage_parameter(self, parameter: str, _: str | None = None) -> str:
+        """No massaging in SVS"""
+        return parameter
+
+    def is_dirty(self) -> bool:
+        """Nothing is really tracked, so it is never dirty"""
+        return False
+
+    def save_state(self) -> tuple[bool, str]:
+        """Nothing was stashed, and we are still on the same version"""
+        return False, SINGLE_VERSION_TAG
+
+    def restore_state(self, _: bool, __: str) -> None:
+        """Nothing to restore"""
+        pass
+
+    def checkout(self, _: str) -> None:
+        """There is single version, so nothing is checked out"""
+        pass

--- a/perun/vcs/svs_repository.py
+++ b/perun/vcs/svs_repository.py
@@ -26,34 +26,73 @@ SINGLE_VERSION_TAG: str = "HEAD"
 
 
 def get_time_of_creation(path: str) -> str:
+    """Returns the time of the creation of the path
+
+    :param path: path we are analysing the time of creation
+    :return: time of creation of the path
+    """
     return time.ctime(
         os.path.getctime(path) if sys.platform.startswith("win") else os.stat(path).st_ctime
     )
 
 
 class SvsRepository(AbstractRepository):
+    """Single Version Repository is simple singleton version control system.
+
+    It has following properties:
+      1. It has single branch
+      2. It has single version
+
+    No changes are made, no changes are tracked, only a singleton state is maintained.
+    """
+
     def __init__(self, vcs_path: str) -> None:
+        """Inits the SVS by remembering its path"""
         super().__init__()
         self.vcs_path: str = vcs_path
 
     def get_minor_head(self) -> str:
-        """Returns always single version tag --- the same version"""
+        """Returns always single version tag --- the same version
+
+        :return: minor head, the single version that is tracked in SVS
+        """
         return SINGLE_VERSION_TAG
 
     def init(self, _: dict[str, Any]) -> bool:
-        """Svs is always initialized"""
+        """Svs is always initialized
+
+        :param _: params for initialization
+        :return: always true, since nothing is initialied
+        """
         return True
 
     def walk_minor_versions(self, _: str) -> Iterator[MinorVersion]:
-        """Yield single version"""
+        """Yield single version
+
+        :param _: head minor version, we are starting the walk
+        :return: iterator of single minor version
+        """
         yield self.get_minor_version_info(SINGLE_VERSION_TAG)
 
     def walk_major_versions(self) -> Iterator[MajorVersion]:
-        """Yields single branch with single version"""
+        """Yields single branch with single version
+
+        :return: iterator of single major version
+        """
         yield MajorVersion(SINGLE_VERSION_BRANCH, SINGLE_VERSION_TAG)
 
     def get_minor_version_info(self, minor_version: str) -> MinorVersion:
-        """Returns valid minor version info only for a SINGLE_VERSION TAG"""
+        """Returns valid minor version info only for a SINGLE_VERSION TAG
+
+        We return:
+          1. The current user
+          2. His email as user@hostname
+          3. Time of creation of perun instance
+          4. The single tag and simple description
+
+        :param minor_version: minor version we are analysing
+        :return information about single version.
+        """
         assert minor_version == SINGLE_VERSION_TAG, f"unknown version `{minor_version}`"
         return MinorVersion(
             get_time_of_creation(self.vcs_path),
@@ -65,7 +104,12 @@ class SvsRepository(AbstractRepository):
         )
 
     def minor_versions_diff(self, baseline_minor_version: str, target_minor_version: str) -> str:
-        """There is no diff, as there is single version"""
+        """There is no diff, as there is single version
+
+        :param baseline_minor_version: baseline version
+        :param target_minor_version: target version
+        :return: empty diff
+        """
         assert (
             baseline_minor_version == target_minor_version
         ), f"{baseline_minor_version} or {target_minor_version} is unsupported"
@@ -75,29 +119,53 @@ class SvsRepository(AbstractRepository):
         return ""
 
     def get_head_major_version(self) -> str:
-        """Returns single branch"""
+        """Returns single branch
+
+        :return: single branch
+        """
         return SINGLE_VERSION_BRANCH
 
     def check_minor_version_validity(self, minor_version: str) -> None:
-        """Only SINGLE_VERSION_TAG is valid minor version in SVS"""
+        """Only SINGLE_VERSION_TAG is valid minor version in SVS
+
+        :param minor_version: minor version for which we are checking the validity
+        """
         assert minor_version == SINGLE_VERSION_TAG, f"invalid minor version {minor_version}"
 
     def massage_parameter(self, parameter: str, _: str | None = None) -> str:
-        """No massaging in SVS"""
+        """No massaging in SVS
+
+        :param param: massaged parameter
+        :param _: type of the massaged parameter
+        :return: the same string
+        """
         return parameter
 
     def is_dirty(self) -> bool:
-        """Nothing is really tracked, so it is never dirty"""
+        """Nothing is really tracked, so it is never dirty
+
+        :return: false since the SVS is never dirty
+        """
         return False
 
     def save_state(self) -> tuple[bool, str]:
-        """Nothing was stashed, and we are still on the same version"""
+        """Nothing was stashed, and we are still on the same version
+
+        :return: nothing was stashed, and we are still on the same version
+        """
         return False, SINGLE_VERSION_TAG
 
     def restore_state(self, _: bool, __: str) -> None:
-        """Nothing to restore"""
+        """Nothing to restore
+
+        :param _: whether something was stashed
+        :param __: to which version should we check out
+        """
         pass
 
     def checkout(self, _: str) -> None:
-        """There is single version, so nothing is checked out"""
+        """There is single version, so nothing is checked out
+
+        :param _: version we are checking out to
+        """
         pass

--- a/perun/vcs/svs_repository.py
+++ b/perun/vcs/svs_repository.py
@@ -161,11 +161,9 @@ class SvsRepository(AbstractRepository):
         :param _: whether something was stashed
         :param __: to which version should we check out
         """
-        pass
 
     def checkout(self, _: str) -> None:
         """There is single version, so nothing is checked out
 
         :param _: version we are checking out to
         """
-        pass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -492,6 +492,25 @@ def pcs_with_root():
 
 
 @pytest.fixture(scope="function")
+def pcs_with_svs():
+    """
+    *
+    """
+    # Change working dir into the temporary directory
+    pcs_path = tempfile.mkdtemp()
+    os.chdir(pcs_path)
+    commands.init_perun_at(pcs_path, False, {"vcs": {"url": "../", "type": "svs"}})
+
+    # Initialize git
+    pcs.vcs().init({})
+
+    yield pcs
+
+    # clean up the directory
+    shutil.rmtree(pcs_path)
+
+
+@pytest.fixture(scope="function")
 def pcs_without_vcs():
     """ """
     # Change working dir into the temporary directory

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2603,3 +2603,27 @@ def test_try_init_error(monkeypatch):
     asserts.predicate_from_cli(result, result.exit_code == 1)
     assert "Initializing Perun" in result.output
     assert "Creating empty commit - failed" in common_kit.escape_ansi(result.output)
+
+
+@pytest.mark.usefixtures("cleandir")
+def test_svs():
+    """Test running init from cli, without any problems
+
+    Expecting no exceptions, no errors, zero status.
+    """
+    runner = CliRunner()
+    dst = str(os.getcwd())
+    result = runner.invoke(cli.init, [dst])
+    asserts.predicate_from_cli(result, result.exit_code == 0)
+
+    result = runner.invoke(cli.collect, ["-c echo", "-w hello", "-o", "prof.perf", "kperf"])
+    asserts.predicate_from_cli(result, result.exit_code == 0)
+    assert "prof.perf" in os.listdir(".")
+
+    result = runner.invoke(cli.collect, ["-c echo", "-w world", "-o", "prof2.perf", "kperf"])
+    asserts.predicate_from_cli(result, result.exit_code == 0)
+    assert "prof2.perf" in os.listdir(".")
+
+    result = runner.invoke(cli.showdiff, ["prof.perf", "prof2.perf", "report", "-o", "diff"])
+    asserts.predicate_from_cli(result, result.exit_code == 0)
+    assert "diff.html" in os.listdir(".")

--- a/tests/test_vcs.py
+++ b/tests/test_vcs.py
@@ -139,8 +139,9 @@ def test_svs(pcs_with_svs):
 
     assert svs.get_head_major_version() == svs_repository.SINGLE_VERSION_BRANCH
     assert svs.is_dirty() == False
-    assert svs.check_minor_version_validity(svs_repository.SINGLE_VERSION_TAG) == True
-    assert svs.check_minor_version_validity("hello") == False
+    svs.check_minor_version_validity(svs_repository.SINGLE_VERSION_TAG)
+    with pytest.raises(AssertionError):
+        svs.check_minor_version_validity("hello")
     assert (
         svs.massage_parameter(svs_repository.SINGLE_VERSION_TAG, "commit")
         == svs_repository.SINGLE_VERSION_TAG

--- a/tests/test_vcs.py
+++ b/tests/test_vcs.py
@@ -1,4 +1,5 @@
 """Basic tests for checking the correctness of the VCS modules"""
+
 from __future__ import annotations
 
 # Standard Imports
@@ -110,3 +111,8 @@ def test_diffs(pcs_full_no_prof):
 def test_abstract_base():
     with pytest.raises(TypeError):
         _ = AbstractRepository()
+
+
+def test_svs(pcs_with_svs):
+    """Tests working with svs"""
+    assert False


### PR DESCRIPTION
This PR adds SVS version control, that is made as a default:

1. SVS has single branch and single version, that tracks nothing.
2. SVS is made default and is intented for gitless usage and version-less usage of perun.