### PR TITLE
Add config option for profile overwriting preference

### DIFF
--- a/docs/collectors.rst
+++ b/docs/collectors.rst
@@ -267,7 +267,7 @@ You can register your new collector as follows:
     7. At this point you can start using your collector either using ``perun collect`` or using the
        following to set the job matrix and run the batch collection of profiles::
 
-        perun config --edit
+        perun config edit
         perun run matrix
 
     8. If you think your collector could help others, please, consider making `Pull Request`_.

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -14,7 +14,7 @@ more details described in :ref:`jobs-matrix`) or information about wrapped repos
 
 In order to configure your local instance of Perun run the following::
 
-    perun config --edit
+    perun config edit
 
 This will open the nearest local configuration in text editor (by default in ``vim``) and lets you
 modify the options w.r.t. Yaml_ format.
@@ -275,6 +275,13 @@ List of Supported Options
    profile (e.g. by running ``perun run matrix``) is automatically registered in the appropriate
    minor version index.
 
+.. confkey:: profiles.overwrite
+
+   If the key is set to a true value (can be 1, true, True, yes, etc.), then a newly generated
+   profile will overwrite an existing profile with identical name, if such profile exists.
+   Otherwise (if set to a false value), the newly generated profile's name will be extended with
+   a copy suffix so that both profiles may be kept.
+
 .. confunit:: degradation
 
    Speficies the list of strategies and how they are applied when checked for degradation in
@@ -363,9 +370,9 @@ Predefined Configuration Templates
 Command Line Interface
 ----------------------
 
-We advise to manipulate with configurations using the ``perun config --edit`` command. In order to
-change the nearest local (resp. global) configuration run ``perun config --local --edit`` (resp.
-``perun config --shared --edit``).
+We advise to manipulate with configurations using the ``perun config edit`` command. In order to
+change the nearest local (resp. global) configuration run ``perun config --local edit`` (resp.
+``perun config --shared edit``).
 
 .. click:: perun.cli_groups.config_cli:config
    :prog: perun config

--- a/docs/jobs.rst
+++ b/docs/jobs.rst
@@ -188,7 +188,7 @@ by :ref:`postprocessors-regression-analysis` with specification ``{'method': 'fu
 
 Run the following to configure the job matrix of the current project::
 
-    perun config --edit
+    perun config edit
 
 This will open the local configuration in editor specified by :ckey:`general.editor` and lets you
 specify configuration for your application and set of collectors and postprocessors. Unless the

--- a/docs/postprocessors.rst
+++ b/docs/postprocessors.rst
@@ -393,7 +393,7 @@ You can register your new postprocessor as follows:
     7. At this point you can start using your postprocessor either using ``perun postprocessby`` or using the
        following to set the job matrix and run the batch collection of profiles::
 
-        perun config --edit
+        perun config edit
         perun run matrix
 
     8. If you think your postprocessor could help others, please, consider making `Pull Request`_.

--- a/perun/cli_groups/collect_cli.py
+++ b/perun/cli_groups/collect_cli.py
@@ -53,6 +53,14 @@ from perun.logic import commands, config as perun_config
     help="Registers the imported profile in index instead of saving it in pending.",
 )
 @click.option(
+    "--overwrite-profiles",
+    is_flag=True,
+    default=False,
+    callback=cli_kit.set_config_option_from_flag(perun_config.runtime, "profiles.overwrite", str),
+    help="If a profile with the same name already exists it will be overwritten instead of"
+    "renaming this profile to contain a copy number suffix, e.g., custom_name(1).perf.",
+)
+@click.option(
     "--minor-version",
     "-m",
     "minor_version_list",

--- a/perun/cli_groups/import_cli.py
+++ b/perun/cli_groups/import_cli.py
@@ -82,6 +82,14 @@ from perun.utils.common import cli_kit
     help="Registers the imported profile in index instead of saving it in pending.",
 )
 @click.option(
+    "--overwrite-profiles",
+    is_flag=True,
+    default=False,
+    callback=cli_kit.set_config_option_from_flag(config.runtime, "profiles.overwrite"),
+    help="If a profile with the same name already exists it will be overwritten instead of"
+    "renaming this profile to contain a copy number suffix, e.g., custom_name(1).perf.",
+)
+@click.option(
     "--profile-dir",
     "-pd",
     nargs=1,

--- a/perun/logic/config_templates.py
+++ b/perun/logic/config_templates.py
@@ -37,6 +37,8 @@ The actually set options are specified in the following table. When the option i
 +-------------------------------------------+----------------------------------------+-------------------------------+------------+
 | :ckey:`profiles.register_after_run`       | true                                   |               --              |     --     |
 +-------------------------------------------+----------------------------------------+-------------------------------+------------+
+| :ckey:`profiles.overwrite`                | false                                  | false                         |     --     |
++-------------------------------------------+----------------------------------------+-------------------------------+------------+
 | :ckey:`format.output_profile_template`    | %collector%-of-%cmd%-%workload%-%date% |               --              |     --     |
 +-------------------------------------------+----------------------------------------+-------------------------------+------------+
 
@@ -141,16 +143,22 @@ postprocessors:
 {% endif %}
 ## Try '$ perun postprocessby --help' to obtain list of supported collectors!
 
-## The following option automatically registers newly collected profiles for current minor version
+## The following options automatically register newly collected profiles for current minor version
+## and make sure that profiles with identical names are not overwritten but instead extended with
+## a copy number suffix.
 {% if profiles is defined %}
 profiles:
   {% if profiles.register_after_run is defined %}
     register_after_run: {{ profiles.register_after_run }}
   {% endif %}
+  {% if profiles.overwrite is defined %}
+    overwrite: {{ profiles.overwrite }}
+  {% endif %}
 {% else %}
 ## Uncomment the following to enable this behaviour:
 # profiles:
 #   register_after_run: true
+#   overwrite: false
 {% endif %}
 
 ## Be default, we multisort the profiles by time > stem > copy in ascending order
@@ -264,8 +272,9 @@ class MasterConfiguration:
 
 
 class DeveloperConfiguration(MasterConfiguration):
-    """Configuration meant for advanced users (developers), which sets the basic degradation checks
-    and automatic execution of the ``make`` before each collection.
+    """Configuration meant for advanced users (developers), which sets the basic degradation
+    checks, automatic execution of the ``make`` before each collection and disables profiles
+    overwriting for identical profile names.
 
     The following configurations options will be additionally set:
 
@@ -280,11 +289,14 @@ class DeveloperConfiguration(MasterConfiguration):
     +-------------------------------------------+-------------------------------+
     | :ckey:`execute.pre_run`                   | make                          |
     +-------------------------------------------+-------------------------------+
+    | :ckey:`profiles.overwrite`                | false                         |
+    +-------------------------------------------+-------------------------------+
     """
 
     def __init__(self) -> None:
         """Initialization of keys used for jinja2 template"""
         super().__init__()
+        self.profiles = {"overwrite": "false"}
         self.execute = {"pre_run": ["make"]}
         self.degradation = {
             "strategy": [{"method": "average_amount_threshold"}],
@@ -311,6 +323,8 @@ class UserConfiguration(DeveloperConfiguration):
     | :cunit:`collectors`                       | :ref:`collectors-time`                 |
     +-------------------------------------------+----------------------------------------+
     | :ckey:`profiles.register_after_run`       | true                                   |
+    +-------------------------------------------+----------------------------------------+
+    | :ckey:`profiles.overwrite`                | false                                  |
     +-------------------------------------------+----------------------------------------+
     | :ckey:`format.output_profile_template`    | %collector%-of-%cmd%-%workload%-%date% |
     +-------------------------------------------+----------------------------------------+
@@ -390,7 +404,7 @@ class UserConfiguration(DeveloperConfiguration):
         super().__init__()
         self.collectors = [{"name": "time", "params": {"warmup": 3, "repeat": 10}}]
         self.format = {"output_profile_template": "%collector%-of-%cmd%-%workload%-%date%"}
-        self.profiles = {"register_after_run": "true"}
+        self.profiles = {"register_after_run": "true", "overwrite": "false"}
 
         # Lookup executables and workloads
         executable_candidates = UserConfiguration._locate_executable_candidates()

--- a/perun/profile/helpers.py
+++ b/perun/profile/helpers.py
@@ -128,7 +128,8 @@ class ProfilePath:
         """Finalize the profile path such that it can be used to store a profile.
 
         This includes (1) generating a default profile name unless a user-defined name was
-        provided, and (2) deducing the correct copy number to avoid overwriting existing profiles.
+        provided, and (2) deducing the correct copy number to avoid overwriting existing profiles
+        unless the configuration permits overwriting.
 
         :param profile: the profile that will be stored under this path.
 
@@ -137,11 +138,15 @@ class ProfilePath:
         if not self.stem:
             # No custom profile name provided, generate the stem
             self.stem = generate_profile_name(profile)[: -len(".perf")]
-        # We must check for duplicate files first
-        for duplicate in self.directory.glob(f"{self.stem}*"):
-            p = ProfilePath.from_path(duplicate)
-            if p.stem == self.stem:
-                self.copy = max(self.copy, p.copy + 1)
+        # Does the user wish to overwrite existing profiles?
+        if not common_kit.strtobool(
+            str(config.lookup_key_recursively("profiles.overwrite", "false"))
+        ):
+            # We must check for duplicate files first
+            for duplicate in self.directory.glob(f"{self.stem}*"):
+                p = ProfilePath.from_path(duplicate)
+                if p.stem == self.stem:
+                    self.copy = max(self.copy, p.copy + 1)
         return self
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1439,6 +1439,7 @@ def test_collect_correct(pcs_with_root):
         )
         asserts.predicate_from_cli(result, result.exit_code == 0)
 
+    # Test that overwriting option works correctly
     assert len(os.listdir(os.path.join(".perun", "logs"))) == 0
     result = runner.invoke(
         cli.cli,
@@ -1450,14 +1451,16 @@ def test_collect_correct(pcs_with_root):
             "-pd",
             ".",
             "-pn",
-            "prof3.perf",
+            "prof.perf",
+            "--overwrite-profiles",
             "time",
             "--repeat=1",
             "--warmup=1",
         ],
     )
     asserts.predicate_from_cli(result, result.exit_code == 0)
-    assert "prof3.perf" in os.listdir(".")
+    files_new = os.listdir(".")
+    assert "prof(1).perf" not in files_new and "prof.perf" in files_new
     assert len(os.listdir(os.path.join(".perun", "logs"))) >= 1
 
     assert "log" not in os.listdir(".")
@@ -1474,13 +1477,14 @@ def test_collect_correct(pcs_with_root):
             ".",
             "-pn",
             "prof2.perf",
+            "--save-to-index",
             "time",
             "--repeat=1",
             "--warmup=1",
         ],
     )
     asserts.predicate_from_cli(result, result.exit_code == 0)
-    assert "prof2.perf" in os.listdir(".")
+    assert "prof2.perf" not in os.listdir(".")
     assert "log" in os.listdir(".")
 
 

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -119,6 +119,27 @@ def test_import_stack(pcs_with_svs):
     profiles = os.listdir(os.path.join(".perun", "jobs"))
     assert len(profiles) == 3 and "custom_import_profile(1).perf" in profiles
 
+    # Request that the existing profile is overwritten
+    result = runner.invoke(
+        cli.cli,
+        [
+            "import",
+            "-pn",
+            "custom_import_profile",
+            "--overwrite-profiles",
+            "--import-dir",
+            pool_path,
+            "--machine-info",
+            "machine_info.json",
+            "perf",
+            "stack",
+            "import.stack",
+        ],
+    )
+    assert result.exit_code == 0
+    profiles = os.listdir(os.path.join(".perun", "jobs"))
+    assert len(profiles) == 3 and "custom_import_profile.perf" in profiles
+
     result = runner.invoke(
         cli.cli,
         [


### PR DESCRIPTION
This PR adds support for a new `profiles.overwrite` key in the Perun configuration that may be used to set the preference for (not) overwriting profiles with conflicting names.

Combined with the previous PR #301, this PR fixes #282. Although this solution does not prompt the user as originally planned, it is a solution more in line with how such features work in Perun (CLI, config options, and no need for manual input from the user).