### PR TITLE
Fix the usage of capitalize() in log.py

### DIFF
--- a/perun/postprocess/regression_analysis/tools.py
+++ b/perun/postprocess/regression_analysis/tools.py
@@ -122,7 +122,7 @@ def sort_points(x_pts: list[float], y_pts: list[float]) -> tuple[list[float], li
     return list(res_x_pts), list(res_y_pts)
 
 
-def split_model_interval(start: int, end: int, steps: int) -> npt.NDArray[np.float64]:
+def split_model_interval(start: int, end: int, steps: int) -> npt.NDArray[np.floating[Any]]:
     """Splits the interval defined by its edges to #steps points in a safe manner, i.e. no zero
         points in the array, which prevents zero division errors.
 

--- a/perun/utils/common/common_kit.py
+++ b/perun/utils/common/common_kit.py
@@ -213,6 +213,20 @@ def format_counter_number(count: int, max_number: int) -> str:
     return f"{count:{len(str(max_number))}d}"
 
 
+def capitalize_first(string: str) -> str:
+    """Helper function that capitalizes only the first letter of a string.
+
+    Note that contrary to the library string method `capitalize()` that changes the remaining
+    characters to lowercase, this helper function does not modify any other character except the
+    first.
+
+    :param string: the string to capitalize
+
+    :return: the string with the first letter being uppercase
+    """
+    return string[0].upper() + string[1:]
+
+
 def default_signal_handler(signum: int, frame: types.FrameType) -> None:
     """Default signal handler used by the HandledSignals CM.
 

--- a/perun/utils/log.py
+++ b/perun/utils/log.py
@@ -325,23 +325,31 @@ def minor_status(msg: str, status: str = "", sep: str = "-") -> None:
 
     It prints the status of some action, starting with `-` with indent and ending with newline.
 
-    :param msg: printed message, which will be stripped from whitespace and capitalized
+    Note, that there are some sanitizations happening to the message:
+      1. Leading and trailing whitespace characters will be stripped;
+      2. The first character will be made uppercase, if possible.
+
+    :param msg: message to print, will be sanitized
     :param status: status of the info
     :param sep: separator used to separate the info with its results
     """
-    write(" " * CURRENT_INDENT * 2 + f" - {msg.strip().capitalize()} {sep} {status}")
+    write(
+        " " * CURRENT_INDENT * 2 + f" - {common_kit.capitalize_first(msg.strip())} {sep} {status}"
+    )
 
 
 def minor_info(msg: str, end: str = "\n") -> None:
     """Prints minor information, formatted with indent and starting with -
 
     Note, that there are some sanitizations happening:
-      1. If we want to end the info in new line, we add the punctuations;
+      1. Leading and trailing whitespace characters will be stripped;
+      2. The first character will be made uppercase, if possible;
+      3. If the message ends with a new line, we add a punctuation.
 
-    :param msg: printed message, which will be stripped from whitespace and capitalized
+    :param msg: message to print, will be sanitized
     :param end: ending of the message
     """
-    msg = msg.strip().capitalize()
+    msg = common_kit.capitalize_first(msg.strip())
     if end == "\n" and msg[-1] not in ".!;":
         msg += "."
     write(" " * CURRENT_INDENT * 2 + f" - {msg}", end)

--- a/perun/view/scatter/factory.py
+++ b/perun/view/scatter/factory.py
@@ -232,7 +232,7 @@ def _create_regressogram_model(model: ProfileModel) -> hv.Curve:
 
 
 def _render_step_function(
-    x_pts: npt.NDArray[np.float64], y_pts: npt.NDArray[np.float64], legend: str
+    x_pts: npt.NDArray[np.floating[Any]], y_pts: npt.NDArray[np.floating[Any]], legend: str
 ) -> hv.Curve:
     """Build regressogram's step lines according to given coordinates.
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1144,7 +1144,7 @@ def test_reg_analysis_correct(pcs_single_prof):
         [cprof_idx, "regression-analysis", "-m", "iterative", "-r", "all", "-s", "4"],
     )
     asserts.predicate_from_cli(result, result.exit_code == 0)
-    asserts.predicate_from_cli(result, result.output.count("too few point") == 5)
+    asserts.predicate_from_cli(result, result.output.count("Too few point") == 5)
     asserts.predicate_from_cli(result, "succeeded" in result.output)
 
     # Test too many steps output
@@ -1162,7 +1162,7 @@ def test_reg_analysis_correct(pcs_single_prof):
         ],
     )
     asserts.predicate_from_cli(result, result.exit_code == 0)
-    asserts.predicate_from_cli(result, result.output.count("too few point") == 7)
+    asserts.predicate_from_cli(result, result.output.count("Too few point") == 7)
     asserts.predicate_from_cli(result, "succeeded" in result.output)
 
     # Test steps value clamping with iterative method

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -104,7 +104,7 @@ def test_no_params_exists_pcs_in_same_dir(capsys):
     # Check if user was warned, that at the given path, the perun pcs was reinitialized
     out, _ = capsys.readouterr()
     assert (
-        "Reinitialized existing perun repository" in common_kit.escape_ansi(out)
+        "Reinitialized existing Perun repository" in common_kit.escape_ansi(out)
         and f"{pcs_path}" in out
     )
 
@@ -178,7 +178,7 @@ def test_git_exists_already(capsys):
     # Capture the out and check if the message contained "Reinitialized"
     out, _ = capsys.readouterr()
     assert (
-        "Reinitialized existing git repository" in common_kit.escape_ansi(out) and pcs_path in out
+        "Reinitialized existing Git repository" in common_kit.escape_ansi(out) and pcs_path in out
     )
 
 


### PR DESCRIPTION
The `log.py` module used the string `capitalize()` method to sanitize the logged messages. This also accidentally transformed the path strings in the output to be lowercase, which was confusing to the user.

This PR fixes #270.