### PR TITLE
Add test dependencies to `make install`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ dev:
 	pre-commit install
 
 install:
-	pip3 install .
+	pip3 install .[test]
 
 check:
 	python3 -m mypy ./perun/


### PR DESCRIPTION
Previously, `make install` did not install python testing packages, so subsequent `make test` failed due to missing dependencies.