### PR TITLE
Release version 0.25.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,17 @@
 Changelog
 =========
 
+0.25.0 (2025-03-23)
+-------------------
+
+  - Perun showdiff report now uses a different visual template that supports annotations.
+  - Change flamegraph generation to show the processes bars as well.
+  - Perun showdiff report now allows forwarding certain options (all optional) to flamegraph.pl.
+  - Perun showdiff report now shows profile labels as well.
+  - Enhance index to support profile overwriting.
+  - Fix a bug where profile labels were not correctly updating when profiles were overwritten.
+
+
 0.24.0 (2025-02-06)
 -------------------
 

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
     'perun',
     'c',
-    version: '0.24.0',
+    version: '0.25.0',
     license: 'GPL-3',
     meson_version: '>=1.0.0',
     default_options: [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
     # String / text utilities
     "Faker>=26.0.0",
     "ruamel.yaml>=0.18.6",
-    "Jinja2>=3.1.5",
+    "Jinja2>=3.1.6",
 
     # File analysis
     "python-magic>=0.4.27",


### PR DESCRIPTION
Changelog:
  - Perun showdiff report now uses a different visual template that supports annotations.
  - Change flamegraph generation to show the processes bars as well.
  - Perun showdiff report now allows forwarding certain options (all optional) to flamegraph.pl.
  - Perun showdiff report now shows profile labels as well.
  - Enhance index to support profile overwriting.
  - Fix a bug where profile labels were not correctly updating when profiles were overwritten.