### PR TITLE
Fix incorrect colors in flamegraph diffs

### DIFF
--- a/perun/view_diff/flamegraph/run.py
+++ b/perun/view_diff/flamegraph/run.py
@@ -173,7 +173,6 @@ def generate_flamegraphs(
                     rhs_flame,
                     "Baseline-Target Diff Flamegraph",
                     img_width=width,
-                    fg_flags="--negate",
                     fg_max_trace=max_trace,
                     fg_max_resource=max_resources,
                 )
@@ -183,6 +182,7 @@ def generate_flamegraphs(
                     lhs_flame,
                     "Target-Baseline Diff Flamegraph",
                     img_width=width,
+                    fg_flags="--negate",
                     fg_max_trace=max_trace,
                     fg_max_resource=max_resources,
                 )


### PR DESCRIPTION
The `--negate` parameter has been incorrectly supplied to the baseline-target diff flamegraph instead of the target-baseline diff flamegraph, resulting in wrong colors being used for degradations and optimizations in the generated diffs.