### PR TITLE
Release 0.25.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+0.25.1 (2025-03-24)
+-------------------
+
+  - Fix an issue with sdist build not including 'add.svg' asset for showdiff report.
+
+
 0.25.0 (2025-03-23)
 -------------------
 

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
     'perun',
     'c',
-    version: '0.25.0',
+    version: '0.25.1',
     license: 'GPL-3',
     meson_version: '>=1.0.0',
     default_options: [

--- a/perun/templates/assets/meson.build
+++ b/perun/templates/assets/meson.build
@@ -1,6 +1,7 @@
 perun_templates_assets_dir = perun_templates_dir / 'assets'
 
 perun_templates_assets_files = files(
+    'add.svg',
     'bin.svg',
     'fire.svg',
     'grid_view.svg',


### PR DESCRIPTION
Fix an issue with sdist build not including 'add.svg' asset for showdiff report.