### PR TITLE
Release version 0.23.8

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,18 @@
 Changelog
 =========
 
+0.23.8 (2025-01-05)
+-------------------
+
+  - Fix a bug in the logging module capitalizing log messages
+  - Fix showdiff not deleting a temporary palette.map file
+  - Perun import now allows to specify the name of the resulting profile
+  - It is now possible to specify the sort order for perun status
+  - Perun status now by default sorts profiles in ascending order w.r.t. the time
+  - Perun import now allows to specify a user-defined string label to associate with the profile
+  - New tag %label% may now be used when specifying formats in config
+
+
 0.23.7 (2024-11-04)
 -------------------
 

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
     'perun',
     'c',
-    version: '0.23.7',
+    version: '0.23.8',
     license: 'GPL-3',
     meson_version: '>=1.0.0',
     default_options: [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     # String / text utilities
     "Faker>=26.0.0",
     "ruamel.yaml>=0.18.6",
-    "Jinja2>=3.1.4",
+    "Jinja2>=3.1.5",
 
     # File analysis
     "python-magic>=0.4.27",


### PR DESCRIPTION
  - Fix bug in the logging module capitalizing log messages
  - Fix showdiff not deleting a temporary palette.map file
  - Perun import now allows to specify the name of the resulting profile
  - It is now possible to specify the sort order for perun status
  - Perun status now by default sorts profiles in ascending order w.r.t. the time
  - Perun import now allows to specify a user-defined string label to associate with the profile
  - New tag %lable% may now be used when specifying formats in config