### PR TITLE
Fix CSV parsing in perun import

### DIFF
--- a/perun/cli_groups/import_cli.py
+++ b/perun/cli_groups/import_cli.py
@@ -179,7 +179,7 @@ def from_binary(ctx: click.Context, import_entries: list[str], **kwargs: Any) ->
 
     where the CSV file is in the format
 
-      #Profile,Exit_code[,stat-header1]+
+      Profile,Exit_code[,stat-header1]+
       profile_path[,<exit code>[,<stat value>]+]
       ...
 
@@ -206,7 +206,7 @@ def from_text(ctx: click.Context, import_entries: list[str], **kwargs: Any) -> N
 
     where the CSV file is in the format
 
-      #Profile,Exit_code[,stat-header1]+
+      Profile,Exit_code[,stat-header1]+
       profile_path[,<exit code>[,<stat value>]+]
       ...
 
@@ -234,7 +234,7 @@ def from_stacks(ctx: click.Context, import_entries: list[str], **kwargs: Any) ->
 
     where the CSV file is in the format
 
-      #Profile,Exit_code[,stat-header1]+
+      Profile,Exit_code[,stat-header1]+
       profile_path[,<exit code>[,<stat value>]+]
       ...
 

--- a/perun/profile/imports.py
+++ b/perun/profile/imports.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 # Standard Imports
 from collections import defaultdict
-import csv
 from dataclasses import asdict, dataclass
 import gzip
 import json
@@ -12,9 +11,10 @@ import os
 from pathlib import Path
 import subprocess
 import sys
-from typing import Any
+from typing import Any, Sequence
 
 # Third-Party Imports
+import polars as pl
 
 # Perun Imports
 from perun import profile as profile
@@ -36,7 +36,7 @@ class _PerfProfileSpec:
     """
 
     path: Path
-    exit_code: int = 0
+    exit_code: int = -1
 
 
 @vcs_kit.lookup_minor_version
@@ -465,7 +465,7 @@ def _parse_perf_import_entries(
 
     where the CSV file is in the format
 
-      #Profile,Exit_code[,stat-header1]+
+      Profile,Exit_code[,stat-header1]+
       profile_path[,<exit code>[,<stat value>]+]
       ...
 
@@ -515,23 +515,30 @@ def _parse_perf_import_csv(
     :param stats: profile stats that will be merged with the CSV stats.
     """
     csv_path = _massage_import_path(csv_file, import_dir)
-    with streams.safely_open_and_log(csv_path, "r", fatal_fail=True) as csvfile:
-        csv_reader = csv.reader(csvfile, delimiter=",")
+    with streams.safely_open_and_log(csv_path, "r", fatal_fail=True) as csvfile_handle:
         try:
-            header: list[str] = next(csv_reader)
-        except StopIteration:
+            import_csv = pl.read_csv(csvfile_handle, comment_prefix="#")
+        except pl.exceptions.NoDataError:
             # Empty CSV file, skip
             log.warn(f"Empty import file {csv_path}. Skipping.")
             return
+        except pl.exceptions.ComputeError as e:
+            # The CSV file contains spurious columns, or is otherwise weirdly formatted.
+            # We log the issue so the user is aware of it, and we retry parsing it less strictly.
+            log.warn(
+                f"Encountered error when processing {csv_path}: {str(e).splitlines()[0]}."
+                " Attempting recovery."
+            )
+            import_csv = pl.read_csv(csvfile_handle, comment_prefix="#", truncate_ragged_lines=True)
         # Parse the stats headers
         csv_stats: list[profile.ProfileStat] = [
             profile.ProfileStat.from_string(*stat_definition.split("|"))
-            for stat_definition in header[2:]
+            for stat_definition in import_csv.columns[2:]
         ]
         # Parse the remaining rows that represent profile specifications and filter invalid ones
         profiles.extend(
             record
-            for row in csv_reader
+            for row in import_csv.iter_rows()
             if (record := _parse_perf_entry(row, import_dir, csv_stats)) is not None
         )
         # Merge CSV stats with the other stats
@@ -541,7 +548,7 @@ def _parse_perf_import_csv(
 
 
 def _parse_perf_entry(
-    entry: list[str], import_dir: Path, stats: list[profile.ProfileStat]
+    entry: Sequence[str | float], import_dir: Path, stats: list[profile.ProfileStat]
 ) -> _PerfProfileSpec | None:
     """Parse a single perf profile import entry.
 
@@ -551,25 +558,31 @@ def _parse_perf_entry(
 
     :return: the parsed profile, or None if the import entry is invalid.
     """
-    if len(entry) == 0 or not entry[0]:
-        # Empty profile specification, warn
+    # Attempt to parse the profile specification.
+    if len(entry) == 0 or entry[0] is None or str(entry[0]).strip() == "":
+        # Empty profile specification, warn and skip.
         log.warn("Empty import profile specification. Skipping.")
         return None
-    # Parse the profile specification
-    profile_info = _PerfProfileSpec(
-        _massage_import_path(entry[0], import_dir),
-        int(entry[1].strip()) if len(entry) >= 2 else _PerfProfileSpec.exit_code,
-    )
-    # Parse the stat values and add them to respective stats
-    for stat_value, stat_obj in zip(map(_massage_stat_value, entry[2:]), stats):
-        stat_obj.value.append(stat_value)
-    if len(entry[2:]) > len(stats):
-        log.warn(
-            f"Imported profile {profile_info.path} specifies more stats values than stats headers."
-            " Ignoring additional stats."
-        )
-    if profile_info.exit_code != 0:
+    profile_path = _massage_import_path(str(entry[0]), import_dir)
+    # Attempt to parse the exit code, if provided.
+    exit_code = _PerfProfileSpec.exit_code
+    try:
+        exit_code = int(entry[1])
+    except (IndexError, TypeError):
+        # No exit code was provided. Either there is no value, or the value is None.
+        log.warn(f"No exit code provided, using the default code {exit_code}.")
+    except ValueError:
+        # An exit code was provided, but it is an invalid value that cannot be represented as int.
+        log.warn(f"Invalid exit code '{entry[1]}' provided, using the default code {exit_code}.")
+    if exit_code != 0:
         log.warn("Importing a profile with non-zero exit code.")
+    profile_info = _PerfProfileSpec(profile_path, exit_code)
+
+    # Parse the stat values and add them to respective stats
+    for stat_value, stat_obj in zip(entry[2:], stats):
+        # Filter out missing values; supported values are floats and strings.
+        if stat_value:
+            stat_obj.value.append(common_kit.try_convert(stat_value, (float, str)))
     return profile_info
 
 
@@ -589,20 +602,6 @@ def _merge_stats(new_stat: profile.ProfileStat, into_stats: list[profile.Profile
             return
     # There is no stat to merge with, extend the current collection of stats
     into_stats.append(new_stat)
-
-
-def _massage_stat_value(stat_value: str) -> str | float:
-    """Massages a stat value read from a string to check whether it is numerical or not.
-
-    :param stat_value: the stat value to massage.
-
-    :return: a massaged stat value.
-    """
-    stat_value = stat_value.strip()
-    try:
-        return float(stat_value)
-    except ValueError:
-        return stat_value
 
 
 def _massage_import_path(path_str: str, import_dir: Path) -> Path:

--- a/perun/profile/stats.py
+++ b/perun/profile/stats.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 from collections import Counter
 import dataclasses
 import enum
+import math
 import statistics
 from typing import Any, Protocol, Iterable, ClassVar, Union, cast
 
@@ -344,18 +345,27 @@ class StatisticalSummary(ProfileStatAggregation):
         """
         # We assume there aren't too many values so that multiple passes of the list don't matter
         # too much. If this becomes a bottleneck, we can use pandas describe() instead.
-        values = list(values)
-        quantiles = statistics.quantiles(values, n=20, method="inclusive")
-        return cls(
-            float(min(values)),
-            quantiles[2],  # p10
-            quantiles[5],  # p25
-            quantiles[10],  # p50
-            quantiles[15],  # p75
-            quantiles[18],  # p90
-            float(max(values)),
-            statistics.mean(values),
-        )
+        values = list(val for val in values if not math.isnan(val))
+        try:
+            quantiles = statistics.quantiles(values, n=20, method="inclusive")
+            return cls(
+                float(min(values)),
+                quantiles[2],  # p10
+                quantiles[5],  # p25
+                quantiles[10],  # p50
+                quantiles[15],  # p75
+                quantiles[18],  # p90
+                float(max(values)),
+                statistics.mean(values),
+            )
+        except statistics.StatisticsError:
+            if values:
+                # There is not enough points to generate the statistics, use the single value.
+                value = values[0]
+            else:
+                # There are no valid data points, use nan.
+                value = math.nan
+            return cls(value, value, value, value, value, value, value, value)
 
     def infer_auto_comparison(self, comparison: ProfileStatComparison) -> ProfileStatComparison:
         if comparison != ProfileStatComparison.AUTO:

--- a/perun/utils/common/common_kit.py
+++ b/perun/utils/common/common_kit.py
@@ -28,11 +28,7 @@ import click
 
 # Perun Imports
 from perun.postprocess.regression_analysis import tools
-from perun.utils.exceptions import (
-    NotPerunRepositoryException,
-    SignalReceivedException,
-    SuppressedExceptions,
-)
+from perun.utils.exceptions import NotPerunRepositoryException, SignalReceivedException
 
 if TYPE_CHECKING:
     import types
@@ -353,7 +349,7 @@ def locate_dir_on(path: str, searched_dir: str) -> str:
     return ""
 
 
-def try_convert(value: Any, list_of_types: list[type]) -> Any:
+def try_convert(value: Any, list_of_types: Iterable[type]) -> Any:
     """Tries to convert a value into one of the specified types
 
     :param value: object that is going to be converted to one of the types

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ dependencies = [
     # Science / math / statistics / ML
     "numpy>=2.0.0",
     "pandas>=2.2.2",
+    "polars>=1.34.0",
     "statsmodels>=0.14.2",
     "scikit-learn>=1.5.1",
     "scipy>=1.13",

--- a/tests/sources/imports/import.csv
+++ b/tests/sources/imports/import.csv
@@ -1,3 +1,4 @@
 #Stackfile,Exit_code,bogo-ops-per-second-real-time| higher_is_better|bogo-ops-per-second |min,stat2|stat2_direction|stat2_unit|max,timer|auto||sequence,wall-clock|lower_is_better|ns||wall-clock run time
 import.stack.gz, 0, 18511.379883,956.36,"TSC",1564819
-import.stack,0,17894.875698,897.01,"HPET",1568644
+import.stack,,17894.875698,897.01,"HPET",1568644,10
+import.stack,nan,17894.875698,897.01,,nan


### PR DESCRIPTION
The new CSV parser in `perun import` now properly supports comments in CSV files, and gracefully handles cases where entries in the CSV file are missing or invalid.