### PR TITLE
Extend the showdiff traces table with new metrics

### DIFF
--- a/perun/templates/diff_sections/section_traces_table.html.jinja2
+++ b/perun/templates/diff_sections/section_traces_table.html.jinja2
@@ -1,6 +1,7 @@
 {% import 'macros/section_title.html.jinja2' as m_title %}
 
-{% set traces_table_info = "Click on a row to explore top N calling contexts (traces) of the selected function.
+{% set traces_table_info = "Mouseover a column header to display a tooltip explaining the column.
+            Click on a row to explore top N calling contexts (traces) of the selected function.
             Click on (+) next to a trace row to open a detail about that concrete trace.
             You may filter the table using the select form in the table header." %}
 
@@ -8,19 +9,25 @@
 
     {{ m_title.display_title("Traces Table", "traces table", traces_table_info, notes_enabled) }}
 
-    <table id="table" class="traces_table" style="width: 100%;">
+    <table id="table" class="traces_table display" style="width: 100%;">
         <thead>
             <tr>
                 <th></th>
                 <th>Unit</th>
                 <th>Change</th>
                 <th>Metric</th>
-                <th>Absolute Δ</th>
-                <th>Relative Δ</th>
+                <th title="The amount of resources consumed by the Unit in the baseline profile.">Baseline</th>
+                <th title="The amount of resources consumed by the Unit in the target profile.">Target</th>
+                <th title="The change in total amount of resources consumed by the target and baseline profile.">Total Δ [%]</th>
+                <th title="The absolute difference of Target - Baseline.">Absolute Δ</th>
+                <th title="The relative difference of Target - Baseline.">Relative Δ [%]</th>
             </tr>
         </thead>
         <tfoot>
             <tr>
+                <th></th>
+                <th></th>
+                <th></th>
                 <th></th>
                 <th></th>
                 <th></th>
@@ -41,12 +48,18 @@
             <th>Unit</th>
             <th>Change</th>
             <th>Metric</th>
-            <th>Absolute Δ</th>
-            <th>Relative Δ</th>
+            <th title="The amount of resources consumed by the Unit in the baseline profile.">Baseline</th>
+            <th title="The amount of resources consumed by the Unit in the target profile.">Target</th>
+            <th title="The change in total amount of resources consumed by the target and baseline profile.">Total Δ [%]</th>
+            <th title="The absolute difference of Target - Baseline.">Absolute Δ</th>
+            <th title="The relative difference of Target - Baseline.">Relative Δ [%]</th>
         </tr>
     </thead>
     <tfoot>
         <tr>
+            <th></th>
+            <th></th>
+            <th></th>
             <th></th>
             <th></th>
             <th></th>

--- a/perun/templates/scripts/traces_table_js.html.jinja2
+++ b/perun/templates/scripts/traces_table_js.html.jinja2
@@ -1,6 +1,6 @@
 <script>
     // Selection table
-    let table = {"data":[{%- for val in selection_table %}{"uid":"{{ val.uid }}","index":"{{ val.index }}","fresh": "{{ val.fresh }}","stats": {{ val.stats|map('list')|list }},"traces": {{ val.trace_stats|map('list')|list }},"type": "{{ val.main_stat }}","abs": "{{ val.abs_amount }}","rel": "{{ val.rel_amount }}" },{%- endfor %}]};
+    let table = {"data":[{%- for val in selection_table %}{"uid":"{{ val.uid }}","index":"{{ val.index }}","fresh": "{{ val.fresh }}","stats": {{ val.stats|map('list')|list }},"traces": {{ val.trace_stats|map('list')|list }},"type": "{{ val.main_stat }}","baseline_abs": "{{ val.baseline_abs }}","target_abs": "{{ val.target_abs }}","total_rel_delta": "{{ val.total_rel_delta }}","abs_delta": "{{ val.abs_delta }}","rel_delta": "{{ val.rel_delta }}" },{%- endfor %}]};
     let selection_table = $("#table").DataTable({
         data: table.data,
         columns: [
@@ -19,7 +19,7 @@
                     if (type ==='display') {
                         if (data === "not in baseline") {
                             return '<span style="font-weight: bold; color: {{ palette.Target }}">' + data + "</span>";
-                        } else if (data == "not in target") {
+                        } else if (data === "not in target") {
                             return '<span style="font-weight: bold; color: {{ palette.Baseline }}">' + data + "</span>";
                         } else {
                             return '<span style="font-weight: bold; color: {{ palette.Equal }}">' + data + "</span>";
@@ -32,17 +32,27 @@
                 data: "type",
                 render: function(data, type) {return (type === 'display') ? stat_id_to_name(data) : data;}
             }, {
-                data: "abs",
+                data: "baseline_abs",
                 className: "dt-body-right",
                 render: function(data, type) {return (type === 'display') ? format_value(data) : data;}
-            },
-            {
-                data: "rel",
+            }, {
+                data: "target_abs",
+                className: "dt-body-right",
+                render: function(data, type) {return (type === 'display') ? format_value(data) : data;}
+            }, {
+                data: "total_rel_delta",
+                render: function(data, type) {return (type === 'display') ? format_relative(data) : data;}
+            }, {
+                data: "abs_delta",
+                className: "dt-body-right",
+                render: function(data, type) {return (type === 'display') ? format_value(data, true) : data;}
+            }, {
+                data: "rel_delta",
                 render: function(data, type) {return (type === 'display') ? format_relative(data) : data;}
             },
             { data: "index", visible: false},
         ],
-        order: [[4, "desc"]],
+        order: [[6, "desc"]],
         iDisplayLength: 10,
         select: true,
         scrollY: "550px",
@@ -99,11 +109,17 @@
         } else {
             let d = row.data();
             row.child(format_row(d)).show();
-            new DataTable("#metrics" + d.index, {paging: false, info: false, searching: false, order: [[1, 'desc']], columns: [
+            new DataTable("#metrics" + d.index, {paging: false, info: false, searching: false, order: [[3, 'desc']], columns: [
                     {
                         render: function(data, type) {return (type === 'display') ? stat_id_to_name(data) : data;}
                     }, {
                         render: function(data, type) {return (type === 'display') ? format_value(data) : data;}
+                    }, {
+                        render: function(data, type) {return (type === 'display') ? format_value(data) : data;}
+                    }, {
+                        render: function(data, type) {return (type === 'display') ? format_relative(data) : data;}
+                    }, {
+                        render: function(data, type) {return (type === 'display') ? format_value(data, true) : data;}
                     }, {
                         render: function(data, type) {return (type === 'display') ? format_relative(data) : data;}
                     }
@@ -122,6 +138,12 @@
                     }, {
                         render: function(data, type) {return (type === 'display') ? format_value(data) : data;}
                     }, {
+                        render: function(data, type) {return (type === 'display') ? format_value(data) : data;}
+                    }, {
+                        render: function(data, type) {return (type === 'display') ? format_relative(data) : data;}
+                    }, {
+                        render: function(data, type) {return (type === 'display') ? format_value(data, true) : data;}
+                    }, {
                         render: function(data, type) {return (type === 'display') ? format_relative(data) : data;}
                     }, {visible: false},
                 ],
@@ -131,7 +153,7 @@
                 paging: false,
                 info: false,
                 searching: false,
-                order: [[3, "desc"]]
+                order: [[5, "desc"]]
             });
             trace_table.on('click', 'td.inner-details-control', function(el) {
                 var sub_tr = $(this).closest('tr');
@@ -151,19 +173,4 @@
             tr.addClass('shown');
         }
     });
-
-    selection_table.on('select', function(e, dt, type, indexes) {
-        if (type === 'row') {
-            let data = selection_table.rows(indexes).data();
-            if (data.length > 0) {
-                var div = document.getElementById('sankey_tools');
-                if (div.style.display === "none")
-                    div.style.display = "block";
-                sel_uid = data[0].index;
-                sel_uid_text = data[0].uid;
-                layout.title = sel_uid_text;
-                initializeGraph();
-            }
-        }
-    })
 </script>

--- a/perun/templates/scripts/value_formatters_js.html.jinja2
+++ b/perun/templates/scripts/value_formatters_js.html.jinja2
@@ -8,15 +8,19 @@
         return val;
     }
 
-    function format_value(val) {
+    function format_value(val, show_positive_sign=false) {
         let result = "<span";
         val = ensureNumber(val);
+        let sign = "";
         if (val > 0) {
             result += ' style="font-weight: bold; color: {{ palette.DarkIncrease }}';
+            if (show_positive_sign) {
+                sign = "+"
+            }
         } else if (val < 0) {
             result += ' style="font-weight: bold; color: {{ palette.DarkDecrease }}';
         }
-        return result + '">' + formatNumber(val) + "</span>";
+        return result + '">' + sign + formatNumber(val) + "</span>";
     }
 
     function formatNumber(value) {
@@ -40,19 +44,18 @@
 
     function format_relative(value) {
         value = ensureNumber(value);
-        if (Math.abs(value) >= 0 && Math.abs(value) <= 1) {
-            value = value * 100
-        }
         let fixedValue = Number(value).toFixed(2)
         let result = '<span style="font-weight: bold; ';
+        let sign = "";
         if (value > 0 && value <= 100) {
             result += 'color: {{ palette.DarkIncrease }}"';
+            sign = "+"
         } else if (value >= -100 && value < 0) {
             result += 'color: {{ palette.DarkDecrease }}"';
         } else {
             result += 'color: {{ palette.DarkEqual}}"';
         }
-        return result + '">' + fixedValue + "%</span>";
+        return result + '">' + sign + fixedValue + "%</span>";
     }
 
     function formatMs(ms) {
@@ -108,7 +111,7 @@
             result += '<span class="decrease">' + format(base, stat_unit) + ' ↘ ' + format(tgt, stat_unit) + '</span>';
         }
         return result;
-    };
+    }
 
     function format_path_prex(path_stats, index, path_cost) {
         let result = '<span class="';
@@ -138,12 +141,12 @@
         result += '">' + (bottleneck_rate * 100).toFixed(2) + '%</span>';
         result += '{{ tooltip('<span style="font-weight: bold">Bottleneck rate:</span> the ratio between the cost of the whole path to all paths leading to the current uid') }}'
         return result;
-    };
+    }
 
     function format_sub_row(d, uid) {
         let result = '<table style="width: 100%; border: none;" class="nested">';
         let stat_type = stat_map[d[2]].toLowerCase(), stat_unit = unit_map[stat_map.indexOf(d[2])];
-        let parts = d[5].split('#');
+        let parts = d[8].split('#');
         let traces = parts[0].split(';'), base = parts[1].split(';').map(Number), tgt = parts[2].split(';').map(Number);
         let min_base = Math.min(...base), min_tgt = Math.min(...tgt);
         let sum_base = base.reduce((acc, v) => acc + v, 0), sum_tgt = tgt.reduce((acc, v) => acc + v, 0);
@@ -173,22 +176,35 @@
         });
         result += '</table>';
         return result
-    };
+    }
 
     function format_row(d) {
         let result = '<table id="metrics' + d.index + '" class="display" style="width:100%; border-right: 10px solid #ddd; border-left: 10px solid #ddd;">';
-        result += "<thead><tr><th>Metric</th><th>Absolute</th><th>Relative</th></tr></thead><tbody>";
+        result += "<thead><tr><th>Metric</th>"
+        result += '<th title="The amount of resources consumed by the Unit in the baseline profile.">Baseline</th>';
+        result += '<th title="The amount of resources consumed by the Unit in the target profile.">Target</th>';
+        result += '<th title="The change in total amount of resources consumed by the target and baseline profile.">Total Δ [%]</th>';
+        result += '<th title="The absolute difference of Target - Baseline.">Absolute Δ</th>';
+        result += '<th title="The relative difference of Target - Baseline.">Relative Δ [%]</th></tr></thead><tbody>';
         d.stats.forEach((value, index) => {
             result += "<tr>";
             result += '<td style="white-space: pre-wrap">' + value[0] + "</td>";
             result += '<td style="white-space: pre-wrap">' + value[1] + "</td>";
             result += '<td style="white-space: pre-wrap">' + value[2] + "</td>";
+            result += '<td style="white-space: pre-wrap">' + value[3] + "</td>";
+            result += '<td style="white-space: pre-wrap">' + value[4] + "</td>";
+            result += '<td style="white-space: pre-wrap">' + value[5] + "</td>";
             result += "</tr>";
         });
         result += '</tbody></table>';
         result += '<h4 style="text-align: center; width: 100%; border-bottom: 1px solid #ddd;">Top ' + d.traces.length + ' Traces</h4>';
         result += '<table id="traces' + d.index + '" class="display" style="margin-top: -30px; width:100%; border-right: 10px solid #ddd; border-left: 10px solid #ddd;">';
-        result += "<thead><tr><th></th><th>Trace</th><th>Metric</th><th>Abs</th><th>Rel</th></tr></thead><tbody>";
+        result += "<thead><tr><th></th><th>Trace</th><th>Metric</th>"
+        result += '<th title="The amount of resources consumed by the Unit in the baseline profile.">Baseline</th>';
+        result += '<th title="The amount of resources consumed by the Unit in the target profile.">Target</th>';
+        result += '<th title="The change in total amount of resources consumed by the target and baseline profile.">Total Δ [%]</th>';
+        result += '<th title="The absolute difference of Target - Baseline.">Absolute Δ</th>';
+        result += '<th title="The relative difference of Target - Baseline.">Relative Δ [%]</th></tr></thead><tbody>';
         d.traces.forEach((value, index) => {
             result += "<tr>";
             result += '<td style="white-space: pre-wrap"></td>';
@@ -198,6 +214,9 @@
             result += '<td style="white-space: pre-wrap">' + value[2] + "</td>";
             result += '<td style="white-space: pre-wrap">' + value[3] + "</td>";
             result += '<td style="white-space: pre-wrap">' + value[4] + "</td>";
+            result += '<td style="white-space: pre-wrap">' + value[5] + "</td>";
+            result += '<td style="white-space: pre-wrap">' + value[6] + "</td>";
+            result += '<td style="white-space: pre-wrap">' + value[7] + "</td>";
             result += "</tr>";
         });
         result += '</tbody></table>';

--- a/perun/view_diff/report.py
+++ b/perun/view_diff/report.py
@@ -67,11 +67,16 @@ class SelectionRow:
 
     :ivar uid: uid of the selected graph
     :ivar index: index in the sorted list of data
-    :ivar abs_amount: absolute change in the units
     :ivar fresh: the state of the uid - 1) not in baseline (added in target),
         2) not in target (removed in target), or 3) possibly unchanged
-    :ivar main_stat: type of the
-    :ivar rel_amount: relative change in the units
+    :ivar main_stat: type of the data
+    :ivar baseline_abs: the absolute baseline value
+    :ivar target_abs: the absolute target value
+    :ivar total_rel_delta: the relative delta between total target and baseline value
+    :ivar abs_delta: absolute change between target and baseline
+    :ivar rel_delta: relative change between target and baseline
+    :ivar stats: overview of all stat values
+    :ivar trace_stats: a collection of stats for traces
     """
 
     __slots__ = [
@@ -79,8 +84,11 @@ class SelectionRow:
         "index",
         "fresh",
         "main_stat",
-        "abs_amount",
-        "rel_amount",
+        "baseline_abs",
+        "target_abs",
+        "total_rel_delta",
+        "abs_delta",
+        "rel_delta",
         "stats",
         "trace_stats",
     ]
@@ -90,30 +98,43 @@ class SelectionRow:
         uid: str,
         index: int,
         fresh: Literal["not in baseline", "not in target", "in both"],
-        stats: list[tuple[int, float, float]],
-        trace_stats: list[tuple[str, str, float, float, str]],
+        stats: list[tuple[int, float, float, float, float, float]],
+        trace_stats: list[tuple[str, str, float, float, float, float, float, str]],
     ) -> None:
         """Initializes the selection row"""
         self.uid: str = uid
         self.index: int = index
         self.fresh: Literal["not in baseline", "not in target", "in both"] = fresh
         self.main_stat: int = stats[0][0]
-        self.abs_amount: float = common_kit.to_compact_num(stats[0][1])
-        self.rel_amount: float = common_kit.to_compact_num(stats[0][2])
-        # stat_type, abs, rel
-        self.stats: list[tuple[int, float, float]] = [
-            (stat[0], common_kit.to_compact_num(stat[1]), common_kit.to_compact_num(stat[2]))
+        self.baseline_abs: float = common_kit.to_compact_num(stats[0][1])
+        self.target_abs: float = common_kit.to_compact_num(stats[0][2])
+        self.total_rel_delta: float = common_kit.to_compact_num(stats[0][3])
+        self.abs_delta: float = common_kit.to_compact_num(stats[0][4])
+        self.rel_delta: float = common_kit.to_compact_num(stats[0][5])
+        # stat_type, baseline_abs, target_abs, total_rel_delta, abs_delta, rel_delta
+        self.stats: list[tuple[int, float, float, float, float, float]] = [
+            (
+                stat[0],
+                common_kit.to_compact_num(stat[1]),
+                common_kit.to_compact_num(stat[2]),
+                common_kit.to_compact_num(stat[3]),
+                common_kit.to_compact_num(stat[4]),
+                common_kit.to_compact_num(stat[5]),
+            )
             for stat in stats
         ]
-        # trace, stat_type, abs, rel, long_trace
+        # trace, stat_t, baseline_abs, target_abs, total_rel_delta, abs_delta, rel_delta, long_trace
         all_stats = Stats.all_stats()
-        self.trace_stats: list[tuple[str, int, float, float, str]] = [
+        self.trace_stats: list[tuple[str, int, float, float, float, float, float, str]] = [
             (
                 t[0],
                 all_stats.index(t[1]),
                 common_kit.to_compact_num(t[2]),
                 common_kit.to_compact_num(t[3]),
-                t[4],
+                common_kit.to_compact_num(t[4]),
+                common_kit.to_compact_num(t[5]),
+                common_kit.to_compact_num(t[6]),
+                t[7],
             )
             for t in trace_stats
         ]
@@ -567,6 +588,33 @@ def generate_trace_stats(graph: Graph) -> dict[str, list[TraceStat]]:
     return trace_stats
 
 
+def _get_baseline_target_total() -> tuple[list[float], list[float]]:
+    """A helper function to obtain baseline target total values for all stats.
+
+    :return: collections of baseline and target total values
+    """
+    # TODO: Nasty, but currently the only reasonable way to access the maxima.
+    return [
+        float(stat.value[0])
+        for stat in Config().profile_stats["baseline"]
+        if stat.name.startswith("Overall")
+    ], [
+        float(stat.value[0])
+        for stat in Config().profile_stats["target"]
+        if stat.name.startswith("Overall")
+    ]
+
+
+def _to_percentage(value: float) -> float:
+    """Transforms a value to a percentage and round it to 2 decimal places.
+
+    :param value: the value to transform and round
+
+    :return: the transformed value
+    """
+    return round(100 * value, 2)
+
+
 def generate_selection(graph: Graph, trace_stats: dict[str, list[TraceStat]]) -> list[SelectionRow]:
     """Generates selection table
 
@@ -576,25 +624,31 @@ def generate_selection(graph: Graph, trace_stats: dict[str, list[TraceStat]]) ->
     """
     selection = []
     log.minor_info("Generating selection table")
-    trace_stat_cache: dict[str, tuple[str, str, float, float, str]] = {}
+    trace_stat_cache: dict[str, tuple[str, str, float, float, float, float, float, str]] = {}
     stat_len = len(Stats.all_stats())
+    baseline_max, target_max = _get_baseline_target_total()
     for uid, nodes in log.progress(
         graph.uid_to_nodes.items(), description="Generating Selection Rows"
     ):
         baseline_overall: array.array[float] = array.array("d", [0.0] * stat_len)
         target_overall: array.array[float] = array.array("d", [0.0] * stat_len)
-        stats: list[tuple[int, float, float]] = []
+        # StatID, baseline abs, target abs, total delta, abs delta, rel delta
+        stats: list[tuple[int, float, float, float, float, float]] = []
         for node in nodes:
             for i, known_stat in enumerate(Stats.all_stats()):
                 baseline_overall[i] += node.stats.baseline[known_stat]
                 target_overall[i] += node.stats.target[known_stat]
         for i in range(0, stat_len):
             baseline, target = baseline_overall[i], target_overall[i]
-            if baseline != 0 or target != 0:
-                abs_diff = target - baseline
-                rel_diff = round(100 * abs_diff / max(baseline, target), 2)
-                stats.append((i, abs_diff, rel_diff))
-        stats = sorted(stats, key=itemgetter(2))
+            total_diff = _to_percentage(target / target_max[i] - baseline / baseline_max[i])
+            abs_diff = target - baseline
+            try:
+                rel_diff = _to_percentage(abs_diff / max(baseline, target))
+            except ZeroDivisionError:
+                # Skip this record, both baseline and target are 0
+                continue
+            stats.append((i, baseline, target, total_diff, abs_diff, rel_diff))
+        stats = sorted(stats, key=itemgetter(3))
 
         if stats:
             state: Literal["not in baseline", "not in target", "in both"] = "in both"
@@ -612,30 +666,39 @@ def generate_selection(graph: Graph, trace_stats: dict[str, list[TraceStat]]) ->
 
 
 def extract_stats_from_trace(
-    graph: Graph, uid_stats: list[TraceStat], cache: dict[str, tuple[str, str, float, float, str]]
-) -> list[tuple[str, str, float, float, str]]:
+    graph: Graph,
+    uid_stats: list[TraceStat],
+    cache: dict[str, tuple[str, str, float, float, float, float, float, str]],
+) -> list[tuple[str, str, float, float, float, float, float, str]]:
     """Extracts stats from trace
 
     :param graph: sankey graph
     :param uid_stats: stats for each uid in the graph
     :param cache: helper cache for reducing the statistics
     """
-    uid_trace_stats: list[tuple[str, str, float, float, str]] = []
-    top_n_limit, sort_by_key, relative_thresh = (
+    uid_trace_stats: list[tuple[str, str, float, float, float, float, float, str]] = []
+    top_n_limit, sort_by_key, relative_thresh, threshold_idx = (
         Config().top_n_traces,
-        3,
+        4,
         Config().relative_threshold,
+        6,
     )
+    baseline_max, target_max = _get_baseline_target_total()
     for trace in uid_stats:
-        # Trace is in form of [short_trace, stat_type, abs, rel, long_trace]
+        # Trace is in form of [short_trace, stat_type, baseline abs, target abs, total delta,
+        # abs delta, rel delta, long_trace]
         for i, stat in enumerate(Stats.all_stats()):
             key = f"{trace.trace_id}#{stat}"
             if key not in cache:
                 target_cost, baseline_cost = trace.target_cost[i], trace.baseline_cost[i]
-                if target_cost == 0 and baseline_cost == 0:
-                    continue
                 abs_amount = target_cost - baseline_cost
-                rel_amount = abs_amount / max(target_cost, baseline_cost)
+                try:
+                    rel_amount = _to_percentage(abs_amount / max(baseline_cost, target_cost))
+                except ZeroDivisionError:
+                    continue
+                total_diff = _to_percentage(
+                    target_cost / target_max[i] - baseline_cost / baseline_max[i]
+                )
 
                 short_id = f"{graph.uid_to_id[trace.trace[0]]};{graph.uid_to_id[trace.trace[-1]]}"
                 long_trace = ";".join([f"{graph.uid_to_id[t]}" for t in trace.trace])
@@ -646,8 +709,17 @@ def extract_stats_from_trace(
                     common_kit.compact_convert_list_to_str(trace.target_partial_costs[i])
                 )
                 long_data = f"{long_trace}#{long_baseline_stats}#{long_target_stats}"
-                cache[key] = (short_id, stat, abs_amount, rel_amount, long_data)
-            if float(cache[key][sort_by_key]) >= relative_thresh:
+                cache[key] = (
+                    short_id,
+                    stat,
+                    baseline_cost,
+                    target_cost,
+                    total_diff,
+                    abs_amount,
+                    rel_amount,
+                    long_data,
+                )
+            if float(cache[key][threshold_idx]) >= relative_thresh:
                 common_kit.add_to_sorted(
                     uid_trace_stats, cache[key], itemgetter(sort_by_key), top_n_limit
                 )


### PR DESCRIPTION
The traces table in reports now contain a new set of metrics: baseline (absolute), target (absolute), total delta, absolute delta and relative delta. The table now also contains tooltips on certain columns, and some minor styling changes have been made. The most important new metric is the `total delta` which shows the total impact of the change on the overall number of consumed resources.

The extended table looks like this:
<img width="2367" height="792" alt="Screenshot from 2025-07-19 22-10-14" src="https://github.com/user-attachments/assets/a92b8024-5a5a-4de6-ac5c-76b7d4d11537" />
