### PR TITLE
Release version 0.26.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+
+0.26.0 (2026-01-14)
+-------------------
+
+  - Showdiff report now supports two variants: native and folded.
+  - Showdiff folded report works on external folded profiles (e.g., perf-folded) without the need to import them first.
+  - Breaking CLI changes: showdiff CLI has been changed substantially.
+
+
 0.25.6 (2025-11-05)
 -------------------
 

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
     'perun',
     'c',
-    version: '0.25.6',
+    version: '0.26.0',
     license: 'GPL-3',
     meson_version: '>=1.0.0',
     default_options: [


### PR DESCRIPTION
Changelog:

  - Showdiff report now supports two variants: native and folded.
  - Showdiff folded report works on external folded profiles (e.g., perf-folded) without the need to import them first.
  - Breaking CLI changes: showdiff CLI has been changed substantially.