### PR TITLE
Release version 0.23.6

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+0.23.6 (2024-10-06)
+-------------------
+
+  - Fix issue with empty CLI stats headers
+  - Implement lazy loading of the most expensive internal packages to speedup Perun and make CLI snappier
+
+
 0.23.5 (2024-09-25)
 -------------------
 

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
     'perun',
     'c',
-    version: '0.23.5',
+    version: '0.23.6',
     license: 'GPL-3',
     meson_version: '>=1.0.0',
     default_options: [


### PR DESCRIPTION
- Fix issue with empty CLI stats headers
- Implement lazy loading of the most expensive internal packages to speedup Perun and make CLI snappier