### PR TITLE
Bump dependencies for Python 3.9 and fix related dependency issues

### DIFF
--- a/perun/check/methods/integral_comparison.py
+++ b/perun/check/methods/integral_comparison.py
@@ -67,7 +67,7 @@ def compute_nparam_integral(x_pts: list[float], y_pts: list[float]) -> float:
     :param list y_pts: list of y-coordinates from non-parametric model
     :return float: the value of integral computed using samples
     """
-    return integrate.simps(y_pts, x_pts, even="avg")
+    return integrate.simpson(y_pts, x=x_pts)
 
 
 def execute_analysis(

--- a/perun/check/methods/local_statistics.py
+++ b/perun/check/methods/local_statistics.py
@@ -102,7 +102,7 @@ def compute_window_stats(
     # compute the all statistical metrics on the specified intervals
     return {
         # integral
-        "int": np.atleast_1d(integrate.simps(y_array, x_array, axis=axis, even="avg")),
+        "int": np.atleast_1d(integrate.simpson(y_array, x=x_array, axis=axis)),
         # average/mean
         "avg": np.atleast_1d(np.nanmean(y_array, axis=axis)),
         # median/2.percentile

--- a/perun/postprocess/kernel_regression/methods.py
+++ b/perun/postprocess/kernel_regression/methods.py
@@ -288,8 +288,8 @@ def kernel_smoothing(
     :return dict: the output dictionary with result of kernel regression
     """
     # Retype the coordinated list for requirements of computational class
-    x_pts = np.asanyarray(in_x_pts, dtype=np.float_)
-    y_pts = np.asanyarray(in_y_pts, dtype=np.float_)
+    x_pts = np.asanyarray(in_x_pts, dtype=np.float64)
+    y_pts = np.asanyarray(in_y_pts, dtype=np.float64)
 
     # Obtaining the kernel instance from supported types according to the given name
     kernel = _KERNEL_TYPES_MAPS[config["kernel_type"]]
@@ -354,8 +354,8 @@ def kernel_ridge(
     :return dict: the output dictionary with result of kernel regression
     """
     # Retype the coordinated list for requirements of computational class
-    x_pts = np.asanyarray(in_x_pts, dtype=np.float_).reshape(-1, 1)
-    y_pts = np.asanyarray(in_y_pts, dtype=np.float_)
+    x_pts = np.asanyarray(in_x_pts, dtype=np.float64).reshape(-1, 1)
+    y_pts = np.asanyarray(in_y_pts, dtype=np.float64)
 
     # Obtaining the edges of the given range
     low_boundary = config["gamma_range"][0]

--- a/perun/postprocess/regressogram/methods.py
+++ b/perun/postprocess/regressogram/methods.py
@@ -9,7 +9,9 @@ import inspect
 
 # Third-Party Imports
 import numpy as np
-import numpy.lib.histograms as numpy_bucket_selectors
+
+# TODO: could this be replaced with numpy.histogram_bin_edges?
+import numpy.lib._histograms_impl as numpy_bucket_selectors
 import scipy.stats
 import sklearn.metrics
 

--- a/perun/testing/mock_results.py
+++ b/perun/testing/mock_results.py
@@ -221,13 +221,6 @@ _LREG_EXPECTED_RESULTS = [
 
 INTEGRAL_COMPARISON_RESULTS = [
     DegradationInfo(res=pc.MaybeOptimization, loc="alloc", fb="constant", tt="constant", rd=-0.18),
-    DegradationInfo(
-        res=pc.MaybeDegradation,
-        loc="alloc",
-        fb="regressogram",
-        tt="regressogram",
-        rd=0.16,
-    ),
     DegradationInfo(res=pc.Degradation, loc="ga_grow", fb="constant", tt="constant", rd=1210.03),
     DegradationInfo(res=pc.Degradation, loc="ga_init2", fb="quadratic", tt="quadratic", rd=2.33),
     DegradationInfo(res=pc.Degradation, loc="skipwhite", fb="constant", tt="constant", rd=0.30),
@@ -243,14 +236,14 @@ INTEGRAL_COMPARISON_RESULTS = [
         loc="test_for_static",
         fb="moving_average",
         tt="moving_average",
-        rd=0.91,
+        rd=1.22,
     ),
     DegradationInfo(
         res=pc.MaybeDegradation,
         loc="test_for_static",
         fb="regressogram",
         tt="regressogram",
-        rd=0.16,
+        rd=0.11,
     ),
     DegradationInfo(
         res=pc.MaybeDegradation,
@@ -264,7 +257,7 @@ INTEGRAL_COMPARISON_RESULTS = [
         loc="vim_regexec",
         fb="regressogram",
         tt="regressogram",
-        rd=0.42,
+        rd=0.27,
     ),
 ]
 
@@ -276,14 +269,6 @@ LOCAL_STATISTICS_RESULTS = [
         tt="constant",
         rd=-0.16,
         pi=[(pc.MaybeOptimization, -0.16, 5.45, 5.45)],
-    ),
-    DegradationInfo(
-        res=pc.MaybeDegradation,
-        loc="alloc",
-        fb="regressogram",
-        tt="regressogram",
-        rd=0.11,
-        pi=[(pc.MaybeDegradation, 0.11, 0.0, 275.0)],
     ),
     DegradationInfo(
         res=pc.Degradation,

--- a/perun/thirdparty/pyqt_fit_port/kernels.py
+++ b/perun/thirdparty/pyqt_fit_port/kernels.py
@@ -367,7 +367,7 @@ class Kernel1D:
 
             K_0(z) = \int_{-\infty}^z K(t) dt
         """
-        z = np.asfarray(z)
+        z = np.asarray(z, dtype=float)
         try:
             comp_pdf = self.__comp_pdf
         except AttributeError:
@@ -399,7 +399,7 @@ class Kernel1D:
 
             K_1(z) = \int_{-\infty}^z z K(t) dt
         """
-        z = np.asfarray(z)
+        z = np.asarray(z, dtype=float)
         try:
             comp_pm1 = self.__comp_pm1
         except AttributeError:
@@ -430,7 +430,7 @@ class Kernel1D:
 
             K_2(z) = \int_{-\infty}^z z^2 K(t) dt
         """
-        z = np.asfarray(z)
+        z = np.asarray(z, dtype=float)
         try:
             comp_pm2 = self.__comp_pm2
         except AttributeError:
@@ -460,7 +460,7 @@ class Kernel1D:
         whole frequency range to be explored. For convenience, the second half of the points will
         be provided as negative values.
         """
-        z = np.asfarray(z)
+        z = np.asarray(z, dtype=float)
         t_star = 2 * np.pi / (z[1] - z[0]) ** 2 / len(z)
         dz = t_star * (z[1] - z[0])
         return fftpack.fft(self(z * t_star) * dz).real
@@ -471,7 +471,7 @@ class Kernel1D:
         The points will always be provided as a grid with :math:`2^n` points, representing the
         whole frequency range to be explored.
         """
-        z = np.asfarray(z)
+        z = np.asarray(z, dtype=float)
         a1 = z[1] - z[0]
         gp = (z / a1 + 0.5) * np.pi / (len(z) * a1)
         return fftpack.dct(self(gp) * (gp[1] - gp[0])).real
@@ -512,7 +512,7 @@ class NormalKernel1d(Kernel1D):
         """
         Returns the FFT of the normal distribution
         """
-        z = np.asfarray(z)
+        z = np.asarray(z, dtype=float)
         out = np.multiply(z, z, out)
         out *= -0.5
         np.exp(out, out)
@@ -522,7 +522,7 @@ class NormalKernel1d(Kernel1D):
         """
         Returns the DCT of the normal distribution
         """
-        z = np.asfarray(z)
+        z = np.asarray(z, dtype=float)
         out = np.multiply(z, z, out)
         out *= -0.5
         np.exp(out, out)

--- a/perun/thirdparty/pyqt_fit_port/utils.py
+++ b/perun/thirdparty/pyqt_fit_port/utils.py
@@ -309,8 +309,7 @@ def approx_jacobian(x, func, epsilon, *args):
          The approximation is done using forward differences
 
     """
-    x0 = np.asarray(x)
-    x0 = np.asfarray(x0, dtype=x0.dtype)
+    x0 = np.asarray(x, dtype=float)
     epsilon = x0.dtype.type(epsilon)
     f0 = func(*((x0,) + args))
     jac = np.zeros([len(x0), len(f0)], dtype=x0.dtype)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ dependencies = [
     "pandas>=2.0",
     "statsmodels>=0.14",
     "scikit-learn>=1.3",
-    "scipy>=1.10,<1.14", # 1.11+ dropped support for Python 3.8
+    "scipy>=1.13",
     "networkx>=3.1",
 
     # Plotting / visualization / output

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
 requires = [
-    "meson-python >= 0.15.0",
-    "meson >= 1.2.3",
-    "patchelf >= 0.11.0",
-    "ninja >= 1.0",
-    "wheel",
+    "meson-python >= 0.16.0",
+    "meson >= 1.4.1",
+    "patchelf >= 0.17.2",
+    "ninja >= 1.11.1",
+    "wheel>=0.43.0",
 ]
 build-backend = "mesonpy"
 
@@ -27,78 +27,72 @@ authors = [
 ]
 dependencies = [
     # Build
-    "meson-python>=0.15.0",
-    "meson>=1.2.3",
-    "ninja>=1.0",
+    "meson-python>=0.16.0",
+    "meson>=1.4.1",
+    "ninja>=1.11",
     "wheel>=0.43.0",
 
     # Other
-    "psutil>=5.0.0",
+    "psutil>=6.0.0",
 
     # CLI
-    "click>=8.1",
+    "click>=8.1.7",
 
     # VCS integration
-    "GitPython>=3.1.30",
+    "GitPython>=3.1.43",
     "gitdb>=4.0.10",
 
     # String / text utilities
-    "Faker>=19.3",
-    "ruamel.yaml>=0.17",
+    "Faker>=26.0.0",
+    "ruamel.yaml>=0.18.6",
     "Jinja2>=3.1.4",
 
     # File analysis
-    "python-magic>=0.4",
-    "angr>=9.2",
+    "python-magic>=0.4.27",
+    "angr>=9.2.102",
 
     # Science / math / statistics / ML
-    # TODO: Temporary fix the numpy version, as 2.0.0 may break some codes
-    "numpy>=1.24,<2.0",
-    "pandas>=2.0",
-    "statsmodels>=0.14",
-    "scikit-learn>=1.3",
+    "numpy>=2.0.0",
+    "pandas>=2.2.2",
+    "statsmodels>=0.14.2",
+    "scikit-learn>=1.5.1",
     "scipy>=1.13",
-    "networkx>=3.1",
+    "networkx>=3.2.1",
 
     # Plotting / visualization / output
-    "bokeh>=3.1", # 3.2+ dropped support for Python 3.8
-    "matplotlib>=3.7",
-    "termcolor>=2.4",
-    "tabulate>=0.9",
-    "holoviews>=1.17",
-    "progressbar2>=4.3",
-
-    # Transitive dependencies that we need to limit for some reason
-    "kiwisolver!=1.4.5", # matplotlib dep, 1.4.5 does not work when lazy-importing matplotlib
+    "bokeh>=3.4.2",
+    "matplotlib>=3.9.0",
+    "termcolor>=2.4.0",
+    "tabulate>=0.9.0",
+    "holoviews>=1.19.0",
+    "progressbar2>=4.4.2",
 
     # Some of our dependencies still rely on distutils in 3.12, hence we need the setuptools package
-    "setuptools>=69.0; python_version >= '3.12'"
+    "setuptools>=70.2.0; python_version >= '3.12'"
 ]
 dynamic = ["version"]
 
 [project.optional-dependencies]
 docs = [
-    # Sphinx 7.2 dropped support for Python 3.8
-    "Sphinx>=7.1",
-    "sphinx-click>=5.0",
+    "Sphinx>=7.3.7",
+    "sphinx-click>=6.0.0",
 ]
 lint = [
-    "black>=22.1.0",
-    "pylint>=2.17",
+    "black>=24.4.2",
+    "pylint>=3.2.5",
 ]
 test = [
-    "pytest>=7.4",
-    "pytest-cov>=4.1",
-    "tox>=4.9.0",
+    "pytest>=8.2.2",
+    "pytest-cov>=5.0.0",
+    "tox>=4.16.0",
 ]
 typing = [
-    "mypy>=1.5",
-    "mypy-extensions>=1.0",
-    "typing-extensions>=4.7",
-    "types-tabulate>=0.9",
-    "pandas-stubs>=2.0",
-    "nptyping>=2.5.0",
-    "types-psutil>=5.9.5"
+    "mypy>=1.10.1",
+    "mypy-extensions>=1.0.0",
+    "typing-extensions>=4.12.2",
+    "types-tabulate>=0.9.0",
+    "pandas-stubs>=2.2.2",
+    "types-psutil>=6.0.0"
 ]
 
 [project.urls]


### PR DESCRIPTION
This PR bumps our dependencies to their latest versions that still support 3.9, while resolving some of our existing dependency issues, namely #106 and #203.