### PR TITLE
Fix perf profiles storing only a subtrace in the resources

### DIFF
--- a/perun/collect/kperf/parser.py
+++ b/perun/collect/kperf/parser.py
@@ -28,7 +28,7 @@ def parse_events(perf_events: list[str]) -> list[dict[str, Any]]:
         if event.strip():
             *record, samples = event.split(" ")
             parts = " ".join(record).split(";")
-            command, trace, uid = parts[0], parts[1:-1], parts[-1]
+            command, trace, uid = parts[0], parts[0:-1], parts[-1]
             resources.append(
                 {
                     "amount": int(samples),


### PR DESCRIPTION
Perf profiles in Perun were omitting the initial stack frame containing the name of the process/command that the rest of the call stack belonged to. This made it hard to identify individual processes in system-wide profiles (i.e., profiles collected using `perf record -a ...`).