### PR TITLE
Release version 0.23.7

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,16 @@
 Changelog
 =========
 
+0.23.7 (2024-11-04)
+-------------------
+
+  - Add Flamegraph diffs to the showdiff report
+  - Fix Flamegraph height scaling in showdiff report
+  - Add CPU vulnerabilities overview to the profile specification in showdiff
+  - Perun now supports Python 3.13
+  - README file has been updated with more detailed installation instructions
+
+
 0.23.6 (2024-10-06)
 -------------------
 

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
     'perun',
     'c',
-    version: '0.23.6',
+    version: '0.23.7',
     license: 'GPL-3',
     meson_version: '>=1.0.0',
     default_options: [


### PR DESCRIPTION
- Add Flamegraph diffs to the showdiff report
- Fix Flamegraph height scaling in showdiff report
- Add CPU vulnerabilities overview to the profile specification in showdiff
- Perun now supports Python 3.13
- README file has been updated with more detailed installation instructions