### PR TITLE
Feature: forward parameters to flamegraph

### DIFF
--- a/perun/collect/kperf/parser.py
+++ b/perun/collect/kperf/parser.py
@@ -28,7 +28,7 @@ def parse_events(perf_events: list[str]) -> list[dict[str, Any]]:
         if event.strip():
             *record, samples = event.split(" ")
             parts = " ".join(record).split(";")
-            command, trace, uid = parts[0], parts[1:-1], parts[-1]
+            command, trace, uid = parts[0], parts[0:-1], parts[-1]
             resources.append(
                 {
                     "amount": int(samples),

--- a/perun/utils/external/commands.py
+++ b/perun/utils/external/commands.py
@@ -187,7 +187,9 @@ def run_safely_external_command(
                     log.cprintln(f"captured stderr: {cmderr.decode('utf-8')}", "red")
                 save_output_of_command(cmd, cmdout, "stdout", verbosity=log_verbosity, tag=log_tag)
                 save_output_of_command(cmd, cmderr, "stderr", verbosity=log_verbosity, tag=log_tag)
-                raise subprocess.CalledProcessError(objects[i].returncode, unpiped_commands[i])
+                raise subprocess.CalledProcessError(
+                    objects[i].returncode, unpiped_commands[i], cmdout, cmderr
+                )
 
     # We set exit code to 0 since everything was OK
     set_exit_code(0, log_verbosity)

--- a/perun/view/flamegraph/flamegraph.py
+++ b/perun/view/flamegraph/flamegraph.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 # Standard Imports
+from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass, field
-import os
+from pathlib import Path
 import tempfile
-from typing import Any
+from typing import Any, Iterator
 
 # Third-Party Imports
 
@@ -16,104 +17,142 @@ from perun.utils.common import script_kit
 from perun.utils.external import commands
 
 
-def draw_flame_graph_difference(
-    lhs_flame_data: list[str],
-    rhs_flame_data: list[str],
-    title: str,
-    units: str = "samples",
-    img_width: int = 1200,
-    fg_flags: str = "",
-    fg_min_width: str = "1",
-    fg_max_trace: int = 0,
-    fg_max_resource: float = 0.0,
-) -> str:
-    """Draws difference of two flame graphs from two profiles
+@contextmanager
+def fg_optional_tempfile(flame_data: list[str] | Path) -> Iterator[Path]:
+    """A helper context manager that wraps flame graph data into a file path.
 
-    :param lhs_flame_data: baseline flame graph data
-    :param rhs_flame_data: target flame graph data
-    :param title: title of the flame graph
-    :param units: the units of the flame graph data
-    :param img_width: width of the graph
-    :param fg_flags: additional flags to pass to the flame graph generator script
-    :param fg_min_width: minimum width of the flame graph rectangles that will be drawn
-    :param fg_max_trace: maximum length of traces that are being drawn
-    :param fg_max_resource: maximum number of samples collected
+    If the provided flame graph data are already stored in a file, the file path is wrapped in
+    a context manager. Otherwise, a new temporary file is created, the data are stored in it
+    and the context manager wraps the path. The created temporary file will be deleted when the
+    context manager wrapper exits.
 
-    :return: the difference flame graph
+    :param flame_data: the flame graph data to wrap
+
+    :return: a wrapper context manager
     """
-    with open("lhs.flame", "w") as lhs_handle:
-        lhs_handle.write("".join(lhs_flame_data))
-
-    with open("rhs.flame", "w") as rhs_handle:
-        rhs_handle.write("".join(rhs_flame_data))
-
-    diff_script = script_kit.get_script("difffolded.pl")
-    flame_script = script_kit.get_script("flamegraph.pl")
-    difference_script = (
-        f"{diff_script} -n lhs.flame rhs.flame "
-        f"| {flame_script} --title '{title}' --countname {units} --reverse "
-        f"--width {img_width} --minwidth {fg_min_width} --maxtrace {fg_max_trace}"
-    )
-    if fg_max_resource > 0.0:
-        difference_script += f' --total {fg_max_resource} --rootnode "Maximum (Baseline, Target)"'
-    if fg_flags:
-        difference_script += f" {fg_flags}"
-    out, _ = commands.run_safely_external_command(difference_script)
-    os.remove("lhs.flame")
-    os.remove("rhs.flame")
-
-    return out.decode("utf-8")
+    if isinstance(flame_data, Path):
+        # Wrap the path in a nullcontext so that we can use it as if it was a context manager
+        with nullcontext(flame_data) as tmp:
+            yield tmp
+    else:
+        # Save the flame data into a temporary file
+        with tempfile.NamedTemporaryFile(mode="w") as tmp:
+            tmp.write("".join(flame_data))
+            # The flush ensures that all data are in the file when the flamegraph scripts read them
+            tmp.flush()
+            yield Path(tmp.name)
 
 
 def draw_flame_graph(
-    flame_data: list[str],
+    flame_data: list[str] | Path,
     title: str,
     units: str = "samples",
-    img_width: int = 1200,
-    fg_min_width: str = "1",
-    fg_max_trace: int = 0,
-    fg_max_resource: float = 0.0,
+    *fg_flags: str,
+    **fg_kwargs: Any,
 ) -> str:
     """Draw Flame graph from flame data.
 
-        To create Flame graphs we use perl script created by Brendan Gregg.
-        https://github.com/brendangregg/FlameGraph/blob/master/flamegraph.pl
+    To create Flame graphs we use perl script created by Brendan Gregg.
+    https://github.com/brendangregg/FlameGraph/blob/master/flamegraph.pl
+
+    If the flame graph data are provided directly, they are first stored in a temporary file that
+    can be read by the flame graph scripts.
 
     :param flame_data: the data to generate the flame graph from
     :param title: title of the flame graph
     :param units: the units of the flame graph data
-    :param img_width: width of the graph
-    :param fg_min_width: minimum width of the flame graph rectangles that will be drawn
-    :param fg_max_trace: maximum length of traces that are being drawn
-    :param fg_max_resource: maximum number of samples collected
+    :param fg_flags: additional flags to pass to the flamegraph.pl script
+    :param fg_kwargs: additional parameters forwarded to the flamegraph.pl
+
+    :return: the generated flame graph
     """
     # converting profile format to format suitable to Flame graph visualization
-    with tempfile.NamedTemporaryFile(delete=False) as tmp:
-        tmp.write("".join(flame_data).encode("utf-8"))
-        tmp.close()
-        cmd = " ".join(
+    with fg_optional_tempfile(flame_data) as tmp:
+        # We extend the flags with 'cp' for consistent palette
+        cmd = build_flamegraph_command(tmp, title, units, "cp", *fg_flags, **fg_kwargs)
+        out, _ = commands.run_safely_external_command(cmd)
+    return out.decode("utf-8")
+
+
+def draw_differential_flame_graph(
+    lhs_flame_data: list[str] | Path,
+    rhs_flame_data: list[str] | Path,
+    title: str,
+    units: str = "samples",
+    *fg_flags: str,
+    **fg_kwargs: Any,
+) -> str:
+    """Draws a lhs->rhs differential flame graph.
+
+    If the LHS or RHS flame graph data are provided directly, they are first stored in temporary
+    files that can be read by the flame graph scripts.
+
+    :param lhs_flame_data: the data of the baseline profile to generate the flame graph diff from
+    :param rhs_flame_data: the data of the target profile to generate the flame graph diff from
+    :param title: title of the flame graph
+    :param units: the units of the flame graph data
+    :param fg_flags: additional flags to pass to the flamegraph.pl script
+    :param fg_kwargs: additional parameters forwarded to the flamegraph.pl script
+
+    :return: the lhs->rhs differential flame graph
+    """
+    with (
+        fg_optional_tempfile(lhs_flame_data) as lhs_flame,
+        fg_optional_tempfile(rhs_flame_data) as rhs_flame,
+    ):
+        diff_cmd = " ".join(
             [
-                script_kit.get_script("flamegraph.pl"),
-                tmp.name,
-                "--cp",
-                "--title",
-                f'"{title}"',
-                "--countname",
-                f"{units}",
-                "--reverse",
-                "--width",
-                f"{img_width}",
-                "--maxtrace",
-                f"{fg_max_trace}",
-                "--minwidth",
-                f"{fg_min_width}",
+                script_kit.get_script("difffolded.pl"),
+                "-n",
+                str(lhs_flame),
+                str(rhs_flame),
             ]
         )
-        if fg_max_resource > 0.0:
-            cmd += f' --total {fg_max_resource} --rootnode "Maximum (Baseline, Target)"'
-        out, _ = commands.run_safely_external_command(cmd)
-        os.remove(tmp.name)
+        fg_cmd = build_flamegraph_command(None, title, units, *fg_flags, **fg_kwargs)
+        out, _ = commands.run_safely_external_command(f"{diff_cmd} | {fg_cmd}")
     return out.decode("utf-8")
+
+
+def build_flamegraph_command(
+    input_path: Path | None,
+    title: str,
+    units: str = "samples",
+    *flags: str,
+    total: int | None = None,
+    **kwargs: Any,
+) -> str:
+    """Creates the flamegraph.pl command that generates a (possibly differential) flame graph.
+
+    :param input_path: path to the file with folded flame graph data
+    :param title: title of the flame graph
+    :param units: the units of the flame graph data
+    :param flags: additional flags to pass to the flamegraph.pl script
+    :param total: the 'total' parameter of the flamegraph.pl script, if provided
+    :param kwargs: additional parameters forwarded to the flamegraph.pl script
+
+    :return: the resulting command for generating a flame graph
+    """
+    cmd = [
+        script_kit.get_script("flamegraph.pl"),
+        str(input_path) if input_path is not None else "",
+        "--title",
+        f"'{title}'",
+        "--countname",
+        f"'{units}'",
+        "--reverse",
+    ]
+    # Additional flags
+    cmd.extend(f"--{flag}" for flag in flags)
+    # Additional parameters
+    for key, val in kwargs.items():
+        if val is not None:
+            cmd.append(f"--{key}")
+            cmd.append(f"'{val}'")
+    # The 'total' parameter needs special handling: add a rootnode that scales the flamegraph
+    # on X axis according to the 'total' value
+    if total is not None and total > 0.0:
+        cmd.extend(["--total", str(total), "--rootnode", "'Maximum (Baseline, Target)'"])
+    return " ".join(cmd)
 
 
 def generate_title(profile_header: dict[str, Any]) -> str:
@@ -177,6 +216,8 @@ def _compute_minwidth_samples(max_resource: float, img_width: float, min_width: 
     :param max_resource: the total number of samples collected
     :param img_width: the width of the graph image
     :param min_width: the minimum width of the flame graph rectangles that will be drawn
+
+    :return: the minimum width threshold
     """
     try:
         if min_width.endswith("%"):

--- a/perun/view_diff/flamegraph/run.py
+++ b/perun/view_diff/flamegraph/run.py
@@ -203,7 +203,10 @@ def generate_flamegraphs(
             # Attempt to remove the leftover temporary 'palette.map' file that is no longer needed
             pathlib.Path("palette.map").unlink(missing_ok=True)
         except CalledProcessError as exc:
-            log.warn(f"could not generate flamegraphs: {exc}")
+            log.warn(
+                f"could not generate flamegraphs: {exc}\n"
+                f"Error message: {exc.stderr.decode('utf-8')}"
+            )
     return flamegraphs
 
 

--- a/perun/view_diff/flamegraph/run.py
+++ b/perun/view_diff/flamegraph/run.py
@@ -24,7 +24,10 @@ from perun.view.flamegraph import flamegraph as flamegraph_factory
 from perun.view_diff.short import run as table_run
 
 
-DEFAULT_WIDTH: int = 600
+# Default values of some flamegraph.pl arguments that our code needs as well
+FG_DEFAULT_IMAGE_WIDTH: int = 1200
+FG_DEFAULT_MIN_WIDTH: float = 0.1
+
 TAGS_TO_INDEX: list[str] = []
 
 
@@ -278,7 +281,7 @@ def generate_flamegraph_difference(
     lhs_final_stats, rhs_final_stats = diff_kit.generate_diff_of_stats(lhs_stats, rhs_stats)
 
     log.major_info("Generating Flamegraph Difference")
-    flamegraphs = generate_flamegraphs(lhs_profile, rhs_profile, data_types)
+    flamegraphs = generate_flamegraphs(lhs_profile, rhs_profile, data_types, width=kwargs["width"])
     lhs_header, rhs_header = diff_kit.generate_diff_of_headers(
         diff_kit.generate_specification(lhs_profile), diff_kit.generate_specification(rhs_profile)
     )
@@ -319,8 +322,8 @@ def generate_flamegraph_difference(
     "--width",
     "-w",
     type=click.INT,
-    default=DEFAULT_WIDTH,
-    help="Sets the width of the flamegraph (default=600px).",
+    default=FG_DEFAULT_IMAGE_WIDTH,
+    help=f"Sets the width of the flamegraph (default={FG_DEFAULT_IMAGE_WIDTH}px).",
 )
 @click.option("--output-file", "-o", help="Sets the output file (default=automatically generated).")
 def flamegraph(ctx: click.Context, *_: Any, **kwargs: Any) -> None:

--- a/perun/view_diff/flamegraph/run.py
+++ b/perun/view_diff/flamegraph/run.py
@@ -117,18 +117,21 @@ def generate_flamegraphs(
     lhs_profile: Profile,
     rhs_profile: Profile,
     data_types: list[str],
-    width: int = DEFAULT_WIDTH,
     skip_diff: bool = False,
     minimize: bool = False,
+    **fg_forward_kwargs: Any,
 ) -> list[tuple[str, str, str, str, str]]:
     """Constructs a list of tuples of flamegraphs for list of data_types
 
     :param lhs_profile: baseline profile
     :param rhs_profile: target profile
     :param data_types: list of data types (resources)
-    :param width: width of the flame graph
     :param skip_diff: whether the flamegraph diff should be skipped or not
     :param minimize: whether the flamegraph should be minimized or not
+    :param fg_forward_kwargs: additional parameters forwarded to the flamegraph scripts
+
+    :return: a collection of (data_type, lhs flamegraph, rhs flamegraph, lhs_rhs_diff_flamegraph,
+             rhs_lhs_diff_flamegraph) tuples
     """
     flamegraphs = []
     for i, dtype in log.progress(enumerate(data_types), description="Generating Flamegraphs"):
@@ -140,54 +143,60 @@ def generate_flamegraphs(
             rhs_flame = convert.to_flame_graph_format(
                 rhs_profile, profile_key=data_type, minimize=minimize
             )
-            _, lhs_max_trace, lhs_max_res = flamegraph_factory.compute_max_traces(lhs_flame, width)
-            _, rhs_max_trace, rhs_max_res = flamegraph_factory.compute_max_traces(rhs_flame, width)
-            max_trace = max(lhs_max_trace, rhs_max_trace)
-            max_resources = max(lhs_max_res, rhs_max_res)
-
-            lhs_graph = flamegraph_factory.draw_flame_graph(
-                lhs_flame,
-                "Baseline Flamegraph",
-                img_width=width,
-                fg_max_trace=max_trace,
-                fg_max_resource=max_resources,
+            fg_image_width = fg_forward_kwargs["width"]
+            _, lhs_max_trace, lhs_max_res = flamegraph_factory.compute_max_traces(
+                lhs_flame, fg_image_width
             )
-            escaped_lhs = escape_content(f"lhs_{i}", lhs_graph)
-            log.minor_success(f"Baseline flamegraph ({dtype})", "generated")
-
-            rhs_graph = flamegraph_factory.draw_flame_graph(
-                rhs_flame,
-                "Target Flamegraph",
-                img_width=width,
-                fg_max_trace=max_trace,
-                fg_max_resource=max_resources,
+            _, rhs_max_trace, rhs_max_res = flamegraph_factory.compute_max_traces(
+                rhs_flame, fg_image_width
             )
-            escaped_rhs = escape_content(f"rhs_{i}", rhs_graph)
-            log.minor_success(f"Target flamegraph ({dtype})", "generated")
+            fg_forward_kwargs["maxtrace"] = max(lhs_max_trace, rhs_max_trace)
+            fg_forward_kwargs["total"] = max(lhs_max_res, rhs_max_res)
 
-            if skip_diff:
-                lhs_escaped_diff, rhs_escaped_diff = "", ""
-            else:
-                lhs_diff_graph = flamegraph_factory.draw_flame_graph_difference(
-                    lhs_flame,
-                    rhs_flame,
-                    "Baseline-Target Diff Flamegraph",
-                    img_width=width,
-                    fg_max_trace=max_trace,
-                    fg_max_resource=max_resources,
+            with (
+                flamegraph_factory.fg_optional_tempfile(lhs_flame) as lhs_file,
+                flamegraph_factory.fg_optional_tempfile(rhs_flame) as rhs_file,
+            ):
+                lhs_graph = flamegraph_factory.draw_flame_graph(
+                    lhs_file,
+                    "Baseline Flamegraph",
+                    **fg_forward_kwargs,
                 )
-                lhs_escaped_diff = escape_content(f"lhs_diff_{i}", lhs_diff_graph)
-                rhs_diff_graph = flamegraph_factory.draw_flame_graph_difference(
-                    rhs_flame,
-                    lhs_flame,
-                    "Target-Baseline Diff Flamegraph",
-                    img_width=width,
-                    fg_flags="--negate",
-                    fg_max_trace=max_trace,
-                    fg_max_resource=max_resources,
+                escaped_lhs = escape_content(f"lhs_{i}", lhs_graph)
+                log.minor_success(f"Baseline flamegraph ({dtype})", "generated")
+
+                rhs_graph = flamegraph_factory.draw_flame_graph(
+                    rhs_file,
+                    "Target Flamegraph",
+                    **fg_forward_kwargs,
                 )
-                rhs_escaped_diff = escape_content(f"rhs_diff_{i}", rhs_diff_graph)
-                log.minor_success(f"Diff flamegraph ({dtype})", "generated")
+                escaped_rhs = escape_content(f"rhs_{i}", rhs_graph)
+                log.minor_success(f"Target flamegraph ({dtype})", "generated")
+
+                if skip_diff:
+                    lhs_escaped_diff, rhs_escaped_diff = "", ""
+                else:
+                    lhs_rhs_diff = flamegraph_factory.draw_differential_flame_graph(
+                        lhs_file,
+                        rhs_file,
+                        "Baseline-Target Diff Flamegraph",
+                        **fg_forward_kwargs,
+                    )
+                    lhs_escaped_diff = escape_content(f"lhs_diff_{i}", lhs_rhs_diff)
+                    log.minor_success(f"Baseline-target diff flamegraph ({dtype})", "generated")
+
+                    # We add the '--negate' for consistent diff colors in the rhs to lhs
+                    # flamegraph diff
+                    rhs_lhs_diff = flamegraph_factory.draw_differential_flame_graph(
+                        rhs_file,
+                        lhs_file,
+                        "Target-Baseline Diff Flamegraph",
+                        "samples",
+                        "negate",
+                        **fg_forward_kwargs,
+                    )
+                    rhs_escaped_diff = escape_content(f"rhs_diff_{i}", rhs_lhs_diff)
+                    log.minor_success(f"Target-baseline diff flamegraph ({dtype})", "generated")
             flamegraphs.append(
                 (dtype, escaped_lhs, escaped_rhs, lhs_escaped_diff, rhs_escaped_diff)
             )

--- a/perun/view_diff/report/run.py
+++ b/perun/view_diff/report/run.py
@@ -826,7 +826,7 @@ def generate_report(lhs_profile: Profile, rhs_profile: Profile, **kwargs: Any) -
 @click.option(
     "--flamegraph-width",
     type=int,
-    default=1200,
+    default=flamegraph_run.FG_DEFAULT_IMAGE_WIDTH,
     help="Specifies the width of the flamegraph images in pixels. This option is forwarded to the "
     "flamegraph.pl script.",
 )
@@ -839,7 +839,7 @@ def generate_report(lhs_profile: Profile, rhs_profile: Profile, **kwargs: Any) -
 @click.option(
     "--flamegraph-minwidth",
     type=str,
-    default=0.1,
+    default=flamegraph_run.FG_DEFAULT_MIN_WIDTH,
     help="Filter out fast functions in flamegraphs. May be specified either in pixels (integer or "
     "float value) or as a percentage of time if suffixed with '%'. This option is forwarded "
     "to the flamegraph.pl script.",

--- a/perun/view_diff/report/run.py
+++ b/perun/view_diff/report/run.py
@@ -708,6 +708,12 @@ def generate_report(lhs_profile: Profile, rhs_profile: Profile, **kwargs: Any) -
     :param rhs_profile: target profile
     :param kwargs: additional arguments
     """
+    fg_forward_kwargs = {
+        arg.replace("flamegraph_", ""): val
+        for arg, val in kwargs.items()
+        if arg.startswith("flamegraph_")
+    }
+
     # We automatically set the value of True for kperf, which samples
     Config().minimize = kwargs.get("minimize", False)
     Config().top_n_traces = kwargs.get("top_n", Config().DefaultTopN)
@@ -736,6 +742,7 @@ def generate_report(lhs_profile: Profile, rhs_profile: Profile, **kwargs: Any) -
         Stats.all_stats(),
         skip_diff=False,
         minimize=Config().minimize,
+        **fg_forward_kwargs,
     )
     log.minor_success("Sankey graphs", "generated")
     lhs_header, rhs_header = diff_kit.generate_diff_of_headers(
@@ -816,9 +823,50 @@ def generate_report(lhs_profile: Profile, rhs_profile: Profile, **kwargs: Any) -
     is_flag=True,
     help="Minimizes the traces, folds the recursive calls, hides the generic types.",
 )
+@click.option(
+    "--flamegraph-width",
+    type=int,
+    default=1200,
+    help="Specifies the width of the flamegraph images in pixels. This option is forwarded to the "
+    "flamegraph.pl script.",
+)
+@click.option(
+    "--flamegraph-height",
+    type=int,
+    help="Specifies the height of each flamegraph frame in pixels. This option is forwarded to "
+    "the flamegraph.pl script.",
+)
+@click.option(
+    "--flamegraph-minwidth",
+    type=str,
+    default=0.1,
+    help="Filter out fast functions in flamegraphs. May be specified either in pixels (integer or "
+    "float value) or as a percentage of time if suffixed with '%'. This option is forwarded "
+    "to the flamegraph.pl script.",
+)
+@click.option(
+    "--flamegraph-fonttype",
+    type=str,
+    help="Specifies the font type to use in flamegraphs. This option is forwarded to the "
+    "flamegraph.pl script.",
+)
+@click.option(
+    "--flamegraph-fontsize",
+    type=int,
+    help="Specifies the font size of text in flamegraphs. This option is forwarded to the "
+    "flamegraph.pl script.",
+)
+@click.option(
+    "--flamegraph-bgcolors",
+    type=str,
+    help="Specifies the background colors for flamegraphs. This option is forwarded to the "
+    "flamegraph.pl script.",
+)
 @click.pass_context
 def report(ctx: click.Context, *_: Any, **kwargs: Any) -> None:
-    """Creates sankey graphs representing the differences between two profiles"""
+    """Creates a composite interactive difference report of two profiles that combines multiple
+    visualizations and data tables.
+    """
     assert ctx.parent is not None and f"impossible happened: {ctx} has no parent"
     profile_list = ctx.parent.params["profile_list"]
     generate_report(profile_list[0], profile_list[1], **kwargs)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2638,6 +2638,26 @@ def test_svs():
     asserts.predicate_from_cli(result, result.exit_code == 0)
     assert "prof2.perf" in os.listdir(".")
 
-    result = runner.invoke(cli.showdiff, ["prof.perf", "prof2.perf", "report", "-o", "diff"])
+    result = runner.invoke(
+        cli.showdiff,
+        [
+            "prof.perf",
+            "prof2.perf",
+            "report",
+            "-o",
+            "diff",
+            "--flamegraph-width",
+            1000,
+            "--flamegraph-height",
+            15,
+            "--flamegraph-minwidth",
+            0.1,
+            "--flamegraph-fontsize",
+            14,
+            "--flamegraph-bgcolors",
+            "blue",
+        ],
+    )
     asserts.predicate_from_cli(result, result.exit_code == 0)
+    asserts.predicate_from_cli(result, "WARNING" not in result.output)
     assert "diff.html" in os.listdir(".")

--- a/tests/test_diff_views.py
+++ b/tests/test_diff_views.py
@@ -185,6 +185,40 @@ def test_diff_incremental_sankey_kperf(pcs_with_root):
     assert "diff.html" in os.listdir(os.getcwd())
 
 
+def test_diff_report_invalid_forward_param(pcs_with_root):
+    runner = CliRunner()
+    baseline_profilename = test_utils.load_profilename(
+        "diff_profiles", "kperf-baseline-stats-metadata.perf"
+    )
+    target_profilename = test_utils.load_profilename(
+        "diff_profiles", "kperf-target-stats-metadata.perf"
+    )
+
+    result = runner.invoke(
+        cli.showdiff,
+        [
+            baseline_profilename,
+            target_profilename,
+            "report",
+            "-o",
+            "diff_warn",
+            "--flamegraph-width",
+            1000,
+            "--flamegraph-height",
+            15,
+            "--flamegraph-minwidth",
+            0.1,
+            "--flamegraph-fontsize",
+            14,
+            "--flamegraph-bgcolors",
+            "invalid_color",
+        ],
+    )
+    assert result.exit_code == 0
+    assert 'Unrecognized bgcolor option "invalid_color"' in result.output
+    assert "diff_warn.html" in os.listdir(os.getcwd())
+
+
 def test_diff_incremental_sankey_ktrace(pcs_with_root):
     """Test creating sankey diff graph out of the two profile"""
     runner = CliRunner()


### PR DESCRIPTION
This PR extends the CLI of `showdiff report` so that the user can forward a curated subset of parameters to the `flamegraph.pl` script.