### PR TITLE
Improve handling of tall flamegraphs

### DIFF
--- a/perun/profile/convert.py
+++ b/perun/profile/convert.py
@@ -107,7 +107,10 @@ def models_to_pandas_dataframe(profile: Profile) -> pandas.DataFrame:
 
 
 def to_flame_graph_format(
-    profile: Profile, profile_key: str = "amount", minimize: bool = False
+    profile: Profile,
+    profile_key: str = "amount",
+    minimize: bool = False,
+    squash_unknown: bool = True,
 ) -> list[str]:
     """Transforms the **memory** profile w.r.t. :ref:`profile-spec` into the
     format supported by perl script of Brendan Gregg.
@@ -135,6 +138,7 @@ def to_flame_graph_format(
     :param profile: the memory profile
     :param profile_key: key that is used to obtain the data
     :param minimize: minimizes the uids
+    :param squash_unknown: whether recursive [unknown] frames should be squashed into a single one
     :returns: list of lines, each representing one allocation call stack
     """
     stacks = []
@@ -143,15 +147,27 @@ def to_flame_graph_format(
             if "subtype" not in alloc.keys() or alloc["subtype"] != "free":
                 # Workaround for total time used in some collectors, so it is not outputted
                 if alloc["uid"] != "%TOTAL_TIME%" and profile_key in alloc:
-                    stack_str = to_uid(alloc["uid"]) + ";"
-                    for frame in alloc.get("trace", [])[::-1]:
+                    stack = alloc.get("trace", [])
+                    stack.append(alloc["uid"])
+                    stack_str = ""
+                    unknown_cnt = 0
+                    for frame in reversed(stack):
                         line = to_uid(frame, minimize)
-                        stack_str += line + ";"
-                    if stack_str and stack_str.endswith(";"):
-                        final = stack_str[:-1]
-                        final += " " + str(alloc[profile_key]) + "\n"
-                        stacks.append(final)
-
+                        if squash_unknown:
+                            # Fold unknown towers
+                            if line == "[unknown]":
+                                unknown_cnt += 1
+                                continue
+                            elif unknown_cnt > 0:
+                                stack_str += "[unknown[squashed]];"
+                                unknown_cnt = 0
+                        stack_str += f"{line};"
+                    # The unknown frame might have been the last one, in which case the frame was
+                    # not yet added to the string.
+                    if unknown_cnt > 0:
+                        stack_str += "[unknown[squashed]];"
+                    if stack_str:
+                        stacks.append(f"{stack_str[:-1]} {alloc[profile_key]}\n")
     return stacks
 
 

--- a/perun/view/flamegraph/flamegraph.py
+++ b/perun/view/flamegraph/flamegraph.py
@@ -145,7 +145,11 @@ def build_flamegraph_command(
     cmd.extend(f"--{flag}" for flag in flags)
     # Additional parameters
     for key, val in kwargs.items():
-        if val is not None:
+        if val is True:
+            # This kwarg is a flag
+            cmd.append(f"--{key}")
+        elif val:
+            # This kwarg is a parameter
             cmd.append(f"--{key}")
             cmd.append(f"'{val}'")
     # The 'total' parameter needs special handling: add a rootnode that scales the flamegraph

--- a/perun/view_diff/flamegraph/run.py
+++ b/perun/view_diff/flamegraph/run.py
@@ -131,6 +131,7 @@ def generate_flamegraphs(
     data_types: list[str],
     skip_diff: bool = False,
     minimize: bool = False,
+    squash_unknown: bool = True,
     **fg_forward_kwargs: Any,
 ) -> list[tuple[str, str, str, str, str]]:
     """Constructs a list of tuples of flamegraphs for list of data_types
@@ -140,6 +141,7 @@ def generate_flamegraphs(
     :param data_types: list of data types (resources)
     :param skip_diff: whether the flamegraph diff should be skipped or not
     :param minimize: whether the flamegraph should be minimized or not
+    :param squash_unknown: whether recursive [unknown] frames should be squashed into a single one
     :param fg_forward_kwargs: additional parameters forwarded to the flamegraph scripts
 
     :return: a collection of (data_type, lhs flamegraph, rhs flamegraph, lhs_rhs_diff_flamegraph,
@@ -150,10 +152,10 @@ def generate_flamegraphs(
         try:
             data_type = mapping.from_readable_key(dtype)
             lhs_flame = convert.to_flame_graph_format(
-                lhs_profile, profile_key=data_type, minimize=minimize
+                lhs_profile, profile_key=data_type, minimize=minimize, squash_unknown=squash_unknown
             )
             rhs_flame = convert.to_flame_graph_format(
-                rhs_profile, profile_key=data_type, minimize=minimize
+                rhs_profile, profile_key=data_type, minimize=minimize, squash_unknown=squash_unknown
             )
             fg_image_width = fg_forward_kwargs["width"]
             fg_minwidth = fg_forward_kwargs.get("minwidth", f"{FG_DEFAULT_MIN_WIDTH}")

--- a/perun/view_diff/report/run.py
+++ b/perun/view_diff/report/run.py
@@ -740,6 +740,7 @@ def generate_report(lhs_profile: Profile, rhs_profile: Profile, **kwargs: Any) -
         Stats.all_stats(),
         skip_diff=False,
         minimize=Config().minimize,
+        squash_unknown=not kwargs.get("no_squash_unknown", False),
         **fg_forward_kwargs,
     )
     log.minor_success("Sankey graphs", "generated")
@@ -826,6 +827,13 @@ def generate_report(lhs_profile: Profile, rhs_profile: Profile, **kwargs: Any) -
     is_flag=True,
     help="Minimizes the traces, folds the recursive calls, hides the generic types.",
 )
+# TODO: generalize such that (possibly some) recursive functions may be squashed as well.
+@click.option(
+    "--no-squash-unknown",
+    is_flag=True,
+    default=False,
+    help="Do not squash [unknown] frames in flamegraph into a single frame.",
+)
 @click.option(
     "--flamegraph-width",
     type=int,
@@ -869,6 +877,13 @@ def generate_report(lhs_profile: Profile, rhs_profile: Profile, **kwargs: Any) -
     "--flamegraph-colors",
     type=str,
     help="Specifies the color theme for flamegraphs. This option is forwarded to the "
+    "flamegraph.pl script.",
+)
+@click.option(
+    "--flamegraph-inverted",
+    is_flag=True,
+    default=False,
+    help="Draws icicle graphs instead of flame graphs. This option is forwarded to the "
     "flamegraph.pl script.",
 )
 @click.pass_context

--- a/tests/test_diff_views.py
+++ b/tests/test_diff_views.py
@@ -184,6 +184,25 @@ def test_diff_incremental_sankey_kperf(pcs_with_root):
     assert result.exit_code == 0
     assert "diff.html" in os.listdir(os.getcwd())
 
+    # Try icicle graphs with no squashing of [unknown] frames
+    result = runner.invoke(
+        cli.showdiff,
+        [
+            "--display-style",
+            "diff",
+            baseline_profilename,
+            target_profilename,
+            "report",
+            "--no-squash-unknown",
+            "--flamegraph-inverted",
+            "-o",
+            "diff_icicle.html",
+            "--minimize",
+        ],
+    )
+    assert result.exit_code == 0
+    assert "diff_icicle.html" in os.listdir(os.getcwd())
+
 
 def test_diff_report_invalid_forward_param(pcs_with_root):
     runner = CliRunner()


### PR DESCRIPTION
Perun report currently does not handle tall flamegraphs in a user-friendly manner. This PR attempts to improve this in two ways.
- Flamegraphs now by-default squash `[unknown]` frames into a single frame to avoid tall `[unknown]` towers. This feature may be disabled by the CLI option `--no-squash-unknown`. Note that this is more of an ad-hoc fix, as a proper systematic solution needs #305 to be resolved first in order to avoid computationally expensive processing of the profiling data.
- Additionally, report now supports forwarding the `--inverted` flag to the `flamegraph.pl` script, which creates icicle graphs instead of flame graphs. This is useful for large profiles that do not fully fit into the viewport.