### PR TITLE
Improved profile sorting and fields in status

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -110,13 +110,13 @@ List of Supported Options
     will yield the following status when running ``perun status`` (both for stored and pending
     profiles)::
 
-        ═══════════════════════════════════════════════════════════════════════════════▣
-          id ┃   type  ┃  cmd   ┃ workload ┃  args  ┃ collector  ┃         time        ┃
-        ═══════════════════════════════════════════════════════════════════════════════▣
-         0@p ┃ [mixed] ┃ target ┃ hello    ┃        ┃ complexity ┃ 2017-09-07 14:41:49 ┃
-         1@p ┃ [time ] ┃ perun  ┃          ┃ status ┃ time       ┃ 2017-10-19 12:30:29 ┃
-         2@p ┃ [time ] ┃ perun  ┃          ┃ --help ┃ time       ┃ 2017-10-19 12:30:31 ┃
-        ═══════════════════════════════════════════════════════════════════════════════▣
+        ══════════════════════════════════════════════════════════════════════▣
+          id ┃   type  ┃  cmd   ┃ workload ┃ collector  ┃         time        ┃
+        ══════════════════════════════════════════════════════════════════════▣
+         0@p ┃ [mixed] ┃ target ┃ hello    ┃ complexity ┃ 2017-09-07 14:41:49 ┃
+         1@p ┃ [time ] ┃ perun  ┃ status   ┃ time       ┃ 2017-10-19 12:30:29 ┃
+         2@p ┃ [time ] ┃ perun  ┃ --help   ┃ time       ┃ 2017-10-19 12:30:31 ┃
+        ══════════════════════════════════════════════════════════════════════▣
 
 .. confkey:: format.shortlog
 
@@ -204,6 +204,11 @@ List of Supported Options
 
 .. currentmodule:: perun.profile.helpers
 .. autoattribute:: ProfileInfo.valid_attributes
+
+.. confkey:: format.sort_profiles_order
+
+    ``[recursive]`` Specifies the order which will be used for sorting the output of the
+    ``perun status`` commands. Can be either ``ascending`` or ``descending``.
 
 .. confunit:: execute
 

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -175,6 +175,10 @@ List of Supported Options
         Placeholder for workload that was supplied to the profiled command (refer to
         :munit:`workloads` or :doc:`jobs` for more details).
 
+    ``%label%``:
+
+        Placeholder for custom user-supplied string label associated with a profile.
+
     ``%type%``:
 
         Placeholder for global type of the resources of the profile, i.e. `memory`, `time`,

--- a/docs/logs.rst
+++ b/docs/logs.rst
@@ -34,20 +34,20 @@ E.g. the following formatting string::
 will yield the following status when running ``perun status`` (both for stored and pending
 profiles)::
 
-    ═══════════════════════════════════════════════════════════════════════════════▣
-      id ┃   type  ┃  cmd   ┃ workload ┃  args  ┃ collector  ┃         time        ┃
-    ═══════════════════════════════════════════════════════════════════════════════▣
-     0@p ┃ [mixed] ┃ target ┃ hello    ┃        ┃ complexity ┃ 2017-09-07 14:41:49 ┃
-     1@p ┃ [time ] ┃ perun  ┃          ┃ status ┃ time       ┃ 2017-10-19 12:30:29 ┃
-     2@p ┃ [time ] ┃ perun  ┃          ┃ --help ┃ time       ┃ 2017-10-19 12:30:31 ┃
-    ═══════════════════════════════════════════════════════════════════════════════▣
+    ══════════════════════════════════════════════════════════════════════▣
+      id ┃   type  ┃  cmd   ┃ workload ┃ collector  ┃         time        ┃
+    ══════════════════════════════════════════════════════════════════════▣
+     0@p ┃ [mixed] ┃ target ┃ hello    ┃ complexity ┃ 2017-09-07 14:41:49 ┃
+     1@p ┃ [time ] ┃ perun  ┃ status   ┃ time       ┃ 2017-10-19 12:30:29 ┃
+     2@p ┃ [time ] ┃ perun  ┃ --help   ┃ time       ┃ 2017-10-19 12:30:31 ┃
+    ══════════════════════════════════════════════════════════════════════▣
 
 The first column of the ``perun status`` output, ``id``, has a fixed position and defines a tag for
-the given, which can be used in ``add``, ``rm``, ``show`` and ``postprocessby`` commands as a quick
-wildcard for concrete profiles, e.g. ``perun add 0@p`` would register the first profile stored in
-the pending ``.perun/jobs`` directory to the index of current head. Tags are always in form of
-``i@p`` (for pending profiles) and ``i@i`` for profiles registered in index, where ``i`` stands for
-position in the corresponding storage, index from zero.
+the given profile, which can be used in ``add``, ``rm``, ``show`` and ``postprocessby`` commands as
+a quick wildcard for concrete profiles, e.g. ``perun add 0@p`` would register the first profile
+stored in the pending ``.perun/jobs`` directory to the index of current head. Tags are always in
+form of ``i@p`` (for pending profiles) and ``i@i`` for profiles registered in index, where ``i``
+stands for position in the corresponding storage, index from zero.
 
 The specification of the formatting string can contain the following special tags:
 
@@ -76,10 +76,12 @@ The specification of the formatting string can contain the following special tag
     Original source of the profile. This corresponds to the name of the generated profile
     and the original path.
 
-By default the profiles are sorted according to the timestamp. The sort order can be modified by
-setting either the :ckey:`format.sort_profiles_by` or the :doc:`cli` option ``--sort-by`` to a
-valid profile information attribute. Setting the command line option ``--sort-by`` has higher
-priority than the key set in the :ckey:`format.sort_profiles_by`.
+By default the profiles are sorted in ascending order according to the timestamp. The sort order
+can be modified by setting either the :ckey:`format.sort_profiles_by` and
+:ckey:`format.sort_profiles_order` configuration options, or the :doc:`cli` options ``--sort-by``
+and ``--sort-order`` to a valid profile information attribute and a valid sort order. Setting the
+command line options ``--sort-by`` and ``--sort-order`` have higher priority than the keys set in
+the :ckey:`format.sort_profiles_by` and :ckey:`format.sort_profiles_order`.
 
 .. _logs-log:
 

--- a/docs/logs.rst
+++ b/docs/logs.rst
@@ -65,6 +65,11 @@ The specification of the formatting string can contain the following special tag
     program, script or binary. Refer to :ref:`jobs-overview` for more information about profiling
     jobs and command workloads.
 
+``%label%``:
+    Lists the optional, user-defined string label associated with the profile. Labels may be used
+    to further distinguish profiles, e.g., collected using different environment configuration or
+    collected on differently configured machines.
+
 ``%collector%``:
     Lists the collector which was used to obtain the given profile. Refer to :doc:`collectors` for
     list of supported collectors and more information about collection of profiles.

--- a/perun/cli.py
+++ b/perun/cli.py
@@ -63,7 +63,7 @@ from perun.utils.exceptions import (
     MissingConfigSectionException,
     ExternalEditorErrorException,
 )
-from perun.utils.structs.common_structs import Executable
+from perun.utils.structs.common_structs import Executable, SortOrder
 from perun.utils.structs.diff_structs import HeaderDisplayStyle
 from perun import fuzz as fuzz
 import perun.postprocess
@@ -398,8 +398,8 @@ def add(profile: list[str], minor: Optional[str], **kwargs: Any) -> None:
     pending profiles, then all the non-existing pending profiles will
     be obviously skipped.
     Run ``perun status`` to see the `tag` annotation of pending profiles.
-    Tags consider the sorted order as specified by the following option
-    :ckey:`format.sort_profiles_by`.
+    Tags consider the sorted order as specified by the options
+    :ckey:`format.sort_profiles_by` and :ckey:`format.sort_profiles_order`.
 
     Example of adding profiles:
 
@@ -486,8 +486,8 @@ def remove(
     to represent the removed profile. If the path points to existing profile in
     pending jobs (i.e. ``.perun/jobs`` directory) the profile is removed from the
     jobs, otherwise it is looked-up in the index.
-    Tags consider the sorted order as specified by the following option
-    :ckey:`format.sort_profiles_by`.
+    Tags consider the sorted order as specified by the options
+    :ckey:`format.sort_profiles_by` and :ckey:`format.sort_profiles_order`.
 
     Examples of removing profiles:
 
@@ -565,9 +565,22 @@ def log(head: Optional[str], **kwargs: Any) -> None:
     type=click.Choice(profiles.ProfileInfo.valid_attributes),
     callback=cli_kit.set_config_option_from_flag(pcs.local_config, "format.sort_profiles_by", str),
     help=(
-        "Sets the <key> in the local configuration for sorting profiles. "
-        "Note that after setting the <key> it will be used for sorting which is "
-        "considered in pending and index tags!"
+        "Sets the sort key in the local configuration as 'format.sort_profiles_by' that will be "
+        "used for sorting both pending and index profiles."
+    ),
+)
+@click.option(
+    "--sort-order",
+    "-so",
+    "format__sort_profiles_order",
+    nargs=1,
+    type=click.Choice(SortOrder.supported()),
+    callback=cli_kit.set_config_option_from_flag(
+        pcs.local_config, "format.sort_profiles_order", str
+    ),
+    help=(
+        "Sets the sort order in the local configuration as 'format.sort_profiles_order' that will "
+        "be used for sorting both pending and index profiles."
     ),
 )
 def status(**kwargs: Any) -> None:
@@ -585,17 +598,17 @@ def status(**kwargs: Any) -> None:
     default using ``less``).
 
     An error is raised if the command is executed outside of range of any
-    perun, or configuration misses certain configuration keys
-    (namely ``format.status``).
+    perun, or configuration misses certain configuration keys (namely
+    ``format.status``).
 
     Profiles (both registered in index and stored in pending directory) are sorted
-    according to the :ckey:`format.sort_profiles_by`. The option ``--sort-by``
-    sets this key in the local configuration for further usage. This means that
+    according to the key :ckey:`format.sort_profiles_by` and order
+    :ckey:`format.sort_profiles_order`. The options ``--sort-by`` and ``--sort-order``
+    set these keys in the local configuration for further usage. This means that
     using the pending or index tags will consider this order.
 
     Refer to :ref:`logs-status` for information how to customize the outputs of
-    ``status`` or how to set :ckey:`format.status` in nearest
-    configuration.
+    ``status`` or how to set :ckey:`format.status` in nearest configuration.
     """
     try:
         commands.try_init()
@@ -651,8 +664,8 @@ def show(ctx: click.Context, profile: Profile, **_: Any) -> None:
         5. Otherwise, the directory is walked for any match. Each found match
            is asked for confirmation by user.
 
-    Tags consider the sorted order as specified by the following option
-    :ckey:`format.sort_profiles_by`.
+    Tags consider the sorted order as specified by the options
+    :ckey:`format.sort_profiles_by` and :ckey:`format.sort_profiles_order`.
 
     Example 1. The following command will show the first profile registered at
     index of ``HEAD~1`` commit. The resulting graph will contain bars
@@ -742,8 +755,8 @@ def showdiff(ctx: click.Context, **kwargs: Any) -> None:
         5. Otherwise, the directory is walked for any match. Each found match
            is asked for confirmation by user.
 
-    Tags consider the sorted order as specified by the following option
-    :ckey:`format.sort_profiles_by`.
+    Tags consider the sorted order as specified by the options
+    :ckey:`format.sort_profiles_by` and :ckey:`format.sort_profiles_order`.
 
     Example 1. The following command will show the difference first two profiles
     registered at index of ``HEAD~1`` commit::
@@ -813,8 +826,8 @@ def postprocessby(ctx: click.Context, profile: Profile, **_: Any) -> None:
         5. Otherwise, the directory is walked for any match. Each found match
            is asked for confirmation by user.
 
-    Tags consider the sorted order as specified by the following option
-    :ckey:`format.sort_profiles_by`.
+    Tags consider the sorted order as specified by the options
+    :ckey:`format.sort_profiles_by` and :ckey:`format.sort_profiles_order`.
 
     For checking the associated `tags` to profiles run ``perun status``.
 

--- a/perun/cli_groups/import_cli.py
+++ b/perun/cli_groups/import_cli.py
@@ -80,6 +80,15 @@ from perun.utils.common import cli_kit
     default=False,
     help="Saves the imported profile to index.",
 )
+@click.option(
+    "--profile-name",
+    "-pn",
+    nargs=1,
+    type=str,
+    help=(
+        "Specifies the name of the resulting imported profile, which will be stored in .perun/jobs."
+    ),
+)
 @click.pass_context
 def import_group(ctx: click.Context, **kwargs: Any) -> None:
     """Imports Perun profiles from different formats.

--- a/perun/cli_groups/import_cli.py
+++ b/perun/cli_groups/import_cli.py
@@ -89,6 +89,14 @@ from perun.utils.common import cli_kit
         "Specifies the name of the resulting imported profile, which will be stored in .perun/jobs."
     ),
 )
+@click.option(
+    "--profile-label",
+    "-pl",
+    nargs=1,
+    type=str,
+    default="",
+    help="An optional custom label to associate with the imported profile.",
+)
 @click.pass_context
 def import_group(ctx: click.Context, **kwargs: Any) -> None:
     """Imports Perun profiles from different formats.

--- a/perun/logic/commands.py
+++ b/perun/logic/commands.py
@@ -1094,6 +1094,7 @@ def get_untracked_profiles() -> list[ProfileInfo]:
                     "type": index_entry.type,
                     "cmd": index_entry.cmd,
                     "workload": index_entry.workload,
+                    "label": index_entry.label,
                 },
                 "collector_info": {"name": index_entry.collector},
                 "postprocessors": [{"name": p} for p in index_entry.postprocessors],

--- a/perun/logic/config.py
+++ b/perun/logic/config.py
@@ -214,7 +214,7 @@ format:
     output_profile_template: "%collector%-%cmd%-%workload%-%date%"
     output_show_template: "%collector%-%cmd%-%workload%-%date%"
     sort_profiles_by: time
-    sort_profiles_order: ascending
+    sort_profiles_order: asc
 
 degradation:
     apply: all

--- a/perun/logic/config.py
+++ b/perun/logic/config.py
@@ -11,7 +11,7 @@ containing formats and options for one execution of perun command.
 from __future__ import annotations
 
 # Standard Imports
-from typing import Any, Iterable, Optional
+from typing import Any, Iterable, Optional, TypeVar
 import dataclasses
 import os
 import re
@@ -25,6 +25,9 @@ from perun.logic import config_templates
 from perun.utils import decorators, exceptions, log as perun_log, streams
 from perun.utils.common import common_kit
 from perun.utils.exceptions import SuppressedExceptions
+
+
+T = TypeVar("T")
 
 
 def is_valid_key(key: str) -> bool:
@@ -211,6 +214,7 @@ format:
     output_profile_template: "%collector%-%cmd%-%workload%-%date%"
     output_show_template: "%collector%-%cmd%-%workload%-%date%"
     sort_profiles_by: time
+    sort_profiles_order: ascending
 
 degradation:
     apply: all
@@ -468,3 +472,38 @@ def gather_key_recursively(key: str) -> list[Any]:
         except exceptions.MissingConfigSectionException:
             continue
     return gathered_values
+
+
+def safely_lookup_key_recursively(key: str, allowed_values: Iterable[T], default: T) -> T:
+    """Safely recursively looks up the key in runtime, local and shared config.
+
+    By safely, we mean that if the function returns a value, that value will be one of the allowed
+    values. If no allowed values are provided, or the default value itself is not one of the allowed
+    values, an AssertionError is raised.
+
+    :param key: the looked up key
+    :param allowed_values: a nonempty set of allowed values
+    :param default: a default value (must be one of allowed value) to use in case of any issues
+    """
+    # A set of allowed values must be provided and the default value must be one of the allowed
+    # values to ensure the resulting value is always valid.
+    assert allowed_values and default in allowed_values
+    error_desc: str = ""
+    value = default
+    try:
+        value = lookup_key_recursively(key)
+        if value not in allowed_values:
+            # If the stored key is invalid, we use the default value instead
+            error_desc = f"invalid value '{value}' of key '{key}' in config. "
+            value = default
+    except exceptions.MissingConfigSectionException:
+        # If there is no value for the looked up key, we use the default value instead
+        error_desc = f"missing config value for key '{key}'. "
+    if error_desc:
+        perun_log.warn(
+            error_desc + f"The default value '{default}' will be used instead.\n\n"
+            f"Please run 'perun config edit' and set '{key}' to one of "
+            f"({', '.join(map(str, allowed_values))}). "
+            f"Consult the documentation (Configuration and Logs) for more information."
+        )
+    return value

--- a/perun/logic/config_templates.py
+++ b/perun/logic/config_templates.py
@@ -156,7 +156,7 @@ profiles:
 ## Be default, we sort the profiles by time in ascending order
 format:
   sort_profiles_by: time
-  sort_profiles_order: ascending
+  sort_profiles_order: asc
 {% if format is defined and format.output_profile_template is defined %}
 ## The following changes the automatically generated name of the profiles
   output_profile_template: "{{ format.output_profile_template }}"

--- a/perun/logic/config_templates.py
+++ b/perun/logic/config_templates.py
@@ -153,9 +153,10 @@ profiles:
 #   register_after_run: true
 {% endif %}
 
-## Be default, we sort the profiles by time
+## Be default, we sort the profiles by time in ascending order
 format:
   sort_profiles_by: time
+  sort_profiles_order: ascending
 {% if format is defined and format.output_profile_template is defined %}
 ## The following changes the automatically generated name of the profiles
   output_profile_template: "{{ format.output_profile_template }}"

--- a/perun/logic/index.py
+++ b/perun/logic/index.py
@@ -74,6 +74,7 @@ class BasicIndexEntry:
         self.type: str = "??"
         self.cmd: str = "??"
         self.workload: str = "??"
+        self.label: str = "??"
         self.collector: str = "??"
         self.postprocessors: list[str] = []
 
@@ -141,8 +142,8 @@ class ExtendedIndexEntry(BasicIndexEntry):
     :ivar path: the original path to the profile
     :ivar offset: offset of the entry within the index
     :ivar cmd: command for which we collected data
-    :ivar args: arguments of the command
     :ivar workload: workload of the command
+    :ivar label: a custom profile label
     :ivar collector: collector used to collect data
     :ivar postprocessors: list of postprocessors used to postprocess data
     """
@@ -168,6 +169,7 @@ class ExtendedIndexEntry(BasicIndexEntry):
         self.type: str = profile["header"]["type"]
         self.cmd: str = profile["header"]["cmd"]
         self.workload: str = profile["header"].get("workload", "")
+        self.label: str = profile["header"].get("label", "")
         self.collector: str = profile["collector_info"]["name"]
         self.postprocessors: list[str] = [
             postprocessor["name"] for postprocessor in profile["postprocessors"]
@@ -237,6 +239,7 @@ class ExtendedIndexEntry(BasicIndexEntry):
         profile["header"]["type"] = store.read_string_from_handle(index_handle)
         profile["header"]["cmd"] = store.read_string_from_handle(index_handle)
         profile["header"]["workload"] = store.read_string_from_handle(index_handle)
+        profile["header"]["label"] = store.read_string_from_handle(index_handle)
         profile["collector_info"]["name"] = store.read_string_from_handle(index_handle)
         profile["postprocessors"] = [
             {"name": post} for post in store.read_list_from_handle(index_handle)
@@ -260,6 +263,7 @@ class ExtendedIndexEntry(BasicIndexEntry):
         store.write_string_to_handle(index_handle, self.type)
         store.write_string_to_handle(index_handle, self.cmd)
         store.write_string_to_handle(index_handle, self.workload)
+        store.write_string_to_handle(index_handle, self.label)
         store.write_string_to_handle(index_handle, self.collector)
         store.write_list_to_handle(index_handle, self.postprocessors)
 
@@ -268,15 +272,10 @@ class ExtendedIndexEntry(BasicIndexEntry):
 
         :return:  string representation of the entry
         """
-        return " @{3} {2} -> {1} ({0}) {4}; {5}; {6} {7}".format(
-            self.time,
-            self.checksum,
-            self.path,
-            self.offset,
-            self.type,
-            " ".join([self.cmd, self.workload]),
-            self.collector,
-            " ".join(self.postprocessors),
+        return (
+            f" @{self.offset} {self.path} -> {self.checksum} ({self.time}) {self.type}; "
+            f"{' '.join([self.cmd, self.workload])}; {self.label}; "
+            f"{self.collector} {' '.join(self.postprocessors)}"
         )
 
 

--- a/perun/profile/helpers.py
+++ b/perun/profile/helpers.py
@@ -30,7 +30,7 @@ from typing import Any, TYPE_CHECKING, Union
 # Perun Imports
 from perun.logic import config, index, pcs, store
 from perun import profile as profiles
-from perun.utils import log as perun_log
+from perun.utils import decorators, log as perun_log
 from perun.utils.common import common_kit
 from perun.utils.external import environment
 from perun.utils.exceptions import (

--- a/perun/profile/helpers.py
+++ b/perun/profile/helpers.py
@@ -105,6 +105,8 @@ def generate_profile_name(profile: profiles.Profile) -> str:
             Command of the job
         `%workload%`:
             Workload of the job
+        `%label%`:
+            A custom string label associated with the profile
         `%type%`:
             Type of the generated profile
         `%kernel%`:
@@ -155,6 +157,10 @@ def generate_profile_name(profile: profiles.Profile) -> str:
                 )
                 + "]",
             ),
+            (
+                r"%label%",
+                lambda scanner, token: lookup_value(profile["header"], "label", "_"),
+            ),
             (r"%kernel%", lambda scanner, token: environment.get_kernel()),
             (
                 r"%type%",
@@ -201,6 +207,7 @@ def load_list_for_minor_version(minor_version: str) -> list["ProfileInfo"]:
                 "type": index_entry.type,
                 "cmd": index_entry.cmd,
                 "workload": index_entry.workload,
+                "label": index_entry.label,
             },
             "collector_info": {"name": index_entry.collector},
             "postprocessors": [{"name": p} for p in index_entry.postprocessors],
@@ -518,6 +525,7 @@ class ProfileInfo:
         "type",
         "cmd",
         "workload",
+        "label",
         "collector",
         "postprocessors",
         "checksum",
@@ -540,7 +548,6 @@ class ProfileInfo:
         :param is_raw_profile: true if the stored profile is raw, i.e. in json and not
             compressed
         """
-
         self._is_raw_profile = is_raw_profile
         self.source = path
         self.realpath = os.path.relpath(real_path, os.getcwd())
@@ -548,6 +555,7 @@ class ProfileInfo:
         self.type = profile_info["header"]["type"]
         self.cmd = profile_info["header"]["cmd"]
         self.workload = profile_info["header"]["workload"]
+        self.label = profile_info["header"].get("label", "")
         self.collector = profile_info["collector_info"]["name"]
         self.postprocessors = [
             postprocessor["name"] for postprocessor in profile_info["postprocessors"]
@@ -593,6 +601,7 @@ class ProfileInfo:
         "time",
         "cmd",
         "workload",
+        "label",
         "collector",
         "checksum",
         "source",

--- a/perun/profile/imports.py
+++ b/perun/profile/imports.py
@@ -215,6 +215,7 @@ def import_perf_profile(
                 "cmd": kwargs.get("cmd", ""),
                 "exitcode": [p.exit_code for p in profiles],
                 "workload": kwargs.get("workload", ""),
+                "label": kwargs.get("profile_label", ""),
                 "units": {"time": "sample"},
             },
             "collector_info": {
@@ -262,6 +263,7 @@ def import_elk_profile(
                 "cmd": kwargs.get("cmd", ""),
                 "exitcode": "?",
                 "workload": kwargs.get("workload", ""),
+                "label": kwargs.get("profile_label", ""),
                 "units": {"time": "sample"},
             },
             "collector_info": {

--- a/perun/profile/imports.py
+++ b/perun/profile/imports.py
@@ -228,7 +228,9 @@ def import_perf_profile(
             "postprocessors": [],
         }
     )
-    save_imported_profile(prof, kwargs.get("save_to_index", False), minor_version)
+    save_imported_profile(
+        prof, kwargs.get("save_to_index", False), minor_version, kwargs.get("profile_name")
+    )
 
 
 def import_elk_profile(
@@ -269,21 +271,30 @@ def import_elk_profile(
             "postprocessors": [],
         }
     )
-    save_imported_profile(prof, save_to_index, minor_version)
+    save_imported_profile(prof, save_to_index, minor_version, kwargs.get("profile_name"))
 
 
 def save_imported_profile(
-    prof: profile.Profile, save_to_index: bool, minor_version: MinorVersion
+    prof: profile.Profile,
+    save_to_index: bool,
+    minor_version: MinorVersion,
+    profile_name: str | None = None,
 ) -> None:
     """Saves the imported profile either to index or to pending jobs.
 
     :param prof: imported profile
     :param minor_version: minor version corresponding to the imported profiles.
     :param save_to_index: indication whether we should save the imported profiles to index.
+    :param profile_name: optional custom name of the saved profile
     """
-    full_profile_name = profile.generate_profile_name(prof)
+    if not profile_name:
+        # No custom profile name provided, generate the name
+        profile_name = profile.generate_profile_name(prof)
+    elif not profile_name.endswith(".perf"):
+        # Make sure the profile name ends with the proper suffix
+        profile_name += ".perf"
     profile_directory = pcs.get_job_directory()
-    full_profile_path = os.path.join(profile_directory, full_profile_name)
+    full_profile_path = os.path.join(profile_directory, profile_name)
 
     streams.store_json(prof.serialize(), full_profile_path)
     log.minor_status(

--- a/perun/utils/structs/common_structs.py
+++ b/perun/utils/structs/common_structs.py
@@ -677,6 +677,36 @@ class HandledSignals:
         return isinstance(exc_val, self.handler_exc)
 
 
+class SortOrder(Enum):
+    """Enumeration representing sorting order in a more descriptive way compared to the library."""
+
+    Ascending = "ascending"
+    Descending = "descending"
+
+    @staticmethod
+    def supported() -> list[str]:
+        """Obtain the collection of supported sort orders.
+
+        :return: the collection of valid sort orders
+        """
+        return [order.value for order in SortOrder]
+
+    @staticmethod
+    def default() -> str:
+        """Provide the default sort order.
+
+        :return: the default sort order
+        """
+        return SortOrder.Ascending.value
+
+    def as_sort_flag(self) -> bool:
+        """Translates the sort order into the library bool representation.
+
+        :return: False if the sort order is ascending, True otherwise
+        """
+        return self.value == SortOrder.Descending.value
+
+
 class WebColorPalette:
     """Colour palette for HTML/JS visualizations"""
 

--- a/perun/utils/structs/common_structs.py
+++ b/perun/utils/structs/common_structs.py
@@ -680,8 +680,8 @@ class HandledSignals:
 class SortOrder(Enum):
     """Enumeration representing sorting order in a more descriptive way compared to the library."""
 
-    Ascending = "ascending"
-    Descending = "descending"
+    Ascending = "asc"
+    Descending = "desc"
 
     @staticmethod
     def supported() -> list[str]:

--- a/perun/vcs/git_repository.py
+++ b/perun/vcs/git_repository.py
@@ -115,7 +115,7 @@ class GitRepository(AbstractRepository):
         :return: yields stream of major versions
         :raises VersionControlSystemException: when the master head cannot be massaged
         """
-        for branch in self.git_repo.branches:  # type: ignore
+        for branch in self.git_repo.branches:
             yield MajorVersion(branch.name, self.massage_parameter(branch.name))
 
     def parse_commit(self, commit: git.objects.Commit) -> MinorVersion:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1199,9 +1199,12 @@ def test_status_correct(pcs_single_prof):
     assert config.lookup_key_recursively("format.sort_profiles_by") == "time"
 
     # Try that the sort order changed
-    short_result = runner.invoke(cli.status, ["--short", "--sort-by", "source"])
+    short_result = runner.invoke(
+        cli.status, ["--short", "--sort-by", "source", "--sort-order", "descending"]
+    )
     asserts.predicate_from_cli(short_result, short_result.exit_code == 0)
     assert pcs_single_prof.local_config().get("format.sort_profiles_by") == "source"
+    assert pcs_single_prof.local_config().get("format.sort_profiles_order") == "descending"
 
     # The sort order is kept the same
     short_result = runner.invoke(cli.status, ["--short"])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1200,11 +1200,11 @@ def test_status_correct(pcs_single_prof):
 
     # Try that the sort order changed
     short_result = runner.invoke(
-        cli.status, ["--short", "--sort-by", "source", "--sort-order", "descending"]
+        cli.status, ["--short", "--sort-by", "source", "--sort-order", "desc"]
     )
     asserts.predicate_from_cli(short_result, short_result.exit_code == 0)
     assert pcs_single_prof.local_config().get("format.sort_profiles_by") == "source"
-    assert pcs_single_prof.local_config().get("format.sort_profiles_order") == "descending"
+    assert pcs_single_prof.local_config().get("format.sort_profiles_order") == "desc"
 
     # The sort order is kept the same
     short_result = runner.invoke(cli.status, ["--short"])

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -78,6 +78,8 @@ def test_imports(pcs_with_svs):
         cli.cli,
         [
             "import",
+            "-pn",
+            "custom_import_profile",
             "-c",
             "ls",
             "-w",
@@ -105,7 +107,8 @@ def test_imports(pcs_with_svs):
         ],
     )
     assert result.exit_code == 0
-    assert len(os.listdir(os.path.join(".perun", "jobs"))) == 5
+    profiles = os.listdir(os.path.join(".perun", "jobs"))
+    assert len(profiles) == 5 and "custom_import_profile.perf" in profiles
 
     # Try to import stack profile using import perf record, we expect failure
     result = runner.invoke(

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -341,7 +341,7 @@ def test_status_sort(monkeypatch, pcs_single_prof, capsys, valid_profile_pool):
     commands.status()
 
     out, _ = capsys.readouterr()
-    assert "missing set option" in out
+    assert "missing config value" in out
 
     cfg = config.Config(
         "shared",
@@ -360,5 +360,5 @@ def test_status_sort(monkeypatch, pcs_single_prof, capsys, valid_profile_pool):
     commands.status()
 
     out, _ = capsys.readouterr()
-    assert "invalid sort key" in out
+    assert "invalid value" in out
     monkeypatch.undo()


### PR DESCRIPTION
Perun config now supports option `format.sort_profiles_order` that allows to set the profile sort order as ascending or
descending. By default, profiles are now sorted in ascending order. This fixes #272.

Perun import now has '--profile-name' option to specify a custom profile name for the imported profile. This fixes #271.

Users can now add custom string labels that briefly describe profiles by some common characteristic, e.g., environment settings or machine specification. Labels can be currently specified only during `perun import`. This fixes #273.