### PR TITLE
Add flamegraph diffs to the showdiff report

### DIFF
--- a/perun/check/detection_kit.py
+++ b/perun/check/detection_kit.py
@@ -81,7 +81,7 @@ def create_model_record(model: dict[str, Any]) -> ModelRecord:
         model["model"],
         model["r_square"],
         model["coeffs"][0]["value"] if model.get("coeffs") else model["bucket_stats"],
-        model["coeffs"][1]["value"] if model.get("coeffs") else None,
+        model["coeffs"][1]["value"] if model.get("coeffs") else None,  # type: ignore
         model["coeffs"][2]["value"] if len(model.get("coeffs", [])) == 3 else 0,
         model["x_start"],
         model["x_end"],

--- a/perun/fuzz/factory.py
+++ b/perun/fuzz/factory.py
@@ -177,10 +177,13 @@ def fuzz(
 
             if is_binary:
                 with open(filename, "wb") as bp_out:
-                    bp_out.write((b"".join(fuzzed_lines))[:max_bytes])
+                    # Note: At this point, we know that fuzzed_lines is `list[bytes]` since
+                    # `is_binary == True`
+                    bp_out.write((b"".join(cast(list[bytes], fuzzed_lines)))[:max_bytes])
             else:
                 with open(filename, "w") as fp_out:
-                    # Note: At this point, we know, that fuzzed_lines is `list[str]` wrt `is_binary == False`
+                    # Note: At this point, we know, that fuzzed_lines is `list[str]` since
+                    # `is_binary == False`
                     fp_out.write("".join(cast(list[str], fuzzed_lines))[:max_bytes])
 
     return mutations

--- a/perun/logic/stats.py
+++ b/perun/logic/stats.py
@@ -440,8 +440,7 @@ def _delete_stats_objects(dirs: Iterable[str], files: Iterable[str]) -> None:
         delete_func = shutil.rmtree if idx == 1 else os.remove
         for item in group:
             try:
-                # Note: We, ignore this, as MyPy seems to have problem inferring and coping with delete_func type
-                delete_func(item)  # type: ignore
+                delete_func(item)
             except OSError as exc:
                 # Possibly already deleted files or restricted permission etc., log and skip
                 perun_log.msg_to_file(f"Stats object deletion error: {exc}", 0)

--- a/perun/profile/factory.py
+++ b/perun/profile/factory.py
@@ -80,7 +80,7 @@ class Profile(MutableMapping[str, Any]):
         super().__init__()
         initialization_data = dict(*args, **kwargs)
         global_data = initialization_data.get("global", {"models": []})
-        self._storage = {
+        self._storage: dict[str, Any] = {
             "resources": {},
             "resource_type_map": {},
             "models": global_data.get("models", []) if isinstance(global_data, dict) else [],

--- a/perun/templates/diff_view_flamegraph.html.jinja2
+++ b/perun/templates/diff_view_flamegraph.html.jinja2
@@ -144,7 +144,7 @@
     </table>
 </div>
 
-{% for (_, lhs_flamegraph, rhs_flamegraph, diff_flamegraph) in flamegraphs %}
+{% for (_, lhs_flamegraph, rhs_flamegraph, lhs_diff_flamegraph, rhs_diff_flamegraph) in flamegraphs %}
 <div class="flamegraphs" id="{{ data_types[loop.index0] }}">
     <h2>{{ data_types[loop.index0] }}</h2>
     <div class="left column">
@@ -160,7 +160,7 @@
     <div class="middle">
         <h2 class="column-head">Difference of profiles</h2>
         <div class='svg-container'>
-            {{ diff_flamegraph }}
+            {{ lhs_diff_flamegraph }}
         </div>
 
         <div class="help">

--- a/perun/templates/diff_view_report.html.jinja2
+++ b/perun/templates/diff_view_report.html.jinja2
@@ -243,7 +243,7 @@
                 </tfoot>
             </table>
         </div>
-        {%- for (metric, lhs_flamegraph, rhs_flamegraph, diff_flamegraph) in flamegraphs %}
+        {%- for (metric, lhs_flamegraph, rhs_flamegraph, lhs_diff_flamegraph, rhs_diff_flamegraph) in flamegraphs %}
         <div id="{{ metric|sanitize_variable_name }}" class="tabcontent">
             <div class="middle">
                 <div>
@@ -275,6 +275,16 @@
             <div class="right column">
                 <div class='svg-container'>
                 {{ rhs_flamegraph }}
+                </div>
+            </div>
+            <div class="left column" style="margin-top: 1%">
+                <div class='svg-container'>
+                {{ lhs_diff_flamegraph }}
+                </div>
+            </div>
+            <div class="right column" style="margin-top: 1%">
+                <div class='svg-container'>
+                {{ rhs_diff_flamegraph }}
                 </div>
             </div>
         </div>
@@ -1228,7 +1238,7 @@
             const svgContent = svgContents[i];
             svgContent.setAttribute("viewBox", max_viewBox);
             svgContent.viewBox = max_viewBox;
-            svgContent.getElementsByTagName("rect")[0].style.height = max_box;
+            svgContent.getElementsByTagName("rect")[0].setAttribute("height", max_box);
         };
       }
       resize();
@@ -1260,9 +1270,12 @@
         if (curr_tab == "")
             return;
         const tab = document.getElementById(curr_tab);
+        const searchContent = tab.getElementsByClassName('middle')[0];
         const svgContents = tab.getElementsByClassName('svg-content');
         const lhs_svgContainer = tab.getElementsByClassName('svg-container')[0];
         const rhs_svgContainer = tab.getElementsByClassName('svg-container')[1];
+        const lhs_diff_svgContainer = tab.getElementsByClassName('svg-container')[2];
+        const rhs_diff_svgContainer = tab.getElementsByClassName('svg-container')[3];
         if (lhs_svgContainer) {
             let max_box = 0, max_height = 0;
             for (let i = 0; i < svgContents.length; i++) {
@@ -1276,9 +1289,12 @@
                 if (height > max_box)
                     max_box = height;
             };
-            lhs_svgContainer.style.height = `${max_box}px`;
-            rhs_svgContainer.style.height = `${max_box}px`;
-            tab.style.height = `${max_height + 100}px`;
+            const searchHeight = searchContent.getBoundingClientRect().height;
+            lhs_svgContainer.style.height = `${max_height}px`;
+            rhs_svgContainer.style.height = `${max_height}px`;
+            lhs_diff_svgContainer.style.height = `${max_height}px`;
+            rhs_diff_svgContainer.style.height = `${max_height}px`;
+            tab.style.height = `${max_height * 2.1 + searchHeight}px`;
         }
     }
 
@@ -1300,6 +1316,10 @@
         addListeners("lhs", i, "text");
         addListeners("rhs", i, "rect");
         addListeners("rhs", i, "text");
+        addListeners("lhs_diff", i, "rect");
+        addListeners("lhs_diff", i, "text");
+        addListeners("rhs_diff", i, "rect");
+        addListeners("rhs_diff", i, "text");
     };
 
     {%- if flamegraphs %}
@@ -1313,6 +1333,12 @@
             rhs_{{index}}_reset_search();
             rhs_{{index}}_currentSearchTerm = searchBar_{{index}}.value;
             rhs_{{index}}_search();
+            lhs_diff_{{index}}_reset_search();
+            lhs_diff_{{index}}_currentSearchTerm = searchBar_{{index}}.value;
+            lhs_diff_{{index}}_search();
+            rhs_diff_{{index}}_reset_search();
+            rhs_diff_{{index}}_currentSearchTerm = searchBar_{{index}}.value;
+            rhs_diff_{{index}}_search();
         })
     {%- endfor%}
     {%- endif %}

--- a/perun/view/flamegraph/flamegraph.py
+++ b/perun/view/flamegraph/flamegraph.py
@@ -88,7 +88,6 @@ def draw_flame_graph(
     :param fg_max_resource: maximum number of samples collected
     """
     # converting profile format to format suitable to Flame graph visualization
-    # flame = convert.to_flame_graph_format(profile, profile_key=profile_key, minimize=minimize)
     with tempfile.NamedTemporaryFile(delete=False) as tmp:
         tmp.write("".join(flame_data).encode("utf-8"))
         tmp.close()

--- a/perun/view/flamegraph/flamegraph.py
+++ b/perun/view/flamegraph/flamegraph.py
@@ -3,64 +3,61 @@
 from __future__ import annotations
 
 # Standard Imports
-from typing import TYPE_CHECKING
+from dataclasses import dataclass, field
 import os
 import tempfile
+from typing import Any
 
 # Third-Party Imports
 
 # Perun Imports
-from perun.profile import convert
 from perun.utils import mapping
 from perun.utils.common import script_kit
 from perun.utils.external import commands
 
-if TYPE_CHECKING:
-    from perun.profile.factory import Profile
-
 
 def draw_flame_graph_difference(
-    lhs_profile: Profile,
-    rhs_profile: Profile,
-    width: int = 1200,
-    title: str = "",
-    profile_key: str = "amount",
-    minimize: bool = False,
+    lhs_flame_data: list[str],
+    rhs_flame_data: list[str],
+    title: str,
+    units: str = "samples",
+    img_width: int = 1200,
+    fg_flags: str = "",
+    fg_min_width: str = "1",
+    fg_max_trace: int = 0,
+    fg_max_resource: float = 0.0,
 ) -> str:
     """Draws difference of two flame graphs from two profiles
 
-    :param lhs_profile: baseline profile
-    :param rhs_profile: target_profile
-    :param width: width of the graph
-    :param profile_key: key for which we are constructing profile
-    :param title: if set to empty, then title will be generated
-    """
-    # First we create two flamegraph formats
-    lhs_flame = convert.to_flame_graph_format(
-        lhs_profile, profile_key=profile_key, minimize=minimize
-    )
-    with open("lhs.flame", "w") as lhs_handle:
-        lhs_handle.write("".join(lhs_flame))
-    rhs_flame = convert.to_flame_graph_format(
-        rhs_profile, profile_key=profile_key, minimize=minimize
-    )
-    with open("rhs.flame", "w") as rhs_handle:
-        rhs_handle.write("".join(rhs_flame))
+    :param lhs_flame_data: baseline flame graph data
+    :param rhs_flame_data: target flame graph data
+    :param title: title of the flame graph
+    :param units: the units of the flame graph data
+    :param img_width: width of the graph
+    :param fg_flags: additional flags to pass to the flame graph generator script
+    :param fg_min_width: minimum width of the flame graph rectangles that will be drawn
+    :param fg_max_trace: maximum length of traces that are being drawn
+    :param fg_max_resource: maximum number of samples collected
 
-    header = lhs_profile["header"]
-    profile_type = header["type"]
-    cmd, workload = (header["cmd"], header["workload"])
-    title = title if title != "" else f"{profile_type} consumption of {cmd} {workload}"
-    # TODO: Make better
-    units = header["units"].get(profile_type, "samples")
+    :return: the difference flame graph
+    """
+    with open("lhs.flame", "w") as lhs_handle:
+        lhs_handle.write("".join(lhs_flame_data))
+
+    with open("rhs.flame", "w") as rhs_handle:
+        rhs_handle.write("".join(rhs_flame_data))
 
     diff_script = script_kit.get_script("difffolded.pl")
     flame_script = script_kit.get_script("flamegraph.pl")
     difference_script = (
         f"{diff_script} -n lhs.flame rhs.flame "
         f"| {flame_script} --title '{title}' --countname {units} --reverse "
-        f"--width {width * 2}"
+        f"--width {img_width} --minwidth {fg_min_width} --maxtrace {fg_max_trace}"
     )
+    if fg_max_resource > 0.0:
+        difference_script += f' --total {fg_max_resource} --rootnode "Maximum (Baseline, Target)"'
+    if fg_flags:
+        difference_script += f" {fg_flags}"
     out, _ = commands.run_safely_external_command(difference_script)
     os.remove("lhs.flame")
     os.remove("rhs.flame")
@@ -69,35 +66,31 @@ def draw_flame_graph_difference(
 
 
 def draw_flame_graph(
-    profile: Profile,
-    width: int = 1200,
-    max_trace: int = 0,
-    max_resource: float = 0.0,
-    title: str = "",
-    profile_key: str = "amount",
-    minimize: bool = False,
+    flame_data: list[str],
+    title: str,
+    units: str = "samples",
+    img_width: int = 1200,
+    fg_min_width: str = "1",
+    fg_max_trace: int = 0,
+    fg_max_resource: float = 0.0,
 ) -> str:
-    """Draw Flame graph from profile.
+    """Draw Flame graph from flame data.
 
         To create Flame graphs we use perl script created by Brendan Gregg.
         https://github.com/brendangregg/FlameGraph/blob/master/flamegraph.pl
 
-    :param profile: the memory profile
-    :param width: width of the graph
-    :param profile_key: key for which we are constructing profile
-    :param title: if set to empty, then title will be generated
+    :param flame_data: the data to generate the flame graph from
+    :param title: title of the flame graph
+    :param units: the units of the flame graph data
+    :param img_width: width of the graph
+    :param fg_min_width: minimum width of the flame graph rectangles that will be drawn
+    :param fg_max_trace: maximum length of traces that are being drawn
+    :param fg_max_resource: maximum number of samples collected
     """
     # converting profile format to format suitable to Flame graph visualization
-    flame = convert.to_flame_graph_format(profile, profile_key=profile_key, minimize=minimize)
-
-    header = profile["header"]
-    profile_type = header["type"]
-    cmd, workload = (header["cmd"], header["workload"])
-    title = title if title != "" else f"{profile_type} consumption of {cmd} {workload}"
-    units = mapping.get_unit(mapping.get_readable_key(profile_key))
-
+    # flame = convert.to_flame_graph_format(profile, profile_key=profile_key, minimize=minimize)
     with tempfile.NamedTemporaryFile(delete=False) as tmp:
-        tmp.write("".join(flame).encode("utf-8"))
+        tmp.write("".join(flame_data).encode("utf-8"))
         tmp.close()
         cmd = " ".join(
             [
@@ -110,15 +103,133 @@ def draw_flame_graph(
                 f"{units}",
                 "--reverse",
                 "--width",
-                str(width),
+                f"{img_width}",
                 "--maxtrace",
-                f"{max_trace}",
+                f"{fg_max_trace}",
                 "--minwidth",
-                "1",
+                f"{fg_min_width}",
             ]
         )
-        if max_resource > 0.0:
-            cmd += f' --total {max_resource} --rootnode "Maximum (Baseline, Target)"'
+        if fg_max_resource > 0.0:
+            cmd += f' --total {fg_max_resource} --rootnode "Maximum (Baseline, Target)"'
         out, _ = commands.run_safely_external_command(cmd)
         os.remove(tmp.name)
     return out.decode("utf-8")
+
+
+def generate_title(profile_header: dict[str, Any]) -> str:
+    """Generate a title for flame graph based on the profile header.
+
+    :param profile_header: the profile header
+
+    :return: the title of the flame graph
+    """
+    profile_type = profile_header["type"]
+    cmd, workload = (profile_header["cmd"], profile_header["workload"])
+    return f"{profile_type} consumption of {cmd} {workload}"
+
+
+def get_units(profile_key: str) -> str:
+    """Obtain the units of the flame graph based on the profile key.
+
+    :param profile_key: the profile key
+
+    :return: the units of the flame graph
+    """
+    return mapping.get_unit(mapping.get_readable_key(profile_key))
+
+
+def compute_max_traces(
+    flame_data: list[str],
+    img_width: float,
+    min_width: str = "1",
+) -> tuple[int, int, int]:
+    """Recreate Brendan Gregg's max trace depth computation for correct flamegraph height.
+
+    This function provides the maximum length of traces and filtered maximum that takes into
+    account the filtering of subtraces based on their sample count, as well as the total number of
+    samples collected.
+
+    :param flame_data: the flame graph data
+    :param img_width: the width of the graph image
+    :param min_width: the minimum width of the flame graph rectangles that will be drawn
+
+    :return: the maximum trace length, the maximum length of traces that are being drawn, the total
+             number of samples collected
+    """
+    max_unfiltered_trace = 0
+    flame_stacks: _PerfStackRecord = _PerfStackRecord()
+    # Process each flame data record
+    for stack_trace in flame_data:
+        # Update the perf stack traces representation with this record
+        stack_str, samples = stack_trace.rsplit(maxsplit=1)
+        stack = stack_str.split(";")
+        max_unfiltered_trace = max(len(stack), max_unfiltered_trace)
+        flame_stacks.update_stack(stack, int(float(samples)))
+    min_width_f = _compute_minwidth_samples(flame_stacks.inclusive_samples, img_width, min_width)
+    return max_unfiltered_trace, flame_stacks.filter(min_width_f), flame_stacks.inclusive_samples
+
+
+def _compute_minwidth_samples(max_resource: float, img_width: float, min_width: str) -> float:
+    """Computes the minimum width threshold for flamegraph blocks to be displayed.
+
+    Reconstructed from the flamegraph.pl script.
+
+    :param max_resource: the total number of samples collected
+    :param img_width: the width of the graph image
+    :param min_width: the minimum width of the flame graph rectangles that will be drawn
+    """
+    try:
+        if min_width.endswith("%"):
+            return max_resource * float(min_width[:-1]) / 100
+        else:
+            x_padding: int = 10
+            width_per_time: float = (img_width - 2 * x_padding) / max_resource
+            return float(min_width) / width_per_time
+    except ZeroDivisionError:
+        # Unknown or invalid max_resource, we set the threshold so that it does not filter anything
+        return 0.0
+
+
+@dataclass
+class _PerfStackRecord:
+    """Representation of a single perf stack frame record from flame data.
+
+    :ivar inclusive_samples: the number of samples in which a given stack frame record occurred
+    :ivar nested: callee stack frame records
+    """
+
+    inclusive_samples: int = 0
+    nested: dict[str, _PerfStackRecord] = field(default_factory=dict)
+
+    def update_stack(self, stack: list[str], samples: int) -> None:
+        """Update the stack traces with new flame data record.
+
+        :param stack: the stack trace
+        :param samples: the number of samples that contain this stack trace
+        """
+        self.inclusive_samples += samples
+        if stack:
+            func = stack.pop()
+            self.nested.setdefault(func, _PerfStackRecord()).update_stack(stack, samples)
+
+    def filter(self, min_width: float) -> int:
+        """Filter the stack subtraces (recursively) that do not meet the minimum sample threshold.
+
+        :param min_width: the samples threshold
+
+        :return: the maximum stack length after the filtering
+        """
+        depth: int = 0
+        delete_list: list[str] = []
+        for nested_func, nested_record in self.nested.items():
+            if nested_record.inclusive_samples < min_width:
+                # This nested subtrace does not meet the samples threshold, we cut the entire
+                # subtrace off including its subtraces.
+                delete_list.append(nested_func)
+            else:
+                # This subtrace meets the threshold, check recursively
+                depth = max(depth, nested_record.filter(min_width) + 1)
+        for del_key in delete_list:
+            del self.nested[del_key]
+        return depth

--- a/perun/view/flamegraph/run.py
+++ b/perun/view/flamegraph/run.py
@@ -9,6 +9,7 @@ from typing import Any
 import click
 
 # Perun Imports
+from perun.profile import convert
 import perun.view.flamegraph.flamegraph as flame
 import perun.profile.factory as profile_factory
 
@@ -19,7 +20,11 @@ def save_flamegraph(profile: profile_factory.Profile, filename: str) -> None:
     :param profile: profile for which we are saving flamegraph
     :param filename: name of the file where the flamegraph will be saved
     """
-    flamegraph_content = flame.draw_flame_graph(profile)
+    flamegraph_content = flame.draw_flame_graph(
+        convert.to_flame_graph_format(profile),
+        flame.generate_title(profile["header"]),
+        flame.get_units(profile["header"]["type"]),
+    )
     with open(filename, "w") as file_handle:
         file_handle.write(flamegraph_content)
 

--- a/perun/view_diff/report/run.py
+++ b/perun/view_diff/report/run.py
@@ -734,10 +734,8 @@ def generate_report(lhs_profile: Profile, rhs_profile: Profile, **kwargs: Any) -
         lhs_profile,
         rhs_profile,
         Stats.all_stats(),
-        skip_diff=True,
+        skip_diff=False,
         minimize=Config().minimize,
-        max_trace=Config().max_seen_trace,
-        max_per_resource=Config().max_per_resource,
     )
     log.minor_success("Sankey graphs", "generated")
     lhs_header, rhs_header = diff_kit.generate_headers(lhs_profile, rhs_profile)


### PR DESCRIPTION
Originally, the showdiff report had some code to generate flamegraph diff, but the call to the generate_flamegraphs function had skip_diff=True, so no diff would be generated.

This PR re-enables flamegraph generation and moreover:

- Both baseline-target and target-baseline diffs are generated separately and shown directly below baseline or target flamegraph, respectively. The motivation behind generating both comparisons is discussed [here](https://www.brendangregg.com/blog/2014-11-09/differential-flame-graphs.html) (Section "Negation").
- All four flamegraphs are now unified: they have the same generation parameters where it makes sense (except minor differences, e.g., the --negation flag), they all respond to global search, have the same height and width, etc. Moreover, clicking into the diff flamegraph now opens the sankey graph as well.
- The height resizing of SVG has been reworked. Previously, the height of the images was set according to the longest known traces, however, flamegraph.pl does some postprocessing and removes subtraces that don't meet certain width threshold. This caused some of the generated SVGs to have too much unnecessary blank space above the graphs. E.g., in one case, the longest trace was 34 while the postprocessed one was only 16, which caused the image to have more than double the necessary height and made it harder to compare all four graphs at the same time.