### PR TITLE
Add CPU vulnerabilities to showdiff

### DIFF
--- a/perun/cli.py
+++ b/perun/cli.py
@@ -64,6 +64,7 @@ from perun.utils.exceptions import (
     ExternalEditorErrorException,
 )
 from perun.utils.structs.common_structs import Executable
+from perun.utils.structs.diff_structs import HeaderDisplayStyle
 from perun import fuzz as fuzz
 import perun.postprocess
 import perun.profile.helpers as profiles
@@ -703,6 +704,16 @@ def show(ctx: click.Context, profile: Profile, **_: Any) -> None:
     is_flag=True,
     default=False,
     help="Creates self-contained outputs usable in offline environments (default=False).",
+)
+@click.option(
+    "--display-style",
+    "-d",
+    type=click.Choice(HeaderDisplayStyle.supported()),
+    default=HeaderDisplayStyle.default(),
+    callback=cli_kit.set_config_option_from_flag(perun_config.runtime, "showdiff.display_style"),
+    help="Selects the display style of profile header. The 'full' option displays all provided "
+    "headers, while the 'diff' option shows only headers with different values "
+    f"(default={HeaderDisplayStyle.default()}).",
 )
 @click.pass_context
 def showdiff(ctx: click.Context, **kwargs: Any) -> None:

--- a/perun/profile/__init__.pyi
+++ b/perun/profile/__init__.pyi
@@ -29,7 +29,7 @@ from .helpers import (
     get_default_independent_variable as get_default_independent_variable,
     get_default_dependent_variable as get_default_dependent_variable,
     ProfileInfo as ProfileInfo,
-    ProfileMetadata as ProfileMetadata,
+    ProfileHeaderEntry as ProfileHeaderEntry,
 )
 
 from .imports import (

--- a/perun/profile/factory.py
+++ b/perun/profile/factory.py
@@ -462,13 +462,13 @@ class Profile(MutableMapping[str, Any]):
         for stat in self._storage.get("stats", {}):
             yield stats.ProfileStat.from_profile(stat)
 
-    def all_metadata(self) -> Iterable[helpers.ProfileMetadata]:
+    def all_metadata(self) -> Iterable[helpers.ProfileHeaderEntry]:
         """Iterates through all the metadata records in the profile.
 
         :return: iterable of all metadata records
         """
         for entry in self._storage.get("metadata", {}):
-            yield helpers.ProfileMetadata.from_profile(entry)
+            yield helpers.ProfileHeaderEntry.from_profile(entry)
 
     # TODO: discuss the intent of __len__ and possibly merge?
     def resources_size(self) -> int:

--- a/perun/templates/diff_view_datatables.html.jinja2
+++ b/perun/templates/diff_view_datatables.html.jinja2
@@ -91,14 +91,14 @@
 
 <div class="left column">
     <h2 class="column-head">{{ lhs_tag }}</h2>
-    {{ profile_overview.overview_table('toggleSpecificationCollapse', 'left-specification-info', lhs_header, "Profile Specification") }}
+    {{ profile_overview.nested_overview_table('toggleSpecificationCollapse', 'left-specification-info', lhs_header, "Profile Specification") }}
     <div style="margin: 0 10px;">&nbsp;</div>
 </div>
 
 
 <div class="right column">
     <h2 class="column-head">{{ rhs_tag }}</h2>
-    {{ profile_overview.overview_table('toggleSpecificationCollapse', 'right-specification-info', rhs_header, "Profile Specification") }}
+    {{ profile_overview.nested_overview_table('toggleSpecificationCollapse', 'right-specification-info', rhs_header, "Profile Specification") }}
     <div style="margin: 0 10px;">&nbsp;</div>
 </div>
 
@@ -198,6 +198,11 @@
     {% include 'dataTables.min.js' %}
     {%- endif %}
     {{ profile_overview.toggle_script('toggleSpecificationCollapse', 'left-specification-info', 'right-specification-info') }}
+    {% for (key, value, title, nested_values) in lhs_header %}
+    {% if nested_values %}
+    {{ profile_overview.toggle_nested_table('toggleSpecificationCollapse' ~ loop.index0, 'left-specification-info' ~ loop.index0, 'right-specification-info' ~ loop.index0) }}
+    {% endif %}
+    {% endfor %}
     $(document).ready( function () {
         var lhs = $("#table1").DataTable({
             data: lhs_data.data,

--- a/perun/templates/diff_view_flamegraph.html.jinja2
+++ b/perun/templates/diff_view_flamegraph.html.jinja2
@@ -105,24 +105,24 @@
 
 <div class="left column">
     <h2 class="column-head">{{ lhs_tag }}</h2>
-    {{ profile_overview.overview_table('toggleSpecificationCollapse', 'left-specification-info', lhs_header, "Profile Specification") }}
+    {{ profile_overview.nested_overview_table('toggleSpecificationCollapse', 'left-specification-info', lhs_header, "Profile Specification") }}
     <div style="margin: 0 10px;">&nbsp;</div>
     {{ profile_overview.nested_overview_table('toggleStatsCollapse', 'left-stats-info', lhs_stats, "Profile Stats") }}
     <div style="margin: 0 10px;">&nbsp;</div>
     {%- if rhs_metadata%}
-    {{ profile_overview.overview_table('toggleMetadataCollapse', 'left-metadata-info', lhs_metadata, "Profile Metadata") }}
+    {{ profile_overview.nested_overview_table('toggleMetadataCollapse', 'left-metadata-info', lhs_metadata, "Profile Metadata") }}
     <div style="margin: 0 10px;">&nbsp;</div>
     {%- endif %}
 </div>
 
 <div class="right column">
     <h2 class="column-head">{{ rhs_tag }}</h2>
-    {{ profile_overview.overview_table('toggleSpecificationCollapse', 'right-specification-info', rhs_header, "Profile Specification") }}
+    {{ profile_overview.nested_overview_table('toggleSpecificationCollapse', 'right-specification-info', rhs_header, "Profile Specification") }}
     <div style="margin: 0 10px;">&nbsp;</div>
     {{ profile_overview.nested_overview_table('toggleStatsCollapse', 'right-stats-info', rhs_stats, "Profile Stats") }}
     <div style="margin: 0 10px;">&nbsp;</div>
     {%- if rhs_metadata%}
-    {{ profile_overview.overview_table('toggleMetadataCollapse', 'right-metadata-info', rhs_metadata, "Profile Metadata") }}
+    {{ profile_overview.nested_overview_table('toggleMetadataCollapse', 'right-metadata-info', rhs_metadata, "Profile Metadata") }}
     <div style="margin: 0 10px;">&nbsp;</div>
     {%- endif %}
 </div>
@@ -185,6 +185,16 @@
 {% for (key, value, title, nested_values) in lhs_stats %}
 {% if nested_values %}
 {{ profile_overview.toggle_nested_table('toggleStatsCollapse' ~ loop.index0, 'left-stats-info' ~ loop.index0, 'right-stats-info' ~ loop.index0) }}
+{% endif %}
+{% endfor %}
+{% for (key, value, title, nested_values) in lhs_header %}
+{% if nested_values %}
+{{ profile_overview.toggle_nested_table('toggleSpecificationCollapse' ~ loop.index0, 'left-specification-info' ~ loop.index0, 'right-specification-info' ~ loop.index0) }}
+{% endif %}
+{% endfor %}
+{% for (key, value, title, nested_values) in lhs_header %}
+{% if nested_values %}
+{{ profile_overview.toggle_nested_table('toggleMetadataCollapse' ~ loop.index0, 'left-metadata-info' ~ loop.index0, 'right-metadata-info' ~ loop.index0) }}
 {% endif %}
 {% endfor %}
 {{ accordion.script("table-row") }}

--- a/perun/templates/diff_view_report.html.jinja2
+++ b/perun/templates/diff_view_report.html.jinja2
@@ -181,24 +181,24 @@
 
 <div class="left column">
     <h2 class="column-head">{{ lhs_tag }}</h2>
-    {{ profile_overview.overview_table('toggleSpecificationCollapse', 'left-specification-info', lhs_header, "Profile Specification") }}
+    {{ profile_overview.nested_overview_table('toggleSpecificationCollapse', 'left-specification-info', lhs_header, "Profile Specification") }}
     <div style="margin: 0 10px;">&nbsp;</div>
     {{ profile_overview.nested_overview_table('toggleStatsCollapse', 'left-stats-info', lhs_stats, "Profile Stats") }}
     <div style="margin: 0 10px;">&nbsp;</div>
     {%- if rhs_metadata%}
-    {{ profile_overview.overview_table('toggleMetadataCollapse', 'left-metadata-info', lhs_metadata, "Profile Metadata") }}
+    {{ profile_overview.nested_overview_table('toggleMetadataCollapse', 'left-metadata-info', lhs_metadata, "Profile Metadata") }}
     <div style="margin: 0 10px;">&nbsp;</div>
     {%- endif %}
 </div>
 
 <div class="right column">
     <h2 class="column-head">{{ rhs_tag }}</h2>
-    {{ profile_overview.overview_table('toggleSpecificationCollapse', 'right-specification-info', rhs_header, "Profile Specification") }}
+    {{ profile_overview.nested_overview_table('toggleSpecificationCollapse', 'right-specification-info', rhs_header, "Profile Specification") }}
     <div style="margin: 0 10px;">&nbsp;</div>
     {{ profile_overview.nested_overview_table('toggleStatsCollapse', 'right-stats-info', rhs_stats, "Profile Stats") }}
     <div style="margin: 0 10px;">&nbsp;</div>
     {%- if rhs_metadata%}
-    {{ profile_overview.overview_table('toggleMetadataCollapse', 'right-metadata-info', rhs_metadata, "Profile Metadata") }}
+    {{ profile_overview.nested_overview_table('toggleMetadataCollapse', 'right-metadata-info', rhs_metadata, "Profile Metadata") }}
     <div style="margin: 0 10px;">&nbsp;</div>
     {%- endif %}
 </div>
@@ -538,6 +538,16 @@
     {% for (key, value, title, nested_values) in lhs_stats %}
     {% if nested_values %}
     {{ profile_overview.toggle_nested_table('toggleStatsCollapse' ~ loop.index0, 'left-stats-info' ~ loop.index0, 'right-stats-info' ~ loop.index0) }}
+    {% endif %}
+    {% endfor %}
+    {% for (key, value, title, nested_values) in lhs_header %}
+    {% if nested_values %}
+    {{ profile_overview.toggle_nested_table('toggleSpecificationCollapse' ~ loop.index0, 'left-specification-info' ~ loop.index0, 'right-specification-info' ~ loop.index0) }}
+    {% endif %}
+    {% endfor %}
+    {% for (key, value, title, nested_values) in lhs_header %}
+    {% if nested_values %}
+    {{ profile_overview.toggle_nested_table('toggleMetadataCollapse' ~ loop.index0, 'left-metadata-info' ~ loop.index0, 'right-metadata-info' ~ loop.index0) }}
     {% endif %}
     {% endfor %}
     {% for index in range(0, stat_list|length ) %}

--- a/perun/templates/diff_view_sankey.html.jinja2
+++ b/perun/templates/diff_view_sankey.html.jinja2
@@ -89,13 +89,13 @@
 
 <div class="left column">
     <h2 class="column-head">{{ lhs_tag }}</h2>
-    {{ profile_overview.overview_table('toggleSpecificationCollapse', 'left-specification-info', lhs_header, "Profile Specification") }}
+    {{ profile_overview.nested_overview_table('toggleSpecificationCollapse', 'left-specification-info', lhs_header, "Profile Specification") }}
     <div style="margin: 0 10px;">&nbsp;</div>
 </div>
 
 <div class="right column">
     <h2 class="column-head">{{ rhs_tag }}</h2>
-    {{ profile_overview.overview_table('toggleSpecificationCollapse', 'right-specification-info', rhs_header, "Profile Specification") }}
+    {{ profile_overview.nested_overview_table('toggleSpecificationCollapse', 'right-specification-info', rhs_header, "Profile Specification") }}
     <div style="margin: 0 10px;">&nbsp;</div>
 </div>
 
@@ -245,6 +245,11 @@
         {%- endfor %}
     ]
     {{ profile_overview.toggle_script('toggleSpecificationCollapse', 'left-specification-info', 'right-specification-info') }}
+    {% for (key, value, title, nested_values) in lhs_header %}
+    {% if nested_values %}
+    {{ profile_overview.toggle_nested_table('toggleSpecificationCollapse' ~ loop.index0, 'left-specification-info' ~ loop.index0, 'right-specification-info' ~ loop.index0) }}
+    {% endif %}
+    {% endfor %}
     {{ widgets.add_to_chip_list() }}
     {{ widgets.checkbox_handler() }}
     {{ widgets.get_radio_handler('getPosition', 'positions') }}

--- a/perun/utils/common/common_kit.py
+++ b/perun/utils/common/common_kit.py
@@ -340,8 +340,10 @@ def try_convert(value: Any, list_of_types: list[type]) -> Any:
     :return: converted value or None, if conversion failed for all the types
     """
     for checked_type in list_of_types:
-        with SuppressedExceptions(Exception):
+        try:
             return checked_type(value)
+        except Exception:
+            continue
 
 
 def try_min(lhs: Optional[int | float], rhs: int | float) -> int | float:

--- a/perun/utils/structs/diff_structs.py
+++ b/perun/utils/structs/diff_structs.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+# Standard Imports
+import enum
+
+# Third-Party Imports
+
+# Perun Imports
+
+
+class HeaderDisplayStyle(enum.Enum):
+    """Supported styles of displaying profile specification and metadata."""
+
+    FULL = "full"
+    DIFF = "diff"
+
+    @staticmethod
+    def supported() -> list[str]:
+        """Obtain the collection of supported display styles.
+
+        :return: the collection of valid display styles
+        """
+        return [style.value for style in HeaderDisplayStyle]
+
+    @staticmethod
+    def default() -> str:
+        """Provide the default display style.
+
+        :return: the default display style
+        """
+        return HeaderDisplayStyle.FULL.value

--- a/perun/utils/structs/meson.build
+++ b/perun/utils/structs/meson.build
@@ -5,6 +5,7 @@ perun_utils_structs_files = files(
     'check_structs.py',
     'collect_structs.py',
     'common_structs.py',
+    'diff_structs.py',
     'postprocess_structs.py',
 )
 

--- a/perun/view_diff/datatables/run.py
+++ b/perun/view_diff/datatables/run.py
@@ -210,7 +210,9 @@ def generate_html_report(lhs_profile: Profile, rhs_profile: Profile, **kwargs: A
         ("[%]", "The relative measured value (in percents overall)."),
     ]
 
-    lhs_header, rhs_header = diff_kit.generate_headers(lhs_profile, rhs_profile)
+    lhs_header, rhs_header = diff_kit.generate_diff_of_headers(
+        diff_kit.generate_specification(lhs_profile), diff_kit.generate_specification(rhs_profile)
+    )
     template = templates.get_template("diff_view_datatables.html.jinja2")
     content = template.render(
         perun_version=perun.__version__,

--- a/perun/view_diff/flamegraph/run.py
+++ b/perun/view_diff/flamegraph/run.py
@@ -264,9 +264,11 @@ def generate_flamegraph_difference(
 
     log.major_info("Generating Flamegraph Difference")
     flamegraphs = generate_flamegraphs(lhs_profile, rhs_profile, data_types)
-    lhs_header, rhs_header = diff_kit.generate_headers(lhs_profile, rhs_profile)
-    lhs_meta, rhs_meta = diff_kit.generate_diff_of_metadata(
-        lhs_profile.all_metadata(), rhs_profile.all_metadata(), kwargs["metadata_display"]
+    lhs_header, rhs_header = diff_kit.generate_diff_of_headers(
+        diff_kit.generate_specification(lhs_profile), diff_kit.generate_specification(rhs_profile)
+    )
+    lhs_meta, rhs_meta = diff_kit.generate_diff_of_headers(
+        lhs_profile.all_metadata(), rhs_profile.all_metadata()
     )
 
     template = templates.get_template("diff_view_flamegraph.html.jinja2")
@@ -306,15 +308,6 @@ def generate_flamegraph_difference(
     help="Sets the width of the flamegraph (default=600px).",
 )
 @click.option("--output-file", "-o", help="Sets the output file (default=automatically generated).")
-@click.option(
-    "--metadata-display",
-    type=click.Choice(diff_kit.MetadataDisplayStyle.supported()),
-    default=diff_kit.MetadataDisplayStyle.default(),
-    callback=lambda _, __, ds: diff_kit.MetadataDisplayStyle(ds),
-    help="Selects the display style of profile metadata. The 'full' option displays all provided "
-    "metadata, while the 'diff' option shows only metadata with different values "
-    f"(default={diff_kit.MetadataDisplayStyle.default()}).",
-)
 def flamegraph(ctx: click.Context, *_: Any, **kwargs: Any) -> None:
     """ """
     assert ctx.parent is not None and f"impossible happened: {ctx} has no parent"

--- a/perun/view_diff/report/run.py
+++ b/perun/view_diff/report/run.py
@@ -738,10 +738,12 @@ def generate_report(lhs_profile: Profile, rhs_profile: Profile, **kwargs: Any) -
         minimize=Config().minimize,
     )
     log.minor_success("Sankey graphs", "generated")
-    lhs_header, rhs_header = diff_kit.generate_headers(lhs_profile, rhs_profile)
+    lhs_header, rhs_header = diff_kit.generate_diff_of_headers(
+        diff_kit.generate_specification(lhs_profile), diff_kit.generate_specification(rhs_profile)
+    )
     lhs_diff_stats, rhs_diff_stats = diff_kit.generate_diff_of_stats(lhs_stats, rhs_stats)
-    lhs_meta, rhs_meta = diff_kit.generate_diff_of_metadata(
-        lhs_profile.all_metadata(), rhs_profile.all_metadata(), kwargs["metadata_display"]
+    lhs_meta, rhs_meta = diff_kit.generate_diff_of_headers(
+        lhs_profile.all_metadata(), rhs_profile.all_metadata()
     )
 
     env_filters = {"sanitize_variable_name": filters.sanitize_variable_name}
@@ -813,15 +815,6 @@ def generate_report(lhs_profile: Profile, rhs_profile: Profile, **kwargs: Any) -
     "-m",
     is_flag=True,
     help="Minimizes the traces, folds the recursive calls, hides the generic types.",
-)
-@click.option(
-    "--metadata-display",
-    type=click.Choice(diff_kit.MetadataDisplayStyle.supported()),
-    default=diff_kit.MetadataDisplayStyle.default(),
-    callback=lambda _, __, ds: diff_kit.MetadataDisplayStyle(ds),
-    help="Selects the display style of profile metadata. The 'full' option displays all provided "
-    "metadata, while the 'diff' option shows only metadata with different values "
-    f"(default={diff_kit.MetadataDisplayStyle.default()}).",
 )
 @click.pass_context
 def report(ctx: click.Context, *_: Any, **kwargs: Any) -> None:

--- a/perun/view_diff/sankey/run.py
+++ b/perun/view_diff/sankey/run.py
@@ -529,7 +529,9 @@ def generate_sankey_difference(lhs_profile: Profile, rhs_profile: Profile, **kwa
         SelectionRow(g.uid, i, g.diff, common_kit.safe_division(g.diff, g.sum) * 100)
         for (i, g) in enumerate(sankey_graphs)
     ]
-    lhs_header, rhs_header = diff_kit.generate_headers(lhs_profile, rhs_profile)
+    lhs_header, rhs_header = diff_kit.generate_diff_of_headers(
+        diff_kit.generate_specification(lhs_profile), diff_kit.generate_specification(rhs_profile)
+    )
 
     template = templates.get_template("diff_view_sankey.html.jinja2")
     content = template.render(

--- a/tests/test_diff_views.py
+++ b/tests/test_diff_views.py
@@ -171,14 +171,14 @@ def test_diff_incremental_sankey_kperf(pcs_with_root):
     result = runner.invoke(
         cli.showdiff,
         [
+            "--display-style",
+            "diff",
             baseline_profilename,
             target_profilename,
             "report",
             "-o",
             "diff.html",
             "--minimize",
-            "--metadata-display",
-            "diff",
         ],
     )
     assert result.exit_code == 0

--- a/utils/generate_machine_info.sh
+++ b/utils/generate_machine_info.sh
@@ -118,7 +118,23 @@ get_machine_specification() {
       fi
     done < /proc/cpuinfo
   fi
-  echo -n -e "]"
+  echo -n -e "],"
+
+  vulns=$(lscpu | grep '^Vulnerability ' | sed 's/Vulnerability //g' | sort)
+  first=0
+  echo -n -e "\"cpu_vulnerabilities\": {"
+  while IFS=: read -r key value; do
+    if [[ -n "$key" && -n "$value" ]]; then
+      value=$(echo -n "$value" | xargs)
+      if [[ $first -eq 0 ]]; then
+        first=1
+      else
+        echo -n -e ", "
+      fi
+      echo -n -e "\"$key\": \"$value\""
+    fi
+  done <<< "$vulns"
+  echo -n -e "}"
 
   echo -n "}"
 }


### PR DESCRIPTION
This PR adds support for displaying CPU vulnerabilities in the showdiff commands.

CPU vulnerabilities are obtained using either the `lscpu` command or from `/sys/devices/system/cpu/vulnerabilities/`. Since CPU vulnerabilities may affect kernel performance, it is important to display them in the profile diffs. Moreover, this PR refactors and simplifies the code reponsible for generating profile headers and metadata in the showdiff package.

This PR resolves #263.