### PR TITLE
Add a perf symlink for Ubuntu CI

### DIFF
--- a/.github/workflows/actions/setup/action.yml
+++ b/.github/workflows/actions/setup/action.yml
@@ -4,7 +4,6 @@ inputs:
   python-version:
     description: 'Python version to run'
     required: true
-
 runs:
   using: 'composite'
   steps:
@@ -17,11 +16,15 @@ runs:
     - name: Install Unix dependencies
       if: runner.os == 'Linux'
       shell: sh
+      # The perf symlink is a temporary workaround for an Ubuntu 24.04 bug.
       run: |
         sudo apt-get -qq update
         sudo apt-get install time libunwind8-dev g++-9 gcc-9 git linux-tools-generic
         sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 90 --slave /usr/bin/g++ g++ /usr/bin/g++-9 --slave /usr/bin/gcov gcov /usr/bin/gcov-9
-
+        which perf
+        sudo mv /usr/bin/perf /usr/bin/perf_broken
+        sudo ln -s /usr/lib/linux-tools/6.8.0-*-generic/perf /usr/bin/perf
+        perf --help
     - name: Install macOS dependencies
       if: runner.os == 'macOS'
       shell: sh


### PR DESCRIPTION
Add a temporary workaround for an Ubuntu 24.04 bug related to perf impacting our GH CI: https://bugs.launchpad.net/ubuntu/+source/linux-hwe-6.14/+bug/2117147.