### PR TITLE
Unify naming and saving of profiles

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -202,17 +202,21 @@ List of Supported Options
 
 .. confkey:: format.sort_profiles_by
 
-    ``[recursive]`` Specifies which key of the profile will be used for sorting the output of the
-    ``perun status`` commands. Can be one of the following attributes specified by the class
-    attribute ``ProfileInfo.valid_attributes``:
+    ``[recursive]`` Specifies which keys of the profile will be used for sorting the output of the
+    ``perun status`` commands. It is possible to sort the profiles by multiple keys with the usual
+    multi-key sort semantics by providing a list of the following attributes specified by the
+    class attribute ``ProfileInfo.valid_attributes``:
 
 .. currentmodule:: perun.profile.helpers
 .. autoattribute:: ProfileInfo.valid_attributes
 
 .. confkey:: format.sort_profiles_order
 
-    ``[recursive]`` Specifies the order which will be used for sorting the output of the
-    ``perun status`` commands. Can be either ``ascending`` or ``descending``.
+    ``[recursive]`` Specifies the orderings which will be used for sorting the output of the
+    ``perun status`` commands. Can be either a single value of ``asc`` or ``desc``, in which
+    case the selected ordering will be applied to all :ckey:`format.sort_profiles_by` keys, or
+    it may be a list of orderings, where each ordering will be applied to the corresponding sort
+    key. Keys without specified orderings will use default ordering.
 
 .. confunit:: execute
 

--- a/docs/logs.rst
+++ b/docs/logs.rst
@@ -81,12 +81,13 @@ The specification of the formatting string can contain the following special tag
     Original source of the profile. This corresponds to the name of the generated profile
     and the original path.
 
-By default the profiles are sorted in ascending order according to the timestamp. The sort order
-can be modified by setting either the :ckey:`format.sort_profiles_by` and
-:ckey:`format.sort_profiles_order` configuration options, or the :doc:`cli` options ``--sort-by``
-and ``--sort-order`` to a valid profile information attribute and a valid sort order. Setting the
-command line options ``--sort-by`` and ``--sort-order`` have higher priority than the keys set in
-the :ckey:`format.sort_profiles_by` and :ckey:`format.sort_profiles_order`.
+By default the profiles are sorted in ascending order according to the timestamp, profile name
+stem and copy number. The sort order can be modified by setting either the
+:ckey:`format.sort_profiles_by` and :ckey:`format.sort_profiles_order` configuration options, or
+the :doc:`cli` options ``--sort-by`` and ``--sort-order`` to a valid combination of profile
+information attributes and a valid sort orderings. Setting the command line options ``--sort-by``
+and ``--sort-order`` have higher priority than the keys set in the :ckey:`format.sort_profiles_by`
+and :ckey:`format.sort_profiles_order`.
 
 .. _logs-log:
 

--- a/perun/cli.py
+++ b/perun/cli.py
@@ -42,9 +42,10 @@ the flexibility of Perun's usage.
 from __future__ import annotations
 
 # Standard Imports
-from typing import Optional, Any, TYPE_CHECKING
+import functools
 import os
 import sys
+from typing import Optional, Any, TYPE_CHECKING
 
 # Third-Party Imports
 import click
@@ -562,10 +563,17 @@ def log(head: Optional[str], **kwargs: Any) -> None:
     "-sb",
     "format__sort_profiles_by",
     nargs=1,
-    type=click.Choice(profiles.ProfileInfo.valid_attributes),
-    callback=cli_kit.set_config_option_from_flag(pcs.local_config, "format.sort_profiles_by", str),
+    type=str,
+    callback=cli_kit.set_config_option_from_flag(
+        pcs.local_config,
+        "format.sort_profiles_by",
+        functools.partial(
+            cli_kit.config_value_parse_and_validate,
+            allowed_values=profiles.ProfileInfo.valid_attributes,
+        ),
+    ),
     help=(
-        "Sets the sort key in the local configuration as 'format.sort_profiles_by' that will be "
+        "Sets the sort keys in the local configuration as 'format.sort_profiles_by' that will be "
         "used for sorting both pending and index profiles."
     ),
 )
@@ -574,13 +582,17 @@ def log(head: Optional[str], **kwargs: Any) -> None:
     "-so",
     "format__sort_profiles_order",
     nargs=1,
-    type=click.Choice(SortOrder.supported()),
+    type=str,
     callback=cli_kit.set_config_option_from_flag(
-        pcs.local_config, "format.sort_profiles_order", str
+        pcs.local_config,
+        "format.sort_profiles_order",
+        functools.partial(
+            cli_kit.config_value_parse_and_validate, allowed_values=SortOrder.supported()
+        ),
     ),
     help=(
-        "Sets the sort order in the local configuration as 'format.sort_profiles_order' that will "
-        "be used for sorting both pending and index profiles."
+        "Sets the sort orderings in the local configuration as 'format.sort_profiles_order' that "
+        "will be used for sorting both pending and index profiles."
     ),
 )
 def status(**kwargs: Any) -> None:

--- a/perun/cli.py
+++ b/perun/cli.py
@@ -42,7 +42,6 @@ the flexibility of Perun's usage.
 from __future__ import annotations
 
 # Standard Imports
-import functools
 import os
 import sys
 from typing import Optional, Any, TYPE_CHECKING
@@ -64,11 +63,10 @@ from perun.utils.exceptions import (
     MissingConfigSectionException,
     ExternalEditorErrorException,
 )
-from perun.utils.structs.common_structs import Executable, SortOrder
+from perun.utils.structs.common_structs import Executable
 from perun.utils.structs.diff_structs import HeaderDisplayStyle
 from perun import fuzz as fuzz
 import perun.postprocess
-import perun.profile.helpers as profiles
 import perun.view
 import perun.view_diff
 import perun.deltadebugging.factory as delta
@@ -567,10 +565,7 @@ def log(head: Optional[str], **kwargs: Any) -> None:
     callback=cli_kit.set_config_option_from_flag(
         pcs.local_config,
         "format.sort_profiles_by",
-        functools.partial(
-            cli_kit.config_value_parse_and_validate,
-            allowed_values=profiles.ProfileInfo.valid_attributes,
-        ),
+        cli_kit.validate_profile_sort_by,
     ),
     help=(
         "Sets the sort keys in the local configuration as 'format.sort_profiles_by' that will be "
@@ -586,9 +581,7 @@ def log(head: Optional[str], **kwargs: Any) -> None:
     callback=cli_kit.set_config_option_from_flag(
         pcs.local_config,
         "format.sort_profiles_order",
-        functools.partial(
-            cli_kit.config_value_parse_and_validate, allowed_values=SortOrder.supported()
-        ),
+        cli_kit.validate_profile_sort_order,
     ),
     help=(
         "Sets the sort orderings in the local configuration as 'format.sort_profiles_order' that "

--- a/perun/cli_groups/collect_cli.py
+++ b/perun/cli_groups/collect_cli.py
@@ -7,30 +7,50 @@ import click
 # Perun Imports
 from perun.utils.structs import collect_structs
 from perun.utils.common import cli_kit
+from perun import profile
 from perun.logic import commands, config as perun_config
 
 
 @click.group()
 @click.option(
-    "--output-file",
-    "-o",
+    "--profile-dir",
+    "-pd",
     nargs=1,
-    required=False,
-    multiple=False,
-    type=click.Path(writable=True),
-    help="Specifies the full path to where the profile will be stored.",
+    type=click.Path(),
+    help=(
+        "Specifies the output directory in which the collected profile will be saved. "
+        "The default directory is '.perun/jobs'. "
+        "The directory will be created if it does not exist."
+    ),
 )
 @click.option(
     "--profile-name",
     "-pn",
     nargs=1,
-    required=False,
-    multiple=False,
     type=str,
     help=(
-        "Specifies the name of the profile, which will be collected, e.g. profile.perf. The profile will be stored in"
-        " .perun/jobs"
+        "Specifies the name of the collected profile, e.g., 'profile.perf', that will be stored in "
+        "the output directory. The default name is generated according to the "
+        ":ckey:`format.output_profile_template` configuration parameter."
     ),
+)
+@click.option(
+    "--profile-label",
+    "-pl",
+    nargs=1,
+    type=str,
+    default="",
+    help="An optional custom label to associate with the collected profile(s).",
+)
+@click.option(
+    "--save-to-index",
+    "-s",
+    is_flag=True,
+    default=False,
+    callback=cli_kit.set_config_option_from_flag(
+        perun_config.runtime, "profiles.register_after_run"
+    ),
+    help="Registers the imported profile in index instead of saving it in pending.",
 )
 @click.option(
     "--minor-version",
@@ -180,4 +200,7 @@ def collect(ctx: click.Context, **kwargs: Any) -> None:
     ``perun run job --help``.
     """
     commands.try_init()
+    kwargs["profile_path"] = profile.ProfilePath(
+        kwargs.get("profile_name"), kwargs.get("profile_dir")
+    )
     ctx.obj = kwargs

--- a/perun/cli_groups/import_cli.py
+++ b/perun/cli_groups/import_cli.py
@@ -78,7 +78,19 @@ from perun.utils.common import cli_kit
     "-s",
     is_flag=True,
     default=False,
-    help="Saves the imported profile to index.",
+    callback=cli_kit.set_config_option_from_flag(config.runtime, "profiles.register_after_run"),
+    help="Registers the imported profile in index instead of saving it in pending.",
+)
+@click.option(
+    "--profile-dir",
+    "-pd",
+    nargs=1,
+    type=click.Path(),
+    help=(
+        "Specifies the output directory in which the collected profile will be saved. "
+        "The default directory is '.perun/jobs'. "
+        "The directory will be created if it does not exist."
+    ),
 )
 @click.option(
     "--profile-name",
@@ -86,7 +98,9 @@ from perun.utils.common import cli_kit
     nargs=1,
     type=str,
     help=(
-        "Specifies the name of the resulting imported profile, which will be stored in .perun/jobs."
+        "Specifies the name of the collected profile, e.g., 'profile.perf', that will be stored in "
+        "the output directory. The default name is generated according to the "
+        ":ckey:`format.output_profile_template` configuration parameter."
     ),
 )
 @click.option(
@@ -106,6 +120,9 @@ def import_group(ctx: click.Context, **kwargs: Any) -> None:
     Absolute file paths ignore the import directory.
     """
     commands.try_init()
+    kwargs["profile_path"] = profile.ProfilePath(
+        kwargs.get("profile_name"), kwargs.get("profile_dir")
+    )
     ctx.obj = kwargs
 
 

--- a/perun/logic/config.py
+++ b/perun/logic/config.py
@@ -213,7 +213,10 @@ format:
     shortlog: "%checksum:6% (%stats%) %desc% %changes%"
     output_profile_template: "%collector%-%cmd%-%workload%-%date%"
     output_show_template: "%collector%-%cmd%-%workload%-%date%"
-    sort_profiles_by: time
+    sort_profiles_by:
+    - time
+    - stem
+    - copy
     sort_profiles_order: asc
 
 degradation:

--- a/perun/logic/config.py
+++ b/perun/logic/config.py
@@ -476,30 +476,40 @@ def gather_key_recursively(key: str) -> list[Any]:
     return gathered_values
 
 
-def safely_lookup_key_recursively(key: str, allowed_values: Iterable[T], default: T) -> T:
+def safely_lookup_key_recursively(
+    key: str, allowed_values: Iterable[T], default: list[T]
+) -> list[T]:
     """Safely recursively looks up the key in runtime, local and shared config.
 
-    By safely, we mean that if the function returns a value, that value will be one of the allowed
-    values. If no allowed values are provided, or the default value itself is not one of the allowed
-    values, an AssertionError is raised.
+    The value associated with the key may be a simple scalar value, or it may be a list of values.
+    In both cases, the function returns (possibly a single-item) collection of values.
+
+    By safely, we mean that if the function returns a collection of values, each value will be one
+    of the allowed values. If no allowed values are provided, or some of the default values are not
+    one of the allowed values, an AssertionError is raised.
 
     :param key: the looked up key
     :param allowed_values: a nonempty set of allowed values
-    :param default: a default value (must be one of allowed value) to use in case of any issues
+    :param default: default value(s) respecting the allowed values to use as a fallback
+
+    :return: a collection of values associated with the key, or the default collection
     """
-    # A set of allowed values must be provided and the default value must be one of the allowed
-    # values to ensure the resulting value is always valid.
-    assert allowed_values and default in allowed_values
+    # A set of allowed values must be provided and the default value(s) must be a subset of the
+    # allowed values to ensure the resulting values are always valid.
+    assert allowed_values and all(val in allowed_values for val in default)
     error_desc: str = ""
-    value = default
+    values = default
     try:
-        value = lookup_key_recursively(key)
-        if value not in allowed_values:
-            # If the stored key is invalid, we use the default value instead
-            error_desc = f"invalid value '{value}' of key '{key}' in config. "
-            value = default
+        values = lookup_key_recursively(key)
+        if not isinstance(values, list):
+            values = [values]
+        invalid_values = [val for val in values if val not in allowed_values]
+        if invalid_values:
+            # If the stored values are invalid, we use the default values instead
+            error_desc = f"invalid value(s) '{invalid_values}' of key '{key}' in config. "
+            values = default
     except exceptions.MissingConfigSectionException:
-        # If there is no value for the looked up key, we use the default value instead
+        # If there is no value for the looked up key, we use the default values instead
         error_desc = f"missing config value for key '{key}'. "
     if error_desc:
         perun_log.warn(
@@ -508,4 +518,4 @@ def safely_lookup_key_recursively(key: str, allowed_values: Iterable[T], default
             f"({', '.join(map(str, allowed_values))}). "
             f"Consult the documentation (Configuration and Logs) for more information."
         )
-    return value
+    return values

--- a/perun/logic/config_templates.py
+++ b/perun/logic/config_templates.py
@@ -153,9 +153,9 @@ profiles:
 #   register_after_run: true
 {% endif %}
 
-## Be default, we sort the profiles by time in ascending order
+## Be default, we multisort the profiles by time > stem > copy in ascending order
 format:
-  sort_profiles_by: time
+  sort_profiles_by: [time, stem, copy]
   sort_profiles_order: asc
 {% if format is defined and format.output_profile_template is defined %}
 ## The following changes the automatically generated name of the profiles

--- a/perun/logic/runner.py
+++ b/perun/logic/runner.py
@@ -3,8 +3,7 @@
 from __future__ import annotations
 
 # Standard Imports
-from typing import Any, Iterable, Optional, TYPE_CHECKING, cast, Callable, overload
-import os
+from typing import Any, Iterable, TYPE_CHECKING, cast, Callable, overload
 import signal
 import time
 import subprocess
@@ -14,8 +13,8 @@ import click
 
 # Perun Imports
 from perun.vcs import vcs_kit
-from perun.logic import commands, config, index, pcs
-from perun.utils import log, streams
+from perun.logic import pcs
+from perun.utils import log
 from perun.utils.common import common_kit
 from perun.utils.exceptions import SignalReceivedException
 from perun.utils.external import commands as external_commands
@@ -31,7 +30,7 @@ from perun.utils.structs.common_structs import (
     Unit,
 )
 from perun.workload.singleton_generator import SingletonGenerator
-import perun.profile.helpers as profile
+from perun import profile
 import perun.workload as workloads
 
 
@@ -367,8 +366,8 @@ def run_collector_from_cli_context(
     collector_params.update(ctx.obj["params"])
     run_params = {
         "collector_params": {collector_name: collector_params},
-        "profile_name": ctx.obj["profile_name"],
-        "output_file": ctx.obj["output_file"],
+        "profile_path": ctx.obj["profile_path"],
+        "profile_label": ctx.obj["profile_label"],
     }
     collect_status = run_single_job(
         cmd, workload, [collector_name], [], minor_versions, **run_params
@@ -413,41 +412,6 @@ def run_postprocessor(
     return cast(PostprocessStatus, postprocess_report.status), prof
 
 
-def store_generated_profile(
-    prof: Profile, job: Job, profile_name: Optional[str] = None, output_file: Optional[str] = None
-) -> None:
-    """Stores the generated profile in the pending jobs' directory.
-
-    :param prof: profile that we are storing in the repository
-    :param job: job with additional information about generated profiles
-    :param profile_name: user-defined name of the profile
-    :param profile_name: full path to the profile
-    """
-    full_profile = profile.finalize_profile_for_job(prof, job)
-    if output_file is None:
-        full_profile_name = profile_name or profile.generate_profile_name(full_profile)
-        profile_directory = pcs.get_job_directory()
-        full_profile_path = os.path.join(profile_directory, full_profile_name)
-    else:
-        full_profile_path = output_file
-    streams.store_json(full_profile.serialize(), full_profile_path)
-    external_commands.finalize_logs(os.path.split(full_profile_path)[1])
-    # FIXME: there is an inconsistency in dict/Profile types, needs to be investigated more thoroughly
-    log.minor_status(
-        "stored generated profile ", status=f"{log.path_style(os.path.relpath(full_profile_path))}"
-    )
-    if common_kit.strtobool(
-        str(config.lookup_key_recursively("profiles.register_after_run", "false"))
-    ):
-        # We either store the profile according to the origin, or we use the current head
-        dst = prof.get("origin", pcs.vcs().get_minor_head())
-        # FIXME: consider removing this
-        commands.add([full_profile_path], dst, keep_profile=False)
-    else:
-        # Else we register the profile in pending index
-        index.register_in_pending_index(full_profile_path, prof)
-
-
 def run_postprocessor_on_profile(
     prof: Profile,
     postprocessor_name: str,
@@ -473,7 +437,9 @@ def run_postprocessor_on_profile(
 
     p_status, processed_profile = run_postprocessor(postprocessor_unit, profile_job, prof)
     if p_status == PostprocessStatus.OK and prof and not skip_store:
-        store_generated_profile(processed_profile, profile_job)
+        profile.save_profile(
+            profile.finalize_profile_for_job(prof, profile_job, prof.get("header", {}).get("label"))
+        )
     return p_status, processed_profile
 
 
@@ -664,7 +630,10 @@ def run_single_job(
     status = CollectStatus.OK
     finished_jobs = 0
     for status, prof, job in generator_function(minor_version_list, job_matrix, number_of_jobs):
-        store_generated_profile(prof, job, kwargs.get("profile_name"), kwargs.get("output_file"))
+        profile.save_profile(
+            profile.finalize_profile_for_job(prof, job, kwargs.get("profile_label")),
+            kwargs.get("profile_path"),
+        )
         finished_jobs += 1
     return status if finished_jobs > 0 else CollectStatus.ERROR
 
@@ -684,6 +653,6 @@ def run_matrix_job(
     status = CollectStatus.OK
     finished_jobs = 0
     for status, prof, job in generator_function(minor_version_list, job_matrix, number_of_jobs):
-        store_generated_profile(prof, job)
+        profile.save_profile(profile.finalize_profile_for_job(prof, job))
         finished_jobs += 1
     return status if finished_jobs > 0 else CollectStatus.ERROR

--- a/perun/profile/__init__.pyi
+++ b/perun/profile/__init__.pyi
@@ -14,6 +14,7 @@ from .convert import (
 )
 
 from .helpers import (
+    save_profile as save_profile,
     generate_profile_name as generate_profile_name,
     load_list_for_minor_version as load_list_for_minor_version,
     get_nth_profile_of as get_nth_profile_of,
@@ -28,6 +29,7 @@ from .helpers import (
     merge_resources_of as merge_resources_of,
     get_default_independent_variable as get_default_independent_variable,
     get_default_dependent_variable as get_default_dependent_variable,
+    ProfilePath as ProfilePath,
     ProfileInfo as ProfileInfo,
     ProfileHeaderEntry as ProfileHeaderEntry,
 )

--- a/perun/profile/helpers.py
+++ b/perun/profile/helpers.py
@@ -17,10 +17,12 @@ handle the JSON objects in Python refer to `Python JSON library`_.
 from __future__ import annotations
 
 # Standard Imports
+import contextlib
 import dataclasses
 import json
 import operator
 import os
+from pathlib import Path
 import re
 import time
 from typing import Any, TYPE_CHECKING, Union
@@ -28,16 +30,16 @@ from typing import Any, TYPE_CHECKING, Union
 # Third-Party Imports
 
 # Perun Imports
-from perun.logic import config, index, pcs, store
+from perun.logic import commands, config, index, pcs, store
 from perun import profile as profiles
-from perun.utils import decorators, log as perun_log
+from perun.utils import log as perun_log, streams
 from perun.utils.common import common_kit
-from perun.utils.external import environment
+from perun.utils.external import environment, commands as external_commands
 from perun.utils.exceptions import (
     InvalidParameterException,
     TagOutOfRangeException,
 )
-from perun.utils.structs.common_structs import Unit, Executable, Job, SortOrder
+from perun.utils.structs.common_structs import Unit, Executable, Job, SortOrder, MinorVersion
 from perun.vcs import vcs_kit
 
 if TYPE_CHECKING:
@@ -51,9 +53,102 @@ PROFILE_COUNTER: int = 0
 DEFAULT_SORT_KEY: str = "time"
 
 
+class ProfilePath:
+    """A helper class for storing and manipulating Perun profile paths.
+
+    The profile path is internally stored in parts: the stem (profile name without a suffix);
+    the directory (the Perun job directory by default); and the copy number in case some other
+    profile(s) with the same path already exist(s).
+
+    :ivar stem: the stem part of the profile path.
+    :ivar directory: the directory part of the profile path.
+    :ivar copy: the copy number part of the profile path.
+    """
+
+    __slots__ = "stem", "directory", "copy"
+
+    def __init__(
+        self, name: str | None = None, directory: str | Path | None = None, copy: int = 0
+    ) -> None:
+        """Initialize a new profile path.
+
+        :param name: the name part of the profile path. If not provided, the name will be
+               automatically generated when finalizing the path.
+        :param directory: the directory part of the profile path. Job directory by default.
+        :param copy: the copy number part of the profile path. The number will be automatically
+               deduced when finalizing the path even if it was provided.
+        """
+        # Remove the .perf suffix if it was provided with the name. Any other suffix is
+        # considered to be part of the name.
+        if name is not None and name.endswith(".perf"):
+            name = name[: -len(".perf")]
+        self.stem: str = "" if name is None else name
+        self.directory: Path = Path(directory if directory else pcs.get_job_directory()).resolve()
+        self.copy: int = copy
+
+    @classmethod
+    def from_path(cls, profile_path: Path) -> ProfilePath:
+        """Construct a profile path object from a path.
+
+        :param profile_path: the path that will be represented by the new object.
+
+        :return: the constructed profile path.
+        """
+        profile_path = profile_path.resolve()
+        directory, name, copy = profile_path.parent, profile_path.stem, 0
+        copy_counter_begin = name.rfind("(")
+        if name.endswith(")") and copy_counter_begin != -1:
+            with contextlib.suppress(ValueError):
+                # Attempt to parse the copy number and the profile stem. If the contents of the
+                # parentheses cannot be parsed as integer, we assume it's part of the name.
+                copy = int(name[copy_counter_begin + 1 : -1])
+                name = name[:copy_counter_begin]
+        return cls(name, directory, copy)
+
+    def name(self) -> str:
+        """Construct the name part of the profile path: <stem>(<copy number>).<suffix>
+
+        May be incomplete or incorrect unless the object was finalized.
+
+        :return: the constructed name part.
+        """
+        copy_str = "" if not self.copy else f"({self.copy})"
+        return f"{self.stem}{copy_str}.perf"
+
+    def path(self) -> Path:
+        """Construct the profile path: <directory>/<name>
+
+        May be incomplete or incorrect unless the object was finalized.
+
+        :return: the constructed profile path.
+        """
+        return Path(self.directory, self.name())
+
+    def finalize(self, profile: profiles.Profile) -> ProfilePath:
+        """Finalize the profile path such that it can be used to store a profile.
+
+        This includes (1) generating a default profile name unless a user-defined name was
+        provided, and (2) deducing the correct copy number to avoid overwriting existing profiles.
+
+        :param profile: the profile that will be stored under this path.
+
+        :return: the finalized profile path object.
+        """
+        if not self.stem:
+            # No custom profile name provided, generate the stem
+            self.stem = generate_profile_name(profile)[: -len(".perf")]
+        # We must check for duplicate files first
+        for duplicate in self.directory.glob(f"{self.stem}*"):
+            p = ProfilePath.from_path(duplicate)
+            if p.stem == self.stem:
+                self.copy = max(self.copy, p.copy + 1)
+        return self
+
+
 def lookup_value(container: dict[str, str] | profiles.Profile, key: str, missing: str) -> str:
-    """Helper function for getting the key from the container. If it is not present in the container,
-    or it is empty string or empty object, the function should return the missing constant.
+    """Helper function for getting the key from the container. If it is not present in the
+    container, or it is empty string or empty object, the function should return the missing
+    constant.
 
     :param container: dictionary container
     :param key: string representation of the key
@@ -86,6 +181,44 @@ def lookup_param(profile: profiles.Profile, unit: str, param: str) -> str:
         )
     else:
         return "_"
+
+
+def save_profile(
+    profile: profiles.Profile,
+    profile_path: ProfilePath | None = None,
+    minor_version: MinorVersion | None = None,
+) -> None:
+    """Stores a generated or imported profile on the provided path.
+
+    :param profile: the profile that we are storing.
+    :param profile_path: the target path where the profile will be stored.
+    :param minor_version: the minor version that the profile will be associated with if the
+           profile should be saved in index.
+    """
+    profile_path = ProfilePath() if profile_path is None else profile_path
+    profile_path.finalize(profile)
+    final_profile_path = str(profile_path.path())
+    streams.store_json(profile.serialize(), final_profile_path)
+    external_commands.finalize_logs(profile_path.name())
+
+    perun_log.minor_status(
+        "stored generated profile ",
+        status=f"{perun_log.path_style(str(profile_path.path().relative_to(Path.cwd())))}",
+    )
+    if common_kit.strtobool(
+        str(config.lookup_key_recursively("profiles.register_after_run", "false"))
+    ):
+        # Register the profile within a certain minor version
+        if minor_version is None:
+            # No minor version was provided
+            # We either store the profile according to the origin, or we use the current head
+            minor_version_checksum = profile.get("origin", pcs.vcs().get_minor_head())
+        else:
+            minor_version_checksum = minor_version.checksum
+        commands.add([final_profile_path], minor_version_checksum, keep_profile=False)
+    else:
+        # Else we register the profile in the pending index
+        index.register_in_pending_index(final_profile_path, profile)
 
 
 def generate_profile_name(profile: profiles.Profile) -> str:
@@ -281,9 +414,10 @@ def generate_units(collector: types.ModuleType) -> dict[str, str]:
     return collector.COLLECTOR_DEFAULT_UNITS
 
 
-def generate_header_for_profile(job: Job) -> dict[str, Any]:
+def generate_header_for_profile(job: Job, label: str | None = None) -> dict[str, Any]:
     """
     :param job: job with information about the computed profile
+    :param label: a custom user-defined label to associate with the profile
     :return: dictionary in form of {'header': {}} corresponding to the perun specification
     """
     # At this point, the collector module should be valid
@@ -292,9 +426,10 @@ def generate_header_for_profile(job: Job) -> dict[str, Any]:
     return {
         "type": collector.COLLECTOR_TYPE,
         "cmd": job.executable.cmd,
-        "workload": job.executable.workload,
-        "units": generate_units(collector),
         "exitcode": config.runtime().safe_get("exitcode", "?"),
+        "workload": job.executable.workload,
+        "label": label if label is not None else "",
+        "units": generate_units(collector),
     }
 
 
@@ -318,14 +453,18 @@ def generate_postprocessor_info(job: Job) -> list[dict[str, Any]]:
     ]
 
 
-def finalize_profile_for_job(profile: profiles.Profile, job: Job) -> profiles.Profile:
-    """
+def finalize_profile_for_job(
+    profile: profiles.Profile, job: Job, label: str | None = None
+) -> profiles.Profile:
+    """Generates profile header and other metadata.
+
     :param profile: collected profile through some collector
     :param job: job with information about the computed profile
+    :param label: a custom user-defined label to associate with the profile
     :return: valid profile JSON file
     """
     profile.update({"origin": pcs.vcs().get_minor_head()})
-    profile.update({"header": generate_header_for_profile(job)})
+    profile.update({"header": generate_header_for_profile(job, label)})
     profile.update({"machine": environment.get_machine_specification()})
     profile.update({"collector_info": generate_collector_info(job)})
     profile.update({"postprocessors": generate_postprocessor_info(job)})
@@ -437,6 +576,9 @@ def sort_profiles(profile_list: list["ProfileInfo"]) -> None:
     sort_order = config.safely_lookup_key_recursively(
         "format.sort_profiles_order", SortOrder.supported(), SortOrder.default()
     )
+    # TODO: allow multi-key sort.
+    # TODO: add sort-key "copy" and make it default (operator.attrgetter(*sort_key)) so that
+    #  copies of the profile name are sorted as one would expect.
     profile_list.sort(
         key=operator.attrgetter(sort_key), reverse=SortOrder(sort_order).as_sort_flag()
     )

--- a/perun/profile/helpers.py
+++ b/perun/profile/helpers.py
@@ -50,7 +50,7 @@ ProfileHeaderTuple = tuple[str, Union[str, float], str, dict[str, Union[str, flo
 
 
 PROFILE_COUNTER: int = 0
-DEFAULT_SORT_KEY: str = "time"
+DEFAULT_SORT_KEYS: list[str] = ["time", "stem", "copy"]
 
 
 class ProfilePath:
@@ -570,18 +570,22 @@ def sort_profiles(profile_list: list["ProfileInfo"]) -> None:
 
     :param profile_list: list of ProfileInfo object
     """
-    sort_key = config.safely_lookup_key_recursively(
-        "format.sort_profiles_by", ProfileInfo.valid_attributes, DEFAULT_SORT_KEY
+    sort_keys = config.safely_lookup_key_recursively(
+        "format.sort_profiles_by", ProfileInfo.valid_attributes, DEFAULT_SORT_KEYS
     )
-    sort_order = config.safely_lookup_key_recursively(
-        "format.sort_profiles_order", SortOrder.supported(), SortOrder.default()
+    sort_orders = config.safely_lookup_key_recursively(
+        "format.sort_profiles_order", SortOrder.supported(), [SortOrder.default()]
     )
-    # TODO: allow multi-key sort.
-    # TODO: add sort-key "copy" and make it default (operator.attrgetter(*sort_key)) so that
-    #  copies of the profile name are sorted as one would expect.
-    profile_list.sort(
-        key=operator.attrgetter(sort_key), reverse=SortOrder(sort_order).as_sort_flag()
-    )
+    # Multiple back-to-back sorts on the same data set is fast in Python thanks to the used sorting
+    # algorithm: https://docs.python.org/3/howto/sorting.html#sort-stability-and-complex-sorts
+    # The lists of keys and orderings might be of unequal length: if there are more keys than
+    # orderings, pad it with the default ordering; otherwise ignore the additional orderings.
+    sort_steps = [
+        (key, sort_orders[idx] if len(sort_orders) > idx else SortOrder.default())
+        for idx, key in enumerate(sort_keys)
+    ]
+    for key, order in reversed(sort_steps):
+        profile_list.sort(key=operator.attrgetter(key), reverse=SortOrder(order).as_sort_flag())
 
 
 def merge_resources_of(
@@ -668,6 +672,8 @@ class ProfileInfo:
         "cmd",
         "workload",
         "label",
+        "stem",
+        "copy",
         "collector",
         "postprocessors",
         "checksum",
@@ -690,6 +696,7 @@ class ProfileInfo:
         :param is_raw_profile: true if the stored profile is raw, i.e. in json and not
             compressed
         """
+        p = ProfilePath.from_path(Path(path))
         self._is_raw_profile = is_raw_profile
         self.source = path
         self.realpath = os.path.relpath(real_path, os.getcwd())
@@ -698,6 +705,8 @@ class ProfileInfo:
         self.cmd = profile_info["header"]["cmd"]
         self.workload = profile_info["header"]["workload"]
         self.label = profile_info["header"].get("label", "")
+        self.stem = p.stem
+        self.copy = p.copy
         self.collector = profile_info["collector_info"]["name"]
         self.postprocessors = [
             postprocessor["name"] for postprocessor in profile_info["postprocessors"]
@@ -744,6 +753,8 @@ class ProfileInfo:
         "cmd",
         "workload",
         "label",
+        "stem",
+        "copy",
         "collector",
         "checksum",
         "source",

--- a/perun/profile/imports.py
+++ b/perun/profile/imports.py
@@ -19,7 +19,7 @@ from typing import Any
 # Perun Imports
 from perun import profile as profile
 from perun.collect.kperf import parser
-from perun.logic import commands, config, index, pcs
+from perun.logic import config, pcs
 from perun.utils import log, streams
 from perun.utils.common import script_kit, common_kit
 from perun.utils.external import commands as external_commands, environment
@@ -234,16 +234,13 @@ def import_perf_profile(
             "postprocessors": [],
         }
     )
-    save_imported_profile(
-        prof, kwargs.get("save_to_index", False), minor_version, kwargs.get("profile_name")
-    )
+    profile.save_profile(prof, kwargs.get("profile_path"), minor_version)
 
 
 def import_elk_profile(
     resources: list[dict[str, Any]],
     metadata: dict[str, profile.ProfileHeaderEntry],
     minor_version: MinorVersion,
-    save_to_index: bool = False,
     **kwargs: Any,
 ) -> None:
     """Constructs the profile for elk-stored data and saves them to jobs or index.
@@ -251,7 +248,6 @@ def import_elk_profile(
     :param resources: list of parsed resources.
     :param metadata: parts of the profiles that will be stored as metadata in the profile.
     :param minor_version: minor version corresponding to the imported profiles.
-    :param save_to_index: indication whether we should save the imported profiles to index.
     :param kwargs: rest of the parameters.
     """
     prof = profile.Profile(
@@ -278,41 +274,7 @@ def import_elk_profile(
             "postprocessors": [],
         }
     )
-    save_imported_profile(prof, save_to_index, minor_version, kwargs.get("profile_name"))
-
-
-def save_imported_profile(
-    prof: profile.Profile,
-    save_to_index: bool,
-    minor_version: MinorVersion,
-    profile_name: str | None = None,
-) -> None:
-    """Saves the imported profile either to index or to pending jobs.
-
-    :param prof: imported profile
-    :param minor_version: minor version corresponding to the imported profiles.
-    :param save_to_index: indication whether we should save the imported profiles to index.
-    :param profile_name: optional custom name of the saved profile
-    """
-    if not profile_name:
-        # No custom profile name provided, generate the name
-        profile_name = profile.generate_profile_name(prof)
-    elif not profile_name.endswith(".perf"):
-        # Make sure the profile name ends with the proper suffix
-        profile_name += ".perf"
-    profile_directory = pcs.get_job_directory()
-    full_profile_path = os.path.join(profile_directory, profile_name)
-
-    streams.store_json(prof.serialize(), full_profile_path)
-    log.minor_status(
-        "stored generated profile ",
-        status=f"{log.path_style(os.path.relpath(full_profile_path))}",
-    )
-    if save_to_index:
-        commands.add([full_profile_path], minor_version.checksum, keep_profile=False)
-    else:
-        # Else we register the profile in pending index
-        index.register_in_pending_index(full_profile_path, prof)
+    profile.save_profile(prof, kwargs.get("profile_path"), minor_version)
 
 
 def load_perf_file(filepath: Path) -> str:

--- a/perun/utils/common/cli_kit.py
+++ b/perun/utils/common/cli_kit.py
@@ -141,7 +141,7 @@ def process_continuous_key(
 def set_config_option_from_flag(
     dst_config_getter: Callable[[], config.Config],
     config_option: str,
-    postprocess_function: Callable[[str], str] = lambda x: x,
+    postprocess_function: Callable[[str], str | list[str]] = lambda x: x,
 ) -> Callable[[click.Context, click.Option, Any], Any]:
     """Helper function for setting the config option from the CLI option handler
 
@@ -168,6 +168,29 @@ def set_config_option_from_flag(
         return value
 
     return option_handler
+
+
+def config_value_parse_and_validate(
+    value: str, allowed_values: list[str] | None
+) -> str | list[str]:
+    """Parse and validate config option value.
+
+    The provided string value can in fact be a scalar value or a collection of values delimited
+    by commas. In either case, all values are checked against the list of allowed values for the
+    given option.
+
+    :param value: the value(s) to parse and validate
+    :param allowed_values: list of allowed values for the option
+
+    :return: the parsed value(s)
+    """
+    parsed_values: list[str] = []
+    for val in value.split(","):
+        val = val.strip()
+        if allowed_values and val not in allowed_values:
+            raise click.BadParameter(f"'{val}' is not one of {allowed_values}")
+        parsed_values.append(val)
+    return parsed_values if len(parsed_values) > 1 else parsed_values[0]
 
 
 def yaml_param_callback(

--- a/perun/utils/common/cli_kit.py
+++ b/perun/utils/common/cli_kit.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 # Standard Imports
 from collections import defaultdict
 from importlib import metadata
-from typing import Optional, Callable, Any, TYPE_CHECKING
+from typing import Optional, Callable, Any
 import functools
 import json
 import os
@@ -36,9 +36,7 @@ from perun.utils.exceptions import (
     NotPerunRepositoryException,
 )
 from perun.utils.structs import collect_structs
-
-if TYPE_CHECKING:
-    from perun.utils.structs.common_structs import MinorVersion
+from perun.utils.structs.common_structs import MinorVersion, SortOrder
 
 
 def print_version(_: click.Context, __: click.Option, value: bool) -> None:
@@ -191,6 +189,16 @@ def config_value_parse_and_validate(
             raise click.BadParameter(f"'{val}' is not one of {allowed_values}")
         parsed_values.append(val)
     return parsed_values if len(parsed_values) > 1 else parsed_values[0]
+
+
+# TODO: temporary solution to de-clutter CLI.
+#  Should be resolved by fixing issue #302 https://github.com/Perfexionists/perun/issues/302
+validate_profile_sort_by = functools.partial(
+    config_value_parse_and_validate, allowed_values=profile.ProfileInfo.valid_attributes
+)
+validate_profile_sort_order = functools.partial(
+    config_value_parse_and_validate, allowed_values=SortOrder.supported()
+)
 
 
 def yaml_param_callback(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1213,6 +1213,26 @@ def test_status_correct(pcs_single_prof):
     assert pcs_single_prof.local_config().get("format.sort_profiles_by") == ["source", "label"]
 
 
+def test_status_incorrect(pcs_single_prof):
+    """Test running perun status in perun directory with incorrect CLI options.
+
+    Expecting errors to be detected and reported.
+    """
+    runner = CliRunner()
+    old_sort_by = pcs_single_prof.local_config().get("format.sort_profiles_by")
+    old_sort_order = pcs_single_prof.local_config().get("format.sort_profiles_order")
+
+    # Attempt to run the status with invalid sort-by first
+    short_result = runner.invoke(cli.status, ["--short", "--sort-by", "bogus"])
+    asserts.predicate_from_cli(short_result, short_result.exit_code == 2)
+    assert pcs_single_prof.local_config().get("format.sort_profiles_by") == old_sort_by
+
+    # Now try invalid sort-order
+    short_result = runner.invoke(cli.status, ["--short", "--sort-order", "random"])
+    asserts.predicate_from_cli(short_result, short_result.exit_code == 2)
+    assert pcs_single_prof.local_config().get("format.sort_profiles_order") == old_sort_order
+
+
 @pytest.mark.usefixtures("cleandir")
 def test_init_correct():
     """Test running init from cli, without any problems

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1197,20 +1197,20 @@ def test_status_correct(pcs_single_prof):
     short_result = runner.invoke(cli.status, ["--short"])
     asserts.predicate_from_cli(short_result, short_result.exit_code == 0)
     asserts.predicate_from_cli(short_result, len(short_result.output.split("\n")) == 6)
-    assert config.lookup_key_recursively("format.sort_profiles_by") == "time"
+    assert config.lookup_key_recursively("format.sort_profiles_by") == ["time", "stem", "copy"]
 
     # Try that the sort order changed
     short_result = runner.invoke(
-        cli.status, ["--short", "--sort-by", "source", "--sort-order", "desc"]
+        cli.status, ["--short", "--sort-by", "source,label", "--sort-order", "desc"]
     )
     asserts.predicate_from_cli(short_result, short_result.exit_code == 0)
-    assert pcs_single_prof.local_config().get("format.sort_profiles_by") == "source"
+    assert pcs_single_prof.local_config().get("format.sort_profiles_by") == ["source", "label"]
     assert pcs_single_prof.local_config().get("format.sort_profiles_order") == "desc"
 
     # The sort order is kept the same
     short_result = runner.invoke(cli.status, ["--short"])
     asserts.predicate_from_cli(short_result, short_result.exit_code == 0)
-    assert pcs_single_prof.local_config().get("format.sort_profiles_by") == "source"
+    assert pcs_single_prof.local_config().get("format.sort_profiles_by") == ["source", "label"]
 
 
 @pytest.mark.usefixtures("cleandir")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1400,7 +1400,7 @@ def test_collect_correct(pcs_with_root):
     runner = CliRunner()
     result = runner.invoke(
         collect_cli.collect,
-        ["-c echo", "-w hello", "-o", "prof.perf", "time", "--repeat=1", "--warmup=1"],
+        ["-c echo", "-w hello", "-pd", ".", "-pn", "prof.perf", "time", "--repeat=1", "--warmup=1"],
     )
     asserts.predicate_from_cli(result, result.exit_code == 0)
     assert "prof.perf" in os.listdir(".")
@@ -1427,7 +1427,9 @@ def test_collect_correct(pcs_with_root):
             "collect",
             "-c echo",
             "-w hello",
-            "-o",
+            "-pd",
+            ".",
+            "-pn",
             "prof3.perf",
             "time",
             "--repeat=1",
@@ -1448,7 +1450,9 @@ def test_collect_correct(pcs_with_root):
             "collect",
             "-c echo",
             "-w hello",
-            "-o",
+            "-pd",
+            ".",
+            "-pn",
             "prof2.perf",
             "time",
             "--repeat=1",
@@ -2628,12 +2632,14 @@ def test_svs():
         # Perf is unavailable on macOS
         return
 
-    result = runner.invoke(collect_cli.collect, ["-c echo", "-w hello", "-o", "prof.perf", "kperf"])
+    result = runner.invoke(
+        collect_cli.collect, ["-c echo", "-w hello", "-pd", ".", "-pn", "prof.perf", "kperf"]
+    )
     asserts.predicate_from_cli(result, result.exit_code == 0)
     assert "prof.perf" in os.listdir(".")
 
     result = runner.invoke(
-        collect_cli.collect, ["-c echo", "-w world", "-o", "prof2.perf", "kperf"]
+        collect_cli.collect, ["-c echo", "-w world", "-pd", ".", "-pn", "prof2.perf", "kperf"]
     )
     asserts.predicate_from_cli(result, result.exit_code == 0)
     assert "prof2.perf" in os.listdir(".")

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -68,6 +68,8 @@ def test_import_stack(pcs_with_svs):
         cli.cli,
         [
             "import",
+            "-pn",
+            "custom_import_profile",
             "--import-dir",
             pool_path,
             "--machine-info",
@@ -78,32 +80,15 @@ def test_import_stack(pcs_with_svs):
         ],
     )
     assert result.exit_code == 0
-    assert len(os.listdir(os.path.join(".perun", "jobs"))) == 2
-
-    result = runner.invoke(
-        cli.cli,
-        [
-            "import",
-            "--save-to-index",
-            "-c",
-            "ls",
-            "-w",
-            "..",
-            "perf",
-            "stack",
-            os.path.join(pool_path, "import.stack"),
-            os.path.join(pool_path, "import.stack.gz"),
-        ],
-    )
-    assert result.exit_code == 0
-    assert len(os.listdir(os.path.join(".perun", "jobs"))) == 2
+    profiles = os.listdir(os.path.join(".perun", "jobs"))
+    assert len(profiles) == 2 and "custom_import_profile.perf" in profiles
 
     result = runner.invoke(
         cli.cli,
         [
             "import",
             "-pn",
-            "custom_import_profile",
+            "custom_import_profile.perf",
             "-c",
             "ls",
             "-w",
@@ -132,7 +117,25 @@ def test_import_stack(pcs_with_svs):
     )
     assert result.exit_code == 0
     profiles = os.listdir(os.path.join(".perun", "jobs"))
-    assert len(profiles) == 3 and "custom_import_profile.perf" in profiles
+    assert len(profiles) == 3 and "custom_import_profile(1).perf" in profiles
+
+    result = runner.invoke(
+        cli.cli,
+        [
+            "import",
+            "--save-to-index",
+            "-c",
+            "ls",
+            "-w",
+            "..",
+            "perf",
+            "stack",
+            os.path.join(pool_path, "import.stack"),
+            os.path.join(pool_path, "import.stack.gz"),
+        ],
+    )
+    assert result.exit_code == 0
+    assert len(os.listdir(os.path.join(".perun", "jobs"))) == 3
 
 
 def test_import_error(pcs_with_svs):


### PR DESCRIPTION
This PR refactors the naming and saving of Perun profiles, removing some existing code duplication.

- Profiles are no longer overwritten by default if an existing profile with identical name exists. Instead, the profile name is suffixed with a copy number, e.g., `custom_profile(N).perf`.
- The collect and import CLI now define identical options `--profile-name` and `--profile-dir` that determine the name and target directory for storage of the profile.
- Profiles may now be sorted w.r.t. multiple keys and orderings.
- New sort keys `stem` and `copy` were added to handle new naming scheme with name copies.
- By default, the sorting is now done using multikey `time` > `stem` > `copy` that results in a more natural ordering of profiles.