### PR TITLE
Fix a bug in showdiff report resources processing

### DIFF
--- a/perun/view_diff/flamegraph/run.py
+++ b/perun/view_diff/flamegraph/run.py
@@ -219,7 +219,7 @@ def process_maxima(
         if is_inclusive:
             for key in resource:
                 amount = common_kit.try_convert(resource[key], [float])
-                if amount is None or key == "time":
+                if amount is None or key in ("time", "command", "uid"):
                     continue
                 counts[key] += amount
     for key in counts.keys():

--- a/perun/view_diff/report/run.py
+++ b/perun/view_diff/report/run.py
@@ -430,7 +430,7 @@ def process_max(
     """
     for key in resource:
         amount = common_kit.try_convert(resource[key], [float])
-        if amount is None or key == "time":
+        if amount is None or key in ("time", "command", "uid"):
             continue
         readable_key = mapping.get_readable_key(key)
         counts[readable_key] += amount
@@ -452,7 +452,7 @@ def process_node(
     node = graph.get_node(uid)
     for key in resource:
         amount = common_kit.try_convert(resource[key], [float])
-        if amount is None or key == "time":
+        if amount is None or key in ("time", "command", "uid"):
             continue
         readable_key = mapping.get_readable_key(key)
         node.stats.add_stat(profile_type, readable_key, amount)
@@ -477,7 +477,7 @@ def process_edge(
     tgt_stats = graph.get_caller_stats(tgt, src)
     for key in resource:
         amount = common_kit.try_convert(resource[key], [float])
-        if amount is None or key == "time":
+        if amount is None or key in ("time", "command", "uid"):
             continue
         readable_key = mapping.get_readable_key(key)
         src_stats.add_stat(profile_type, readable_key, amount)


### PR DESCRIPTION
The `process_maxima`, `process_max`, `process_node` and `process_edge` functions were incorrectly processing keys such as "command" or "uid" when their values were convertible to floats. Showdiff then tried generating flamegraphs with all "command" values (including strings) as sample counts, which failed and crashed Perun.

This PR introduced a hotfix for the issues, as a more systematic solution to these types of bugs will be implemented in new internal profile representations and new diff report version that are currently under development.