### PR TITLE
Hotfix Click 8.2.0 incompatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     "psutil>=6.0.0",
 
     # CLI
-    "click>=8.1.7",
+    "click>=8.1.7,<8.2.0",
 
     # VCS integration
     "GitPython>=3.1.43",


### PR DESCRIPTION
The new Click version 8.2.0 introduced a ValueError issue in our testing setup (see https://github.com/pallets/click/issues/824). This PR hotfixes the issue by restricting the Click version to < 8.2.0.