### PR TITLE
Drop support for Python 3.9, add support for Python 3.14

### DIFF
--- a/.github/workflows/actions/setup/action.yml
+++ b/.github/workflows/actions/setup/action.yml
@@ -32,6 +32,12 @@ runs:
         brew update
         brew install gnu-time gcc git libunwind-headers libmagic coreutils
 
+    # The rust toolchain is required for building some packages (e.g., angr) that have no wheels for particular archs.
+    - name: Set up Rust Toolchain
+      uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        components: clippy, rustfmt
+
     - name: Initialize Git
       shell: sh
       run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -10,13 +10,12 @@ on:
 
 jobs:
   # Tests classic build using Tox for selected Python versions
-  # Version 3.9 is omitted due to some dependencies not being compatible with ARM CPUs.
   build:
     runs-on: macos-latest
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v3
@@ -45,7 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v3

--- a/perun/view_diff/report_folded.py
+++ b/perun/view_diff/report_folded.py
@@ -1020,8 +1020,8 @@ def generate_report_from_folded(
     grid: FlameGraphGrid = FlameGraphGrid()
     log.minor_info("Saving post-processed profiles in temporary files.")
     with (
-        tempfile.NamedTemporaryFile(mode="w") as baseline_folded,
-        tempfile.NamedTemporaryFile(mode="w") as target_folded,
+        tempfile.NamedTemporaryFile(mode="w+") as baseline_folded,
+        tempfile.NamedTemporaryFile(mode="w+") as target_folded,
     ):
         base_maxtrace = polars_traces_to_folded_profile(
             pair_profile.baseline, baseline_folded, minwidth_threshold
@@ -1351,6 +1351,7 @@ def polars_traces_to_folded_profile(
         # Update the maximum trace length
         if inclusive >= min_width_threshold:
             max_filtered_len = max(max_filtered_len, len(trace_parts))
+    folded_file.flush()
     return max_filtered_len
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ build-backend = "mesonpy"
 [project]
 name = "perun-toolsuite"
 description = "Perun: Lightweight Performance Version System"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 readme = "README.md"
 license = { file = "LICENSE" }
 authors = [
@@ -222,9 +222,10 @@ exclude_also = [
 # ----------------------
 [tool.black]
 target-version = [
-    "py39",
     "py310",
     "py311",
     "py312",
+    "py313",
+    "py314",
 ]
 line-length = 100

--- a/tests/test_diff_views.py
+++ b/tests/test_diff_views.py
@@ -290,7 +290,7 @@ def test_diff_report_folded(pcs_with_svs):
             # Report-folded-specific options.
             "folded",
             baseline_profiles,
-            "import-stressng.stack",  # "import-empty.csv",
+            "import-stressng.stack",
             "--baseline-dir",
             pool_path,
             "--target-dir",

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 requires =
     tox>=4
 env_list =
-    py{3.9, 3.10, 3.11, 3.12, 3.13}
+    py{3.10, 3.11, 3.12, 3.13, 3.14}
     lint
     typing
     docs


### PR DESCRIPTION
This PR drops support for Python 3.9, which is now classified as end-of-life (see https://devguide.python.org/versions/). Additionally, we add support for the newest Python 3.14.