### PR TITLE
Release version 0.24.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+0.24.0 (2025-02-06)
+-------------------
+
+  - Perun now officially supports macOS machines, albeit with some limitations.
+  - Fix a showdiff bug that resulted in diff flamegraphs inverting colors for optimization/degradation.
+  - Fix a showdiff bug that caused crashes on perf profiles with float-convertible attributes other than 'amount'.
+  - Delta debugging is now integrated into the Perun fuzzing loop.
+
+
 0.23.8 (2025-01-05)
 -------------------
 

--- a/README.md
+++ b/README.md
@@ -112,10 +112,21 @@ likely due to some missing system dependencies:
 - `g++`
 - `python-devel`
 - `libmagic`
+- `coreutils`
 - `cmake` (complexity collector)
 - `perf` (kperf collector)
 - `libunwind`, `libunwind-devel` (memory collector)
 - `perl-open` (flamegraph view)
+
+On macOS, additional system dependencies may be needed:
+- `gnu-time`
+- `libunwind-headers`
+
+## Limited support for macOS
+
+Although Perun can be installed on macOS machines as well, most of the Perun collectors are not supported
+yet. Namely: bounds, complexity, kperf, memory and trace. Moreover, the `perun import record` is not
+supported as well due to the `perf` tool not being available on macOS.
 
 ## Checking Perun Installation
 

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
     'perun',
     'c',
-    version: '0.23.8',
+    version: '0.24.0',
     license: 'GPL-3',
     meson_version: '>=1.0.0',
     default_options: [


### PR DESCRIPTION
Changelog:

  - Perun now officially supports macOS machines, albeit with some limitations.
  - Fix a showdiff bug that resulted in diff flamegraphs inverting colors for optimization/degradation.
  - Fix a showdiff bug that caused crashes on perf profiles with float-convertible attributes other than 'amount'.
  - Delta debugging is now integrated into the Perun fuzzing loop.