### PR TITLE
Release version 0.27.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@ Changelog
 =========
 
 
+0.27.0 (2026-03-23)
+-------------------
+
+  - The traces table have been completely reworked: we no longer rely on an external library.
+  - A first version of traces detail model popup has been added to the traces table.
+
+
 0.26.1 (2026-01-24)
 -------------------
 

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
     'perun',
     'c',
-    version: '0.26.1',
+    version: '0.27.0',
     license: 'GPL-3',
     meson_version: '>=1.0.0',
     default_options: [


### PR DESCRIPTION
- The traces table have been completely reworked: we no longer rely on an external library.
- A first version of traces detail model popup has been added to the traces table.