### PR TITLE
Resolve minor issues in the recent 0.26.0 version 

### DIFF
--- a/perun/cli.py
+++ b/perun/cli.py
@@ -85,7 +85,7 @@ if TYPE_CHECKING:
 DEV_MODE = False
 
 
-@click.group()
+@click.group(context_settings={"help_option_names": ["-h", "--help"]})
 @click.option(
     "--dev-mode",
     "-d",
@@ -924,7 +924,7 @@ def postprocessby(ctx: click.Context, profile: Profile, **_: Any) -> None:
 )
 @click.option(
     "--hang-timeout",
-    "-h",
+    "-ht",
     nargs=1,
     required=False,
     default=10,

--- a/perun/cli_groups/config_cli.py
+++ b/perun/cli_groups/config_cli.py
@@ -28,7 +28,7 @@ from perun.utils.exceptions import (
 )
 @click.option(
     "--shared",
-    "-h",
+    "-s",
     "store_type",
     flag_value="shared",
     help="Sets the shared config, i.e. ``shared.yml.``, as the source config",

--- a/perun/cli_groups/showdiff_cli.py
+++ b/perun/cli_groups/showdiff_cli.py
@@ -203,36 +203,8 @@ def showdiff_group(**_: Any) -> None:
     limitations.
 
     There are in general two different categories of supported profiles: Perun-native profiles
-    and external profiles. Concrete showdiff commands may in general work with one or more supported
-    profile categories.
-
-    Perun-native profiles will be looked up in the following steps:
-
-        1. If [PROFILE] is in form ``i@i`` (i.e, an `index tag`), then `ith`
-           record registered in the minor version <hash> index will be shown.
-
-        2. If [PROFILE] is in form ``i@p`` (i.e., an `pending tag`), then
-           `ith` profile stored in ``.perun/jobs`` will be shown.
-
-        3. [PROFILE] is looked-up within the minor version <hash> index for a
-           match. In case the <profile> is registered there, it will be shown.
-
-        4. [PROFILE] is looked-up within the ``.perun/jobs`` directory. In case
-           there is a match, the found profile will be shown.
-
-        5. Otherwise, the directory is walked for any match. Each found match
-           is asked for confirmation by user.
-
-    Tags consider the sorted order as specified by the options
-    :ckey:`format.sort_profiles_by` and :ckey:`format.sort_profiles_order`.
-
-    Example 1. The following command will show the difference first two profiles
-    registered at index of ``HEAD~1`` commit::
-
-        perun showdiff -m HEAD~1 0@i 1@i report
-
-    Refer to concrete commands for details on their difference visualizations and supported profile
-    formats.
+    and external profiles. Refer to concrete commands for details on their difference visualizations
+    and supported profile formats.
     """
 
 
@@ -289,11 +261,36 @@ def short(profile_list: tuple[profile.Profile, profile.Profile], *_: Any, **kwar
 def flamegraph(
     profile_list: tuple[profile.Profile, profile.Profile], *_: Any, **kwargs: Any
 ) -> None:
-    """Creates a flame graph (or icicle graph) difference grid.
+    """Creates a flame graph (or icicle graph) difference grid from perun-native profiles.
 
     The grid consists of baseline, target, baseline-target diff, and target-baseline diff flame
     graphs. The grid is further accompanied by a set of automatically-derived,and possibly
     user-defined as well, statistics.
+
+    Perun-native profiles will be looked up in the following steps:
+
+        1. If [PROFILE] is in form ``i@i`` (i.e, an `index tag`), then `ith`
+           record registered in the minor version <hash> index will be shown.
+
+        2. If [PROFILE] is in form ``i@p`` (i.e., an `pending tag`), then
+           `ith` profile stored in ``.perun/jobs`` will be shown.
+
+        3. [PROFILE] is looked-up within the minor version <hash> index for a
+           match. In case the <profile> is registered there, it will be shown.
+
+        4. [PROFILE] is looked-up within the ``.perun/jobs`` directory. In case
+           there is a match, the found profile will be shown.
+
+        5. Otherwise, the directory is walked for any match. Each found match
+           is asked for confirmation by user.
+
+    Tags consider the sorted order as specified by the options
+    :ckey:`format.sort_profiles_by` and :ckey:`format.sort_profiles_order`.
+
+    Example 1. The following command will show the flamegraph grid of first two profiles
+    registered at index of ``HEAD~1`` commit::
+
+        perun showdiff flamegraph -m HEAD~1 0@i 1@i
 
     Supports only perun-native profiles.
     """
@@ -428,9 +425,35 @@ def native(
     *_: Any,
     **kwargs: Any,
 ) -> None:
-    """Creates a difference report from perun-native profiles.
+    """Creates an HTML difference report from perun-native baseline and target profiles.
 
-    Supports only perun-native profiles.
+    The difference reports contains comparison of the environment, profile metadata, profile stats,
+    and performance data using flamegraphs and tables.
+
+    Perun-native profiles will be looked up in the following steps:
+
+        1. If [PROFILE] is in form ``i@i`` (i.e, an `index tag`), then `ith`
+           record registered in the minor version <hash> index will be shown.
+
+        2. If [PROFILE] is in form ``i@p`` (i.e., an `pending tag`), then
+           `ith` profile stored in ``.perun/jobs`` will be shown.
+
+        3. [PROFILE] is looked-up within the minor version <hash> index for a
+           match. In case the <profile> is registered there, it will be shown.
+
+        4. [PROFILE] is looked-up within the ``.perun/jobs`` directory. In case
+           there is a match, the found profile will be shown.
+
+        5. Otherwise, the directory is walked for any match. Each found match
+           is asked for confirmation by user.
+
+    Tags consider the sorted order as specified by the options
+    :ckey:`format.sort_profiles_by` and :ckey:`format.sort_profiles_order`.
+
+    Example 1. The following command will show the difference first two profiles
+    registered at index of ``HEAD~1`` commit::
+
+        perun showdiff report native -m HEAD~1 0@i 1@i
     """
     # Lazy load the view_diff module and execute the command
     from perun import view_diff
@@ -567,7 +590,10 @@ def native(
 )
 @click.pass_context
 def report_folded(ctx: click.Context, baseline: str, target: str, **kwargs: Any) -> None:
-    """Creates a difference report from external folded profiles.
+    """Creates an HTML difference report from external folded profiles.
+
+    The difference reports contains comparison of the environment, profile metadata, profile stats,
+    and performance data using flamegraphs and tables.
 
     This report expects one or more baseline and target folded profiles with per-trace measurements,
     e.g., perf folded or eBPF folded profiles.

--- a/perun/templates/scripts/chatbot.html.jinja2
+++ b/perun/templates/scripts/chatbot.html.jinja2
@@ -64,7 +64,18 @@ const $messageInput = $("#message-input");
 const $chatHeader   = $("#chat-header");
 
 $chatButton.on("click", function () {
-  $chatWindow.css("display", $chatWindow.is(":visible") ? "none" : "flex");
+  const isVisible = $chatWindow.is(":visible");
+
+  // Toggle visibility
+  $chatWindow.css("display", isVisible ? "none" : "flex");
+
+  // Add/remove global chat-open flag
+  if (isVisible) {
+    document.body.classList.remove("chat-open");
+  } else {
+    document.body.classList.add("chat-open");
+  }
+
 });
 
 function getPilotPrompt() {
@@ -215,13 +226,14 @@ $(document).ready(() => {
 
     $block.hover(
       function () {
-        if (!isSelected) {
+        // Only show highlight and eye icon if chat is open
+        if (!isSelected && $("body").hasClass("chat-open")) {
           $block.addClass("context-highlight");
           $eyeIcon.show();
         }
       },
       function () {
-        if (!isSelected) {
+        if (!isSelected && $("body").hasClass("chat-open")) {
           $block.removeClass("context-highlight");
           $eyeIcon.hide();
         }

--- a/perun/templates/scripts/value_formatters_js.html.jinja2
+++ b/perun/templates/scripts/value_formatters_js.html.jinja2
@@ -183,9 +183,9 @@
         result += "<thead><tr><th>Metric</th>"
         result += '<th title="The amount of resources consumed by the Unit in the baseline profile.">Baseline</th>';
         result += '<th title="The amount of resources consumed by the Unit in the target profile.">Target</th>';
-        result += '<th title="The change in total amount of resources consumed by the target and baseline profile.">Total Δ [%]</th>';
-        result += '<th title="The absolute difference of Target - Baseline.">Absolute Δ</th>';
-        result += '<th title="The relative difference of Target - Baseline.">Relative Δ [%]</th></tr></thead><tbody>';
+        result += '<th title="The difference between the relative resource consumption proportionally to the total baseline and target consumption change. For example, if the baseline and target consumed 2M and 1M CPU cycles in total, respectively, and a function \'foo\' consumed 100K cycles in both cases, the proportional difference is +5% as \'foo\' now consumes 10% total resources up from 5%.">Proportional Δ [%]</th>';
+        result += '<th title="The difference of Target - Baseline resource consumption. For example, if the baseline and target consumed 2M and 1M CPU cycles in total, respectively, and a function \'foo\' consumed 100K and 75K cycles in baseline, resp. target, the absolute difference is -25K.">Absolute Δ</th>';
+        result += '<th title="The difference of Target - Baseline resource consumption in relative terms. For example, if the baseline and target consumed 2M and 1M CPU cycles in total, respectively, and a function \'foo\' consumed 100K and 80K cycles in baseline, resp. target, the relative difference is -25%.">Relative Δ [%]</th></tr></thead><tbody>';
         d.stats.forEach((value, index) => {
             result += "<tr>";
             result += '<td style="white-space: pre-wrap">' + value[0] + "</td>";
@@ -196,15 +196,21 @@
             result += '<td style="white-space: pre-wrap">' + value[5] + "</td>";
             result += "</tr>";
         });
+
+
+
+
+
+
         result += '</tbody></table>';
         result += '<h4 style="text-align: center; width: 100%; border-bottom: 1px solid #ddd;">Top ' + d.traces.length + ' Traces</h4>';
         result += '<table id="traces' + d.index + '" class="display" style="margin-top: -30px; width:100%; border-right: 10px solid #ddd; border-left: 10px solid #ddd;">';
         result += "<thead><tr><th></th><th>Trace</th><th>Metric</th>"
         result += '<th title="The amount of resources consumed by the Unit in the baseline profile.">Baseline</th>';
         result += '<th title="The amount of resources consumed by the Unit in the target profile.">Target</th>';
-        result += '<th title="The change in total amount of resources consumed by the target and baseline profile.">Total Δ [%]</th>';
-        result += '<th title="The absolute difference of Target - Baseline.">Absolute Δ</th>';
-        result += '<th title="The relative difference of Target - Baseline.">Relative Δ [%]</th></tr></thead><tbody>';
+        result += '<th title="The difference between the relative resource consumption proportionally to the total baseline and target consumption change. For example, if the baseline and target consumed 2M and 1M CPU cycles in total, respectively, and a function \'foo\' consumed 100K cycles in both cases, the proportional difference is +5% as \'foo\' now consumes 10% total resources up from 5%.">Proportional Δ [%]</th>';
+        result += '<th title="The difference of Target - Baseline resource consumption. For example, if the baseline and target consumed 2M and 1M CPU cycles in total, respectively, and a function \'foo\' consumed 100K and 75K cycles in baseline, resp. target, the absolute difference is -25K.">Absolute Δ</th>';
+        result += '<th title="The difference of Target - Baseline resource consumption in relative terms. For example, if the baseline and target consumed 2M and 1M CPU cycles in total, respectively, and a function \'foo\' consumed 100K and 80K cycles in baseline, resp. target, the relative difference is -25%.">Relative Δ [%]</th></tr></thead><tbody>';
         d.traces.forEach((value, index) => {
             result += "<tr>";
             result += '<td style="white-space: pre-wrap"></td>';

--- a/perun/templates/scripts/value_formatters_js.html.jinja2
+++ b/perun/templates/scripts/value_formatters_js.html.jinja2
@@ -197,11 +197,6 @@
             result += "</tr>";
         });
 
-
-
-
-
-
         result += '</tbody></table>';
         result += '<h4 style="text-align: center; width: 100%; border-bottom: 1px solid #ddd;">Top ' + d.traces.length + ' Traces</h4>';
         result += '<table id="traces' + d.index + '" class="display" style="margin-top: -30px; width:100%; border-right: 10px solid #ddd; border-left: 10px solid #ddd;">';

--- a/perun/templates/style/chatbot.css
+++ b/perun/templates/style/chatbot.css
@@ -163,7 +163,7 @@
   transition: box-shadow 0.2s ease;
 }
 
-.context-selected {
+body.chat-open .context-selected {
   box-shadow: 0 0 0 2px #339af0;
   background-color: var(--color-secondary-hover);
 }

--- a/perun/templates/style/traces_table.css
+++ b/perun/templates/style/traces_table.css
@@ -16,6 +16,10 @@
     color: var(--color-white-not-changing);
 }
 
+.traces_table .dt-column-title {
+    color: var(--color-white-not-changing);
+}
+
 .traces_table th {
     padding: 12px;
     text-align: left;

--- a/perun/view/tableof/run.py
+++ b/perun/view/tableof/run.py
@@ -257,7 +257,6 @@ def tableof(*_: Any, **__: Any) -> None:
 @tableof.command()
 @click.option(
     "--headers",
-    "-h",
     default=None,
     multiple=True,
     metavar="<key>",
@@ -322,7 +321,6 @@ def resources(
 @click.pass_context
 @click.option(
     "--headers",
-    "-h",
     default=None,
     multiple=True,
     metavar="<key>",

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -69,9 +69,9 @@ def test_table_cli(pcs_full):
             "tableof",
             "--to-stdout",
             "models",
-            "-h", "uid",
-            "-h", "model",
-            "-h", "coeffs",
+            "--headers", "uid",
+            "--headers", "model",
+            "--headers", "coeffs",
         ],
     )  # fmt: skip
     asserts.predicate_from_cli(result, result.exit_code == 0)
@@ -85,9 +85,9 @@ def test_table_cli(pcs_full):
             "tableof",
             "--to-stdout",
             "models",
-            "-h", "non-existant",
-            "-h", "model",
-            "-h", "coeffs",
+            "--headers", "non-existant",
+            "--headers", "model",
+            "--headers", "coeffs",
         ],
     )  # fmt: skip
     asserts.predicate_from_cli(result, result.exit_code == 2)
@@ -104,9 +104,9 @@ def test_table_cli(pcs_full):
             "--to-stdout",
             "-f", "latex",
             "models",
-            "-h", "uid",
-            "-h", "model",
-            "-h", "coeffs",
+            "--headers", "uid",
+            "--headers", "model",
+            "--headers", "coeffs",
         ],
     )  # fmt: skip
     asserts.predicate_from_cli(result, result.exit_code == 0)
@@ -121,9 +121,9 @@ def test_table_cli(pcs_full):
             "tableof",
             "--output-file", "test_output",
             "models",
-            "-h", "uid",
-            "-h", "model",
-            "-h", "coeffs",
+            "--headers", "uid",
+            "--headers", "model",
+            "--headers", "coeffs",
         ],
     )  # fmt: skip
     output_file = os.path.join(os.getcwd(), "test_output")


### PR DESCRIPTION
This PR fixes some issues in the recent version and implements some minor changes:

- The nested traces table in `showdiff report` now has correctly styled table headers. All table headers now also use the same column names and tooltips.
- Perun now supports both long and short help options (`--help` and `-h`) for CLI commands.
- The `showdiff report`, `showdiff report native`, and `showdiff flamegraph` help docstrings have been changed to be more user-friendly.
- The integrated chatbot has been updated to the latest version. 