### PR TITLE
Ensure `palette.map` file is deleted after the diff report is generated

### DIFF
--- a/perun/view_diff/flamegraph/run.py
+++ b/perun/view_diff/flamegraph/run.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 # Standard Imports
 from collections import defaultdict
 from datetime import datetime, timezone
+import pathlib
 from subprocess import CalledProcessError
 from typing import Any
 import re
@@ -190,6 +191,8 @@ def generate_flamegraphs(
             flamegraphs.append(
                 (dtype, escaped_lhs, escaped_rhs, lhs_escaped_diff, rhs_escaped_diff)
             )
+            # Attempt to remove the leftover temporary 'palette.map' file that is no longer needed
+            pathlib.Path("palette.map").unlink(missing_ok=True)
         except CalledProcessError as exc:
             log.warn(f"could not generate flamegraphs: {exc}")
     return flamegraphs


### PR DESCRIPTION
The consistent palette (`--cp`) option of flamegraph.pl produces a `palette.map` file to match colors of the same functions in multiple flamegraphs. This PR will ensure that Perun showdiff now deletes the palette file after the flamegraphs are generated.