### PR TITLE
Fix cpu_freq AttributeError on macOS

### DIFF
--- a/perun/utils/external/environment.py
+++ b/perun/utils/external/environment.py
@@ -134,7 +134,7 @@ def get_machine_specification() -> dict[str, Any]:
     system = platform.uname()
     try:
         cpu_freq = psutil.cpu_freq().current
-    except RuntimeError:
+    except (RuntimeError, AttributeError):
         # There are issues with CPU freq on some Apple Silicon VMs
         # https://github.com/giampaolo/psutil/pull/2222#issuecomment-2000755602
         cpu_freq = 0.0


### PR DESCRIPTION
Previously, the `cpu_freq()` atrribute caused RuntimeError on macOS devices, however, it appears to raise AttributeError now.

This PR fixes newly failing macOS tests that attempt to call `cpu_freq()`.