### PR TITLE
Provide native Python implementations of Flame Graph scripts

### DIFF
--- a/perun/cli_groups/showdiff_cli.py
+++ b/perun/cli_groups/showdiff_cli.py
@@ -172,11 +172,27 @@ def common_flamegraph_options(command: Callable[..., Any]) -> Callable[..., Any]
         "flamegraph.pl script.",
     )
     @click.option(
+        "--flamegraph-normalize",
+        is_flag=True,
+        default=False,
+        help="Normalize the baseline sample counts when creating differential flame graphs using "
+        "the formula '(baseline_count * target_sum / baseline_sum)'. This colors the flame graph "
+        "frames with hues that respect the change in the total consumptions between two profiles. "
+        "This option is forwarded to the difffolded.pl script.",
+    )
+    @click.option(
         "--flamegraph-parallelize/--flamegraph-no-parallelize",
         is_flag=True,
         default=True,
         help="Generate flamegraph grids using multiple processes. Note that this may consume too"
         "much peak memory for very large perf profiles.",
+    )
+    @click.option(
+        "--flamegraph-use-perl-scripts",
+        is_flag=True,
+        default=False,
+        help="Use the canonical Perl scripts for generating flame graphs. Otherwise, our custom "
+        "and more efficient Python scripts will be used.",
     )
     @functools.wraps(command)
     def wrapper_common_flamegraph_options(*args, **kwargs):

--- a/perun/cli_groups/showdiff_cli.py
+++ b/perun/cli_groups/showdiff_cli.py
@@ -172,9 +172,9 @@ def common_flamegraph_options(command: Callable[..., Any]) -> Callable[..., Any]
         "flamegraph.pl script.",
     )
     @click.option(
-        "--flamegraph-normalize",
+        "--flamegraph-normalize/--flamegraph-no-normalize",
         is_flag=True,
-        default=False,
+        default=True,
         help="Normalize the baseline sample counts when creating differential flame graphs using "
         "the formula '(baseline_count * target_sum / baseline_sum)'. This colors the flame graph "
         "frames with hues that respect the change in the total consumptions between two profiles. "
@@ -192,7 +192,7 @@ def common_flamegraph_options(command: Callable[..., Any]) -> Callable[..., Any]
         is_flag=True,
         default=False,
         help="Use the canonical Perl scripts for generating flame graphs. Otherwise, our custom "
-        "and more efficient Python scripts will be used.",
+        "Python scripts will be used.",
     )
     @functools.wraps(command)
     def wrapper_common_flamegraph_options(*args, **kwargs):

--- a/perun/collect/memory/parsing.py
+++ b/perun/collect/memory/parsing.py
@@ -49,16 +49,16 @@ def parse_stack(stack: list[str]) -> list[dict[str, Any]]:
 
         # getting information of instruction pointer,
         # the source file and line number in the source file
-        ip_info = syscalls.address_to_line(instruction_pointer)
-        if ip_info[0] in ["?", "??"]:
-            ip_info[0] = "unreachable"
-        if ip_info[1] in ["?", "??"]:
-            ip_info[1] = 0
+        src_file, src_line = syscalls.address_to_line(instruction_pointer)
+        if src_file in ["?", "??"]:
+            src_file = "unreachable"
+        if src_line in ["?", "??"]:
+            src_line = "0"
         else:
-            ip_info[1] = common_kit.safe_match(PATTERN_INT, ip_info[1], "<?>")
+            src_line = common_kit.safe_match(PATTERN_INT, src_line, "<?>")
 
-        call_data["source"] = ip_info[0]
-        call_data["line"] = int(ip_info[1])
+        call_data["source"] = src_file
+        call_data["line"] = int(src_line)
 
         data.append(call_data)
 

--- a/perun/collect/memory/syscalls.py
+++ b/perun/collect/memory/syscalls.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 # Standard Imports
-from typing import Any, TYPE_CHECKING
+from typing import TYPE_CHECKING
 import os
 import re
 import subprocess
@@ -20,8 +20,8 @@ PATTERN_WORD = re.compile(r"(\w+)|[?]")
 PATTERN_HEXADECIMAL = re.compile(r"0x[0-9a-fA-F]+")
 
 
-demangle_cache = {}
-address_to_line_cache = {}
+demangle_cache: dict[str, str] = {}
+address_to_line_cache: dict[str, tuple[str, str]] = {}
 
 
 def build_demangle_cache(names: set[str]) -> None:
@@ -63,17 +63,18 @@ def build_address_to_line_cache(addresses: set[tuple[str, str]], binary_name: st
 
     sys_call = ["addr2line", "-e", binary_name] + list_of_addresses
     output = subprocess.check_output(sys_call).decode("utf-8").strip()
-    address_to_line_cache = dict(
-        zip(list_of_addresses, map(lambda x: x.split(":"), output.split("\n")))
-    )
+
+    for addr, source_detail in zip(list_of_addresses, output.split("\n")):
+        src_file, src_line = source_detail.split(":", maxsplit=1)
+        address_to_line_cache[addr] = (src_file, src_line)
 
 
-def address_to_line(ip: str) -> list[Any]:
+def address_to_line(ip: str) -> tuple[str, str]:
     """
     :param ip: instruction pointer value
-    :return: list of two objects, 1st is the name of the source file, 2nd is the line number
+    :return: a pair of (source file, line number)
     """
-    return address_to_line_cache[ip][:]
+    return address_to_line_cache[ip]
 
 
 def run(executable: Executable) -> tuple[int, str]:

--- a/perun/fuzz/methods/binary.py
+++ b/perun/fuzz/methods/binary.py
@@ -70,8 +70,8 @@ def swap_byte(lines: list[bytes]) -> None:
     ba1[index1] = ba2[index2]
     ba2[index2] = tmp
 
-    lines[line_num1] = ba1
-    lines[line_num2] = ba2
+    lines[line_num1] = bytes(ba1)
+    lines[line_num2] = bytes(ba2)
 
 
 @randomizer.random_repeats(RULE_ITERATIONS)

--- a/perun/scripts/diff_flamegraph.py
+++ b/perun/scripts/diff_flamegraph.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+
+"""A helper script for creating differential flamegraphs directly.
+
+The script connects the interfaces of the difffolded.py and flamegraph.py
+scripts such that there is no need to transfer the data through OS pipes.
+The script also leverages the difffolded lazy parsing when possible.
+"""
+
+from __future__ import annotations
+
+import argparse
+from typing import overload, Any
+
+import perun.scripts.difffolded as diff
+import perun.scripts.flamegraph as fg
+
+
+@overload
+def create_diff_flame_graph(
+    baseline: str,
+    target: str,
+    *,
+    bgcolors: str = ...,
+    colors: fg.ColorPalettes = ...,
+    countname: str = ...,
+    cp: bool = ...,
+    encoding: str = ...,
+    factor: float = ...,
+    flamechart: bool = ...,
+    fontsize: float = ...,
+    fonttype: str = ...,
+    fontwidth: float = ...,
+    hash: bool = ...,
+    height: int = ...,
+    inverted: bool = ...,
+    maxtrace: int = ...,
+    minwidth: str = ...,
+    nametype: str = ...,
+    nameattr: str = ...,
+    negate: bool = ...,
+    notes: str = ...,
+    outfile: None = ...,
+    random: bool = ...,
+    rootnode: str = ...,
+    reverse: bool = ...,
+    subtitle: str = ...,
+    total: int = ...,
+    title: str = ...,
+    width: int = ...,
+    **_: Any,
+) -> str: ...
+
+
+@overload
+def create_diff_flame_graph(
+    baseline: str,
+    target: str,
+    *,
+    bgcolors: str = ...,
+    colors: fg.ColorPalettes = ...,
+    countname: str = ...,
+    cp: bool = ...,
+    encoding: str = ...,
+    factor: float = ...,
+    flamechart: bool = ...,
+    fontsize: float = ...,
+    fonttype: str = ...,
+    fontwidth: float = ...,
+    hash: bool = ...,
+    height: int = ...,
+    inverted: bool = ...,
+    maxtrace: int = ...,
+    minwidth: str = ...,
+    nametype: str = ...,
+    nameattr: str = ...,
+    negate: bool = ...,
+    notes: str = ...,
+    outfile: str = ...,
+    random: bool = ...,
+    rootnode: str = ...,
+    reverse: bool = ...,
+    subtitle: str = ...,
+    total: int = ...,
+    title: str = ...,
+    width: int = ...,
+    **_: Any,
+) -> str: ...
+
+
+def create_diff_flame_graph(
+    baseline: str,
+    target: str,
+    *,
+    bgcolors: str = fg.Settings.DefaultBgColors,
+    colors: fg.ColorPalettes = fg.Settings.DefaultColors,
+    countname: str = fg.Settings.DefaultCountName,
+    cp: bool = fg.Settings.DefaultPaletteFlag,
+    encoding: str = fg.Settings.DefaultEncoding,
+    factor: float = fg.Settings.DefaultFactor,
+    flamechart: bool = fg.Settings.DefaultFlameChartFlag,
+    fontsize: float = fg.Settings.DefaultFontSize,
+    fonttype: str = fg.Settings.DefaultFontType,
+    fontwidth: float = fg.Settings.DefaultFontWidth,
+    hash: bool = fg.Settings.DefaultHashFlag,
+    height: int = fg.Settings.DefaultFrameHeight,
+    inverted: bool = fg.Settings.DefaultInvertedFlag,
+    maxtrace: int = fg.Settings.DefaultMaxTrace,
+    minwidth: str = fg.Settings.DefaultMinWidth,
+    nametype: str = fg.Settings.DefaultNameType,
+    nameattr: str = fg.Settings.DefaultNameAttrFile,
+    negate: bool = fg.Settings.DefaultNegateFlag,
+    normalize: bool = False,
+    notes: str = fg.Settings.DefaultNotesText,
+    outfile: str | None = None,
+    random: bool = fg.Settings.DefaultRandomFlag,
+    rootnode: str = fg.Settings.DefaultRootNode,
+    reverse: bool = fg.Settings.DefaultStackReverseFlag,
+    striphex: bool = False,
+    subtitle: str = fg.Settings.DefaultSubtitle,
+    total: int = fg.Settings.DefaultTotal,
+    title: str = fg.Settings.DefaultTitle,
+    width: int = fg.Settings.DefaultImageWidth,
+    **_: Any,
+) -> str | None:
+    """Renders a differential flame graph from the baseline and target profiles.
+
+    This function can also be used as a programmatic API.
+
+    :param baseline: a path to the baseline folded profile.
+    :param target: a path to the target folded profile.
+    :param bgcolors: the background color (gradient). Supports:
+           - named gradients (``yellow``, ``blue``, ``green``, ``grey``,
+             and ``gray``),
+           - hex colors in the ``#RRGGBB`` format (will result in a flat
+             color, not a gradient), or
+           - ``""`` for a palette-derived default gradient.
+    :param colors: the color palette for SVG frames.
+    :param countname: the counts name (e.g. ``samples``, ``cycles``).
+    :param encoding: a specific encoding to use in the XML declaration.
+    :param factor: a multiplier applied to parsed counts.
+    :param flamechart: draw a flame chart instead (sorts by time, does not
+           merge stacks).
+    :param fontsize: SVG text font size (px).
+    :param fonttype: CSS ``font-family`` name for SVG text.
+    :param fontwidth: average character width relative to ``font_size``.
+    :param height: the height of each frame (px).
+    :param hash: color frames using a deterministic hash function.
+    :param inverted: draw an icicle chart instead (deepest frames at top).
+    :param maxtrace: overrides the computation of the canvas height.
+           The height is determined by the maximum trace depth (after
+           filtering the data using ``minwidth``). This option may be used
+           to align two SVGs with possibly different data side-by-side.
+    :param minwidth: specifies the minimum width of displayed frames.
+           Narrower frames will be discarded. May be specified either as
+           a fixed pixel width (e.g., ``0.5``) or relative to the total
+           count (e.g., ``0.1%``).
+    :param nameattr: a path to the name-attribute file
+           (see ``NameAttributes``).
+    :param nametype: the name of the frames in stacks
+          (e.g., ``Function:``, ``Basic Block:``).
+    :param negate: flip the differential red/blue hues when ``True``.
+    :param normalize: normalize the baseline sample counts using the formula
+           (baseline_count * target_sum / baseline_sum).
+    :param notes: addition notes to embedd into the SVG comment header.
+    :param outfile: store the flamegraph in a file or write it to the standard
+           output instead of returning it as a string.
+    :param cp: use consistent palette that loads and stores stable colors
+           via a ``palette.map`` file.
+    :param random: use randomized frame colors within the selected palette.
+           Note that even frames with identical names will have their
+           colors chosen randomly.
+    :param rootnode: the label on the synthetic root frame.
+    :param reverse: the stacks in the folded profile are in the
+           callee-to-caller (instead of caller-to-callee) order.
+    :param striphex: strip hex addresses in the stacks, e.g., replace
+           '0x1234abc' with '0x...'.
+    :param subtitle: optional second title line below the main title.
+    :param total: overrides the sum of all counts, which causes the root
+           node to be wider (suitable for comparing two profiles
+           side-by-side). Must be higher or equal than the actual sum.
+    :param title: the graph title.
+    :param width: the width of the SVG canvas (px).
+
+    :return: the SVG content unless an output file was specified.
+
+    Extra keyword arguments are ignored so that dictionaries with possibly
+    additional keys may be unpacked directly when calling the function.
+    """
+    diff_result: diff.FoldedDiff | diff.FoldedDiffLazy
+    if not normalize and flamechart:
+        # When normalization is disabled and we are creating a flame chart, we
+        # must use the eager API to obtain the correct ``target_sum`` value.
+        diff_result = diff.diff_folded(
+            baseline,
+            target,
+            striphex=striphex,
+            normalize=normalize,
+            sort_stacks=not flamechart,
+        )
+        # We need to translate the dictionary to an iterable of tuples.
+    else:
+        # Otherwise, we can use the (potentially) more efficient lazy API.
+        diff_result = diff.diff_folded_lazy(
+            baseline,
+            target,
+            striphex=striphex,
+            normalize=normalize,
+            sort_stacks=not flamechart,
+        )
+    profile = fg.FoldedDiffData(diff_result.data, diff_result.target_sum)
+    return fg.create_flame_graph(
+        profile,
+        bgcolors=bgcolors,
+        colors=colors,
+        countname=countname,
+        cp=cp,
+        encoding=encoding,
+        factor=factor,
+        flamechart=flamechart,
+        fontsize=fontsize,
+        fonttype=fonttype,
+        fontwidth=fontwidth,
+        hash=hash,
+        height=height,
+        inverted=inverted,
+        maxtrace=maxtrace,
+        minwidth=minwidth,
+        nametype=nametype,
+        nameattr=nameattr,
+        negate=negate,
+        notes=notes,
+        outfile=outfile,
+        random=random,
+        rootnode=rootnode,
+        reverse=reverse,
+        subtitle=subtitle,
+        total=total,
+        title=title,
+        width=width,
+    )
+
+
+if __name__ == "__main__":
+    # CLI entrypoint.
+    _cli_parser = argparse.ArgumentParser(
+        description="Generate a differential flame graph SVG.",
+        usage="%(prog)s [options] baseline target > diff_flame_graph.svg",
+    )
+
+    diff.initialize_cli_options(_cli_parser)
+    fg.initialize_cli_options(_cli_parser)
+    _args = _cli_parser.parse_args()
+    create_diff_flame_graph(**vars(_args))

--- a/perun/scripts/difffolded.py
+++ b/perun/scripts/difffolded.py
@@ -245,12 +245,17 @@ def diff_folded_lazy(
         ...
     ```
 
+    The lazy variant will store the baseline profile in memory and then, when
+    possible, will yield diff records on demand without storing the entire
+    target profile in memory.
+
     Note that the most efficient use-case for lazy diff is when neither sorting
     nor normalization is requested. Otherwise, requesting normalization and/or
     sorting will lead to slightly slower execution and more memory consumption
-    as the entire target profile needs to be parsed eagerly. Still, minor
-    performance gains compared to a fully eager approach can be expected as the
-    normalization and sorting can be done at least partially lazily.
+    as the entire target profile needs to be eagerly parsed and stored in
+    memory. Still, minor performance gains compared to a fully eager approach
+    can be expected as the normalization and sorting can be done at least
+    partially lazily.
 
 
     :param baseline: a path to the baseline folded profile.

--- a/perun/scripts/difffolded.py
+++ b/perun/scripts/difffolded.py
@@ -1,0 +1,667 @@
+#!/usr/bin/env python3
+
+"""difffolded.py 	Diff baseline and target folded stack files.
+                    Use this for generating flame graph differentials.
+
+USAGE: ./difffolded.py [-hnst] [-f integer|float|auto] baseline target | ./flamegraph.py > diff2.svg
+
+Options are described in the usage message (-h).
+
+The flamegraph will be colored based on higher samples (red) and smaller
+samples (blue). The frame widths will be based on the target (2nd folded file).
+This might be confusing if stack frames disappear entirely; it will make
+the most sense to ALSO create a differential based on the baseline widths,
+while switching the hues; eg:
+
+ ./difffolded.py target baseline | ./flamegraph.py --negate > diff1.svg
+
+Here's what they mean when comparing a before and after profile:
+
+diff1.svg: widths show the before profile, colored by what WILL happen
+diff2.svg: widths show the after profile, colored by what DID happen
+
+INPUT: See stackcollapse* programs.
+
+OUTPUT: The full list of stacks, with two columns, one from each file.
+If a stack wasn't present in a file, the column value is zero.
+
+folded_stack_trace count_from_baseline count_from_target
+
+eg:
+
+funca;funcb;funcc 31 33
+...
+
+
+*******************************************************************************
+* Python version details
+*******************************************************************************
+
+This Python version is meant as a drop-in replacement for the original Perl
+script. As such, it requires only a Python interpreter with the Python standard
+library: it deliberately avoids any 3rd party dependencies.
+
+The Python version has been optimized for processing large folded profiles and,
+based on some crude local measurements (Python 3.14, cached bytecode), appears
+to be almost 2x faster for an example ~150 MB folded profile. Moreover, even
+more speedup (~3x) can be achieved by importing the script and using its (lazy)
+API directly. Small profiles tend to exhibit a slowdown compared to the Perl
+version as the execution time is dominated by the Python interpreter startup
+cost (~40ms+ on a local machine). Also note that the optimizations cause some
+code duplication as we have no macros or templates in Python.
+
+Additionally, this version introduces some minor changes compared to the
+original Perl script:
+
+ - Unhandled zero division in normalization is now detected, a warning is
+   issued to the user, and the script falls back to the non-normalized output.
+   Additionally, the exact float comparison has been replaced with a more
+   reliable comparison.
+
+ - Scientific notation is now supported both on the input and output.
+
+ - The script can be used either through a CLI exactly as the Perl version, or
+   through a programmatic Python API by importing the file and calling either
+   the 'diff_folded' or 'diff_folded_lazy' functions. Using the functions
+   directly will lead to an even bigger speedup (crude measurements show up to
+   3x speedup).
+
+ - The CLI has a new '--formatter' option related to the standard output.
+   By default (the 'integer' mode), it truncates all counts to integers.
+   However, the user may supply a custom Python formatter string (e.g.,'.3f'
+   or '.10g') to format the counts (if an invalid formatter is passed, the
+   script falls back to the 'integer' format. This option is ignored when
+   using the API directly.
+
+ - The CLI has a new '--sort-stacks' option which lexicographically sorts the
+   diff records on output. This is especially useful when passing the diff
+   output to the 'flamegraph.py' script directly, but it is also much faster
+   to use this option than to sort the output file later, e.g., using the GNU
+   'sort' coreutil.
+
+ TODO: the script should also support 'reverse'. We do not need it yet, as
+  folded report does not use reversed stacks.
+
+*******************************************************************************
+
+COPYRIGHT: Copyright (c) 2014 Brendan Gregg.
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 2
+ of the License, or (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program; if not, write to the Free Software Foundation,
+ Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+
+ (http://www.gnu.org/copyleft/gpl.html)
+
+01-May-2026   Jiri Pavela   Optimized and ported to Python.
+28-Oct-2014	Brendan Gregg	Created this.
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Iterable, MutableMapping, Iterator
+from operator import itemgetter
+import re
+import sys
+from typing import Any
+
+# Absolute tolerance when comparing floats for equality.
+DIFF_FOLDED_EPS = 1e-9
+
+
+class FoldedDiff:
+    """The result of the diff operation on folded profiles.
+
+    :ivar data: the (possibly normalized and sorted) diffs stored as triples
+          ``(stack, baseline count, target count)`` in a list.
+    :ivar baseline_sum: the sum of all counts in the baseline profile.
+    :ivar target_sum: the sum of all counts in the baseline profile.
+
+    Note that we store the records in 'data' as tuples, since it appears to be
+    the fastest and most memory-efficient variant compared to lists or custom
+    (data)classes even though tuple immutability does not suit us.
+    """
+
+    __slots__ = "data", "baseline_sum", "target_sum"
+
+    def __init__(
+        self,
+        data: list[tuple[str, float, float]],
+        baseline_sum: float,
+        target_sum: float,
+    ) -> None:
+        self.data: list[tuple[str, float, float]] = data
+        self.baseline_sum: float = baseline_sum
+        self.target_sum: float = target_sum
+
+
+class FoldedDiffLazy:
+    """The result of the diff operation on folded profiles computed lazily.
+
+    This object is returned from the generator version of the diff operation.
+    This may be slightly more efficient than the ``FoldedDiff`` when
+    normalization and sorting are disabled, and the caller code needs
+    to iterate over the data at most once.
+
+    Enabling normalization or sorting will generally result in a similar
+    performance as in the eager variant.
+
+    Warning: when normalization and sorting are disabled, the ``target_sum``
+    value is computed lazily as the collection is iterated, i.e., it stores
+    only a partial result until the iterator is exhausted.
+
+    :ivar data: the (possibly normalized and sorted) diffs yielded as
+          triples ``(stack, baseline count, target count)``.
+    :ivar baseline_sum: the sum of all counts in the baseline profile.
+    :ivar target_sum: the sum of all counts in the baseline profile.
+    """
+
+    __slots__ = "data", "baseline_sum", "target_sum"
+
+    def __init__(
+        self,
+        data_generator: Iterable[tuple[str, float, float]],
+        baseline_sum: float,
+        target_sum: float,
+    ) -> None:
+        self.data: Iterable[tuple[str, float, float]] = data_generator
+        self.baseline_sum: float = baseline_sum
+        self.target_sum: float = target_sum
+
+
+def diff_folded(
+    baseline: str,
+    target: str,
+    *,
+    striphex: bool = False,
+    normalize: bool = False,
+    sort_stacks: bool = False,
+    **_: Any,
+) -> FoldedDiff:
+    """Diff two folded profiles.
+
+    This function may be used directly instead of calling the script through
+    its CLI:
+
+    ```
+    folded = diff_folded(baseline, target, False, True)
+    for stack, base_cnt, target_cnt in folded.data:
+        ...
+    ```
+
+    Note that the ``diff_folded_lazy`` variant is generally more efficient when
+    the entire diff does not need to be stored and accessed randomly and/or
+    repeatedly, e.g., when the caller will simply iterate over the diffs.
+
+    :param baseline: a path to the baseline folded profile.
+    :param target: a path to the target folded profile.
+    :param striphex: strip hex addresses in the stacks, e.g.,
+           replace ``0x1234abc`` with ``0x...``.
+    :param normalize: normalize the baseline sample counts using the formula
+           ``(baseline_count * target_sum / baseline_sum)``.
+    :param sort_stacks: sort the records lexicographically w.r.t. the stack.
+
+    :return: a ``FoldedDiff`` object with the diff records.
+
+    Extra keyword arguments are ignored so that dictionaries with possibly
+    additional keys may be unpacked directly when calling the function.
+    """
+    folded = parse_profiles_eagerly(baseline, target, striphex)
+    if sort_stacks:
+        folded.data.sort(key=itemgetter(0))
+    if normalize:
+        folded.data = normalize_eager_diff(folded.data, folded.baseline_sum, folded.target_sum)
+    return folded
+
+
+def diff_folded_lazy(
+    baseline: str,
+    target: str,
+    *,
+    striphex: bool = False,
+    normalize: bool = False,
+    sort_stacks: bool = False,
+    **_: Any,
+) -> FoldedDiffLazy:
+    """Diff two folded profiles lazily.
+
+    This function may be used directly instead of calling the script through
+    its CLI:
+
+    ```
+    folded_lazy = diff_folded_lazy(baseline, target)
+    for stack, base_cnt, target_cnt in folded_lazy.data:
+        ...
+    ```
+
+    Note that the most efficient use-case for lazy diff is when neither sorting
+    nor normalization is requested. Otherwise, requesting normalization and/or
+    sorting will lead to slightly slower execution and more memory consumption
+    as the entire target profile needs to be parsed eagerly. Still, minor
+    performance gains compared to a fully eager approach can be expected as the
+    normalization and sorting can be done at least partially lazily.
+
+
+    :param baseline: a path to the baseline folded profile.
+    :param target: a path to the target folded profile.
+    :param striphex: strip hex addresses in the stacks, e.g.,
+           replace ``0x1234abc`` with ``0x...``.
+    :param normalize: normalize the baseline sample counts using the formula
+           ``(baseline_count * target_sum / baseline_sum)``.
+    :param sort_stacks: sort the records lexicographically w.r.t. the stack.
+
+    :return: a ``FoldedDiffLazy`` object with the diff record generator.
+
+    Extra keyword arguments are ignored so that dictionaries with possibly
+    additional keys may be unpacked directly when calling the function.
+    """
+    if normalize and not sort_stacks:
+        # Normalization without sorting is the only combination that requires
+        # us to parse the profiles eagerly to obtain the 'target_sum'.
+        # However, the normalization itself can be done lazily.
+        folded: FoldedDiff = parse_profiles_eagerly(baseline, target, striphex)
+        data_gen = normalize_lazy_diff(folded.data, folded.baseline_sum, folded.target_sum)
+        return FoldedDiffLazy(data_gen, folded.baseline_sum, folded.target_sum)
+
+    folded_lazy: FoldedDiffLazy = parse_profiles_lazily(baseline, target, striphex)
+    data_iter = folded_lazy.data
+    if sort_stacks:
+        data_iter = sorted(folded_lazy.data, key=itemgetter(0))
+    if normalize:
+        data_iter = normalize_lazy_diff(data_iter, folded_lazy.baseline_sum, folded_lazy.target_sum)
+    folded_lazy.data = data_iter
+    return folded_lazy
+
+
+def parse_profiles_eagerly(
+    baseline_file: str, target_file: str, striphex: bool = False
+) -> FoldedDiff:
+    """A helper function that parses both profiles eagerly.
+
+    :param baseline_file: a path to the baseline folded profile.
+    :param target_file: a path to the target folded profile.
+    :param striphex: strip hex addresses in the stacks, e.g.,
+           replace ``0x1234abc`` with ``0x...``.
+
+    :return: a ``FoldedDiff`` object with non-normalized and unsorted records.
+    """
+    hex_pattern: re.Pattern[str] | None = build_strip_hex_pattern(striphex)
+    baseline_data, baseline_total = parse_baseline(baseline_file, hex_pattern)
+    folded: FoldedDiff = parse_target(target_file, baseline_data, baseline_total, hex_pattern)
+    return folded
+
+
+def parse_profiles_lazily(
+    baseline_file: str, target_file: str, striphex: bool = False
+) -> FoldedDiffLazy:
+    """A helper function that parses the baseline eagerly and the target lazily.
+
+    :param baseline_file: a path to the baseline folded profile.
+    :param target_file: a path to the target folded profile.
+    :param striphex: strip hex addresses in the stacks, e.g.,
+           replace ``0x1234abc`` with ``0x...``.
+
+    :return: a ``FoldedDiffLazy`` object with non-normalized, unsorted records.
+    """
+    hex_pattern: re.Pattern[str] | None = build_strip_hex_pattern(striphex)
+    baseline_data, baseline_total = parse_baseline(baseline_file, hex_pattern)
+    # The 'iter([])' is used as a temporary placeholder in order to
+    # construct a valid 'FoldedDiffLazy' object, which is needed by the parsing
+    # function. This is not the most elegant design, but it allows the lazy
+    # parser to update the 'target_sum' as it parses the target profile.
+    folded_lazy = FoldedDiffLazy(iter([]), baseline_total, 0.0)
+    folded_lazy.data = parse_target_lazy(target_file, folded_lazy, baseline_data, hex_pattern)
+    return folded_lazy
+
+
+def parse_baseline(
+    file_path: str,
+    hex_strip_pattern: re.Pattern[str] | None,
+) -> tuple[dict[str, float], float]:
+    """Parses the baseline profile (eagerly).
+
+    Note that there is no need to have a lazy variant of the baseline parser
+    as even the lazy diff computation needs the entire baseline profile to be
+    parsed.
+
+    :param file_path: a path to the baseline folded profile.
+    :param hex_strip_pattern: a RE pattern for stripping hex symbols.
+
+    :return: a ``stack -> count`` mapping and the sum of all baseline counts.
+    """
+    # Optimize dot access
+    str_rsplit = str.rsplit
+    re_sub = re.Pattern.sub
+
+    baseline_data: dict[str, float] = {}
+    total_baseline = 0.0
+    try:
+        with open(file_path, encoding="utf-8") as file_handle:
+            if hex_strip_pattern is None:
+                for line in file_handle:
+                    stack, count_str = str_rsplit(line, maxsplit=1)
+                    try:
+                        count = float(count_str)
+                        total_baseline += count
+                        baseline_data[stack] = count
+                    except ValueError:
+                        # The count conversion to float failed.
+                        pass
+            else:
+                for line in file_handle:
+                    stack, count_str = str_rsplit(line, maxsplit=1)
+                    stack = re_sub(hex_strip_pattern, "0x...", stack)
+                    try:
+                        count = float(count_str)
+                        total_baseline += count
+                        baseline_data[stack] = count
+                    except ValueError:
+                        # The count conversion to float failed.
+                        pass
+        return baseline_data, total_baseline
+    except OSError:
+        print(f"ERROR: Can't read {file_path}", file=sys.stderr)
+        sys.exit(1)
+
+
+def parse_target(
+    file_path: str,
+    baseline_data: MutableMapping[str, float],
+    baseline_sum: float,
+    hex_strip_pattern: re.Pattern[str] | None,
+) -> FoldedDiff:
+    """Parses the target profile eagerly.
+
+    :param file_path: a path to the target folded profile.
+    :param baseline_data: the baseline profile data.
+    :param baseline_sum: the sum of all baseline counts.
+    :param hex_strip_pattern: a RE pattern for stripping hex symbols.
+
+    :return: a ``FoldedDiff`` object with non-normalized and unsorted records.
+    """
+    # Optimize dot access
+    str_rsplit = str.rsplit
+    re_sub = re.Pattern.sub
+
+    folded_data: list[tuple[str, float, float]] = []
+    total_target = 0.0
+    try:
+        with open(file_path, encoding="utf-8") as file_handle:
+            if hex_strip_pattern is None:
+                for line in file_handle:
+                    stack, count_str = str_rsplit(line, maxsplit=1)
+                    try:
+                        count = float(count_str)
+                        total_target += count
+                        folded_data.append((stack, baseline_data.pop(stack), count))
+                    except KeyError:
+                        folded_data.append((stack, 0.0, count))
+                    except ValueError:
+                        # The count conversion to float failed.
+                        pass
+            else:
+                for line in file_handle:
+                    stack, count_str = str_rsplit(line, maxsplit=1)
+                    stack = re_sub(hex_strip_pattern, "0x...", stack)
+                    try:
+                        count = float(count_str)
+                        total_target += count
+                        folded_data.append((stack, baseline_data.pop(stack), count))
+                    except KeyError:
+                        folded_data.append((stack, 0.0, count))
+                    except ValueError:
+                        # The count conversion to float failed.
+                        pass
+        # Add baseline stacks that do not have a matching record in target.
+        folded_data.extend(
+            (stack, baseline_count, 0.0) for stack, baseline_count in baseline_data.items()
+        )
+        return FoldedDiff(folded_data, baseline_sum, total_target)
+    except OSError:
+        print(f"ERROR: Can't read {file_path}", file=sys.stderr)
+        sys.exit(1)
+
+
+def parse_target_lazy(
+    file_path: str,
+    folded_lazy: FoldedDiffLazy,
+    baseline_data: MutableMapping[str, float],
+    hex_strip_pattern: re.Pattern[str] | None,
+) -> Iterator[tuple[str, float, float]]:
+    """Parses the target profile lazily.
+
+    :param file_path: a path to the target folded profile.
+    :param folded_lazy: a partially initialized ``FoldedDiffLazy`` object
+           where only the ``baseline_sum`` attribute is properly initialized.
+    :param baseline_data: the baseline profile data.
+    :param hex_strip_pattern: a RE pattern for stripping hex symbols.
+
+    :return: a generator over the non-normalized and unsorted diff records.
+    """
+    # Optimize dot access
+    str_rsplit = str.rsplit
+    re_sub = re.Pattern.sub
+
+    try:
+        with open(file_path, encoding="utf-8") as file_handle:
+            if hex_strip_pattern is None:
+                for line in file_handle:
+                    stack, count_str = str_rsplit(line, maxsplit=1)
+                    try:
+                        count = float(count_str)
+                        folded_lazy.target_sum += count
+                        yield stack, baseline_data.pop(stack), count
+                    except KeyError:
+                        yield stack, 0.0, count
+                    except ValueError:
+                        # The count conversion to float failed.
+                        pass
+            else:
+                for line in file_handle:
+                    stack, count_str = str_rsplit(line, maxsplit=1)
+                    stack = re_sub(hex_strip_pattern, "0x...", stack)
+                    try:
+                        count = float(count_str)
+                        folded_lazy.target_sum += count
+                        yield stack, baseline_data.pop(stack), count
+                    except KeyError:
+                        yield stack, 0.0, count
+                    except ValueError:
+                        # The count conversion to float failed.
+                        pass
+        # Add baseline stacks that do not have a matching record in target.
+        for stack, baseline_count in baseline_data.items():
+            yield stack, baseline_count, 0.0
+    except OSError:
+        print(f"ERROR: Can't read {file_path}", file=sys.stderr)
+        sys.exit(1)
+
+
+def normalize_eager_diff(
+    data: list[tuple[str, float, float]], baseline_sum: float, target_sum: float
+) -> list[tuple[str, float, float]]:
+    """Normalize eager diff records.
+
+    Returns the ``data`` unmodified if normalization should be skipped
+    (i.e., zero division error or identical sums).
+
+    :param data: eagerly computed diff records to normalize.
+    :param baseline_sum: the sum of all baseline counts.
+    :param target_sum: the sum of all target counts.
+    """
+    scale: float | None = compute_scale_factor(baseline_sum, target_sum)
+    if scale is not None:
+        return [
+            (stack, count_baseline * scale, count_target)
+            for stack, count_baseline, count_target in data
+        ]
+    return data
+
+
+def normalize_lazy_diff(
+    data_iter: Iterable[tuple[str, float, float]],
+    baseline_sum: float,
+    target_sum: float,
+) -> Iterable[tuple[str, float, float]]:
+    """Normalize lazily computed diff records.
+
+    Returns the ``data_iter`` if normalization should be skipped
+    (i.e., zero division error or identical sums).
+
+    :param data_iter: lazily computed diff records to normalize.
+    :param baseline_sum: the sum of all baseline counts.
+    :param target_sum: the sum of all target counts.
+    """
+    scale: float | None = compute_scale_factor(baseline_sum, target_sum)
+    if scale is not None:
+        return (
+            (stack, count_baseline * scale, count_target)
+            for stack, count_baseline, count_target in data_iter
+        )
+    return data_iter
+
+
+def build_strip_hex_pattern(striphex: bool) -> re.Pattern[str] | None:
+    """Pre-compile a regex pattern for detecting hex addresses.
+
+    :param striphex: a flag indicating whether to strip hex addresses.
+
+    :return: a regex pattern or ``None``, if hex stripping is disabled.
+    """
+    return re.compile(r"0x[0-9a-fA-F]+") if striphex else None
+
+
+def compute_scale_factor(baseline_sum: float, target_sum: float) -> float | None:
+    """Safely compute the normalization scale factor.
+
+    If the scale factor cannot be computed, the normalization will be skipped.
+
+    :param baseline_sum: the sum of all baseline counts.
+    :param target_sum: the sum of all target counts.
+
+    :return: a normalization scale factor or ``None`` if it cannot be computed.
+    """
+    scale: float | None = None
+    # The 1e-9 acts as a float comparison epsilon.
+    if abs(baseline_sum - target_sum) > DIFF_FOLDED_EPS:
+        try:
+            scale = target_sum / baseline_sum
+        except ZeroDivisionError:
+            # The original Perl script did not detect zero divisions.
+            # If it happens, we avoid the normalization.
+            print(
+                "WARNING: Skipping normalization as the total baseline" " consumption is zero.",
+                file=sys.stderr,
+            )
+    return scale
+
+
+def print_diff_records(
+    folded_data: Iterable[tuple[str, float, float]],
+    formatter: str,
+) -> None:
+    """Format and print the folded records to the standard output.
+
+    :param folded_data: the (eagerly or lazily computed) diff records to print.
+    :param formatter: the formatting string to use for counts. Should be either
+           ``""``, ``"integer"``, or any valid float formatting string.
+    """
+    # We avoid the print function as it has slightly higher overhead compared
+    # to a direct stdout write.
+    out = sys.stdout.write
+
+    try:
+        if formatter not in ("", "integer"):
+            for stack, c1, c2 in folded_data:
+                out(f"{stack} {c1:{formatter}} {c2:{formatter}}\n")
+            return
+    except ValueError as e:
+        # Likely an invalid formatter. Fall back to an integer format.
+        print(f"WARNING: An invalid formatter: {e}", file=sys.stderr)
+    for stack, c1, c2 in folded_data:
+        out(f"{stack} {int(c1):d} {int(c2):d}\n")
+
+
+def initialize_cli_options(cli_parser: argparse.ArgumentParser) -> None:
+    """Initializes the CLI options that may be reused by composite scripts.
+
+    When importing the difffolded.py script by other Python scripts, it might
+    be helpful to extend their CLI options with the options and arguments used
+    by this script.
+
+    Note that the ``--formater`` and ``--sort-stacks`` options are skipped.
+
+    :param cli_parser: a CLI parser to extend.
+    """
+    cli_parser.add_argument(
+        "-n",
+        "--normalize",
+        action="store_true",
+        help=(
+            "Normalize the baseline sample counts using the formula"
+            "(baseline_count * target_sum / baseline_sum)."
+        ),
+    )
+    cli_parser.add_argument(
+        "-s",
+        "--striphex",
+        action="store_true",
+        help=("Strip hex addresses in the stacks, e.g., replace '0x1234abc' with" " '0x...'."),
+    )
+    cli_parser.add_argument(
+        "baseline",
+        metavar="baseline",
+        type=str,
+        help="The first folded stack file (baseline).",
+    )
+    cli_parser.add_argument(
+        "target",
+        metavar="target",
+        type=str,
+        help="The second folded stack file (target)",
+    )
+
+
+if __name__ == "__main__":
+    _cli_parser = argparse.ArgumentParser(
+        description=("Diff two folded stack files for flame graph differentials."),
+        usage=(
+            "%(prog)s [-hnst] [-f integer|float|auto] folded1 folded2 |"
+            " flamegraph.pl > diff2.svg"
+        ),
+    )
+    _cli_parser.add_argument(
+        "-f",
+        "--formatter",
+        default="integer",
+        type=str,
+        help=(
+            "Format the counts on stdout output: use 'integer' or '' to"
+            " truncate floats to integers and avoid scientific notation;"
+            " or supply a custom formatter string (e.g., '.10g') that will be"
+            " passed directly to the f-string expression. Falls back to the"
+            " 'integer' formatter in case of an invalid formating string"
+            " (default='integer')."
+        ),
+    )
+    _cli_parser.add_argument(
+        "-t",
+        "--sort-stacks",
+        action="store_true",
+        help="Sort the stacks lexicographically.",
+    )
+    initialize_cli_options(_cli_parser)
+    _cli_args = _cli_parser.parse_args()
+
+    _folded_lazy = diff_folded_lazy(**vars(_cli_args))
+    print_diff_records(_folded_lazy.data, _cli_args.formatter)

--- a/perun/scripts/difffolded.py
+++ b/perun/scripts/difffolded.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 
 """difffolded.py 	Diff baseline and target folded stack files.
-                    Use this for generating flame graph differentials.
+
+Use this for generating flame graph differentials.
 
 USAGE: ./difffolded.py [-hnst] [-f integer|float|auto] baseline target | ./flamegraph.py > diff2.svg
 

--- a/perun/scripts/flamegraph.py
+++ b/perun/scripts/flamegraph.py
@@ -1,0 +1,3485 @@
+#!/usr/bin/env python3
+"""flamegraph.py		flame stack grapher.
+
+This takes stack samples and renders a call graph, allowing hot functions
+and codepaths to be quickly identified.  Stack samples can be generated using
+tools such as DTrace, perf, SystemTap, and Instruments.
+
+USAGE: ./flamegraph.py [options] input.folded > graph.svg
+       ./flamegraph.py [options] --outfile graph.svg input.folded
+       grep funcA input.txt | ./flamegraph.pl [options] > graph.svg
+
+Then open the resulting .svg in a web browser, for interactivity: mouse-over
+frames for info, click to zoom, and ctrl-F to search.
+
+Options are listed in the usage message (--help).
+
+The input is stack frames and sample counts formatted as single lines.  Each
+frame in the stack is semicolon separated, with a space and count at the end
+of the line.  These can be generated for Linux perf script output using
+stackcollapse-perf.pl, for DTrace using stackcollapse.pl, and for other tools
+using the other stackcollapse programs.  Example input:
+
+ swapper;start_kernel;rest_init;cpu_idle;default_idle;native_safe_halt 1
+
+An optional extra column of counts can be provided to generate a differential
+flame graph of the counts, colored red for more, and blue for less.  This
+can be useful when using flame graphs for non-regression testing.
+See the header comment in the difffolded.py program for instructions.
+
+The input functions can optionally have annotations at the end of each
+function name, following a precedent by some tools (Linux perf's _[k]):
+    _[k] for kernel
+    _[i] for inlined
+        _[j] for jit
+        _[w] for waker
+Some of the stackcollapse programs support adding these annotations, eg,
+stackcollapse-perf.pl --kernel --jit. They are used merely for colors by
+some palettes, eg, flamegraph.pl --color=java.
+
+The output flame graph shows relative presence of functions in stack samples.
+The ordering on the x-axis has no meaning; since the data is samples, time
+order of events is not known.  The order used sorts function names
+alphabetically.
+
+While intended to process stack samples, this can also process stack traces.
+For example, tracing stacks for memory allocation, or resource usage.  You
+can use --title to set the title to reflect the content, and --countname
+to change "samples" to "bytes" etc.
+
+There are a few different palettes, selectable using --color.  By default,
+the colors are selected at random (except for differentials).  Functions
+called "-" will be printed gray, which can be used for stack separators (eg,
+between user and kernel stacks).
+
+*******************************************************************************
+* Python version details
+*******************************************************************************
+
+This Python version is meant as a drop-in replacement for the original Perl
+script. As such, it requires only a Python interpreter with the Python standard
+library: it deliberately avoids any 3rd party dependencies.
+
+The Python version has been optimized for processing large folded profiles and,
+based on some crude local measurements (Python 3.14, cached bytecode), appears
+to be almost 8x faster for standard flame graphs and 4.5x faster for
+differential flamegraphs using an example ~150 MB folded profile. Small profiles
+(approximatelly < 500 KB based on local measurements) tend to exhibit a slowdown
+compared to the Perl version as the execution time is dominated by the Python
+interpreter startup cost (~40ms+ on a local machine). Also note that the
+optimizations cause some code duplication as we have no macros or templates
+in Python.
+
+Additionally, this version introduces some minor changes compared to the
+original Perl script:
+
+ - The colors of individual frames do not match exactly since Perl and Python
+   use different PRNG in their random modules.
+
+ - The original Perl script has more CLI options than displayed in its help
+   (usage) message. The Python script lists all the options.
+
+ - The CLI contains two additional options. Namely, the ``outfile`` option
+   allows to specify the output file directly (instead of relying solely on OS
+   pipes); and the ``max_trace`` option allows the users to override the flame
+   graph height (suitable for aligning multiple graphs in a grid or truncating
+   too deep graphs).
+
+ - Large count figures (e.g., CPU cycles) are often difficult to read. Hence,
+   this version formats the numbers using SI suffixes to improve readability.
+
+ - An additional JS code related to our particular use in flame graph grids.
+
+  TODO: remove some of the new additions if we decide to make the flame graph
+   scripts available in a standalone repo / a fork of B. Gregg's repo.
+
+*******************************************************************************
+
+HISTORY
+
+This was inspired by Neelakanth Nadgir's excellent function_call_graph.rb
+program, which visualized function entry and return trace events.  As Neel
+wrote: "The output displayed is inspired by Roch's CallStackAnalyzer which
+was in turn inspired by the work on vftrace by Jan Boerhout".  See:
+https://blogs.oracle.com/realneel/entry/visualizing_callstacks_via_dtrace_and
+
+Copyright 2016 Netflix, Inc.
+Copyright 2011 Joyent, Inc.  All rights reserved.
+Copyright 2011 Brendan Gregg.  All rights reserved.
+
+CDDL HEADER START
+
+The contents of this file are subject to the terms of the
+Common Development and Distribution License (the "License").
+You may not use this file except in compliance with the License.
+
+You can obtain a copy of the license at docs/cddl1.txt or
+http://opensource.org/licenses/CDDL-1.0.
+See the License for the specific language governing permissions
+and limitations under the License.
+
+When distributing Covered Code, include this CDDL HEADER in each
+file and include the License file at docs/cddl1.txt.
+If applicable, add the following below this CDDL HEADER, with the
+fields enclosed by brackets "[]" replaced with your own identifying
+information: Portions Copyright [yyyy] [name of copyright owner]
+
+CDDL HEADER END
+
+01-May-2026 Jiri Pavela     Optimized and ported to Python.
+11-Oct-2014	Adrien Mahieux	Added zoom.
+21-Nov-2013 Shawn Sterling  Added consistent palette file option
+17-Mar-2013 Tim Bunce       Added options and more tunables.
+15-Dec-2011	Dave Pacheco	Support for frames with whitespace.
+10-Sep-2011	Brendan Gregg	Created this.
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable, Iterable, Sequence
+import enum
+from operator import itemgetter
+from pathlib import Path
+import random
+import re
+import sys
+from typing import Any, TextIO, ClassVar, Literal, TypeAlias, overload
+
+ColoringFn: TypeAlias = Callable[[str], str]
+ColoringCtxFn: TypeAlias = Callable[["Colors", str], str]
+
+
+class ColorPalettes(enum.Enum):
+    """Supported color palettes for SVG frames (CLI parameter ``--colors``).
+
+    Each member value is the palette name accepted on the command line.
+    """
+
+    HOT = "hot"
+    MEM = "mem"
+    IO = "io"
+    WAKEUP = "wakeup"
+    CHAIN = "chain"
+    JAVA = "java"
+    JS = "js"
+    PERL = "perl"
+    RED = "red"
+    GREEN = "green"
+    BLUE = "blue"
+    AQUA = "aqua"
+    YELLOW = "yellow"
+    PURPLE = "purple"
+    ORANGE = "orange"
+
+    @staticmethod
+    def supported() -> list[str]:
+        """Get the collection of supported color palettes.
+
+        :return: palette string names accepted by ``--colors``.
+        """
+        return [palette.value for palette in ColorPalettes]
+
+    @staticmethod
+    def default() -> ColorPalettes:
+        """Get the default color palette.
+
+        :return: the default HOT color palette.
+        """
+        return ColorPalettes.HOT
+
+
+class NameAttributes:
+    """A cache for pre-processed name-attribute entries.
+
+    Users may optionally supply a so-called name-attribute file which lists
+    additional HTML attributes that should be associated with certain names
+    (e.g., functions). These attributes are then embedded into the SVG frames
+    depicting these names.
+
+    Each line in the name-attribute file must have the following format:
+    <name>TAB<attribute1>=<value1>TAB<attribute2>=<value2>[...]
+
+    This class wraps the loading and processing of these name-attribute entries,
+    and builds a cache that can be queried for already partially pre-processed
+    HTML markup.
+
+    :ivar attr_cache: name -> (opening markup, closing markup).
+    """
+
+    __slots__ = ("attr_cache",)
+
+    def __init__(self, filepath: str) -> None:
+        """Loads name-attribute mappings from ``filepath``.
+
+        The program will be terminated if the file does not exist, or if it
+        is malformed.
+
+        :param filepath: path to the name-attr file, or ``""`` for no file.
+        """
+        self.attr_cache: dict[str, tuple[str, str]] = self._init_attr_cache(filepath)
+
+    def get_frame(self, name: str, title: str) -> tuple[str, str]:
+        """Return SVG opening and closing markup for the ``name``.
+
+        When the ``name`` is not in the cache, the method returns the standard
+        opening and closing markup used for names without any user-supplied
+        attributes.
+
+        :param name: the frame name used as a key in the cache lookup.
+        :param title: the inner ``<title>`` text.
+
+        :return: (opening markup, closing markup).
+        """
+        try:
+            begin, end = self.attr_cache[name]
+        except KeyError:
+            begin, end = ("<g>\n<title>", "</g>\n")
+        return f"{begin}{title}</title>\n", end
+
+    @staticmethod
+    def _init_attr_cache(filepath: str) -> dict[str, tuple[str, str]]:
+        """Parse ``filepath`` into the name-attr cache.
+
+        :param filepath: the name-attr file path, or ``""`` for no file.
+
+        :return: a constructed cache.
+        """
+        cache: dict[str, tuple[str, str]] = {}
+        if not filepath:
+            return cache
+        try:
+            with open(filepath, "r") as fh:
+                for line in fh:
+                    func_name, *attrs = line.split("\t")
+                    cache[func_name] = NameAttributes._construct_name_attrs(
+                        **dict(attr.split("=") for attr in attrs)
+                    )
+            return cache
+        except IOError as e:
+            print(f"ERROR: Can't read {filepath}: {e}", file=sys.stderr)
+            sys.exit(1)
+        except (ValueError, IndexError):
+            print(f"ERROR: Invalid format in {filepath}", file=sys.stderr)
+            sys.exit(1)
+
+    @staticmethod
+    def _construct_name_attrs(
+        id: str | None = None,
+        g_extra: str | None = None,
+        href: str | None = None,
+        target: str | None = None,
+        a_extra: str | None = None,
+        **rest: str,
+    ) -> tuple[str, str]:
+        """Build the opening and closing SVG fragments for the given attributes.
+
+        :param id: an ``id=`` value.
+        :param g_extra: extra attributes to use in ``<g>``.
+        :param href: if set, emit ``<a xlink:href=...>`` instead of ``<g>``.
+        :param target: link target (defaults to ``_top`` when ``href`` is set).
+        :param a_extra: extra attributes to use in ``<a>`` when ``href`` is set.
+        :param rest: remaining ``name=value`` pairs (e.g. ``class``).
+
+        :return: (opening markup, closing markup).
+        """
+        # Process the ``<g>`` attributes.
+        g_attrs = []
+        if id is not None:
+            g_attrs.append(f'id="{id}"')
+        if (g_class := rest.get("class")) is not None:
+            # Cannot name the parameter ``class`` (reserved keyword).
+            g_attrs.append(f'class="{g_class}"')
+        if g_extra is not None:
+            g_attrs.append(g_extra)
+
+        # Use ``<a>`` instead of ``<g>`` when a link is requested.
+        if href is not None:
+            a_attrs = [
+                f'xlink:href="{href}"',
+                f'target="{target}"' if target is not None else "_top",
+            ]
+            if a_extra is not None:
+                a_attrs.append(a_extra)
+            return f'<a {" ".join(a_attrs + g_attrs)}>\n<title>', "</a>\n"
+        return f'<g {" ".join(g_attrs)}>\n<title>', "</g>\n"
+
+
+class Settings:
+    """The flame graph construction options as available through the CLI."""
+
+    __slots__ = (
+        "infile",
+        "outfile",
+        "bg_colors",
+        "colors",
+        "count_name",
+        "encoding",
+        "factor",
+        "flame_chart_flag",
+        "font_size",
+        "font_type",
+        "font_width",
+        "frame_height",
+        "hash_flag",
+        "image_width",
+        "inverted",
+        "max_trace",
+        "min_width_value",
+        "min_width_relative",
+        "name_attr",
+        "name_type",
+        "negate",
+        "notes_text",
+        "consistent_palette_flag",
+        "random_flag",
+        "root_node",
+        "stack_reverse_flag",
+        "subtitle",
+        "total",
+        "title",
+    )
+
+    DefaultBgColors: ClassVar[str] = ""
+    DefaultColors: ClassVar[ColorPalettes] = ColorPalettes.default()
+    DefaultCountName: ClassVar[str] = "samples"
+    DefaultEncoding: ClassVar[str] = ""
+    DefaultFactor: ClassVar[float] = 1.0
+    DefaultFlameChartFlag: ClassVar[bool] = False
+    DefaultFontSize: ClassVar[float] = 12.0
+    DefaultFontType: ClassVar[str] = "Verdana"
+    DefaultFontWidth: ClassVar[float] = 0.59
+    DefaultFrameHeight: ClassVar[int] = 16
+    DefaultHashFlag: ClassVar[bool] = False
+    DefaultImageWidth: ClassVar[int] = 1200
+    DefaultInvertedFlag: ClassVar[bool] = False
+    DefaultMaxTrace: ClassVar[int] = -1
+    DefaultMinWidth: ClassVar[str] = "0.1"
+    DefaultNameType: ClassVar[str] = "Function:"
+    DefaultNameAttrFile: ClassVar[str] = ""
+    DefaultNegateFlag: ClassVar[bool] = False
+    DefaultNotesText: ClassVar[str] = ""
+    DefaultOutFile: ClassVar[str] = ""
+    DefaultPaletteFlag: ClassVar[bool] = False
+    DefaultRandomFlag: ClassVar[bool] = False
+    DefaultRootNode: ClassVar[str] = "all"
+    DefaultStackReverseFlag: ClassVar[bool] = False
+    DefaultSubtitle: ClassVar[str] = ""
+    DefaultTotal: ClassVar[int] = -1
+    DefaultTitle: ClassVar[str] = ""
+
+    # Used to cheaply translate SVG-breaking characters.
+    TranslationTable: ClassVar[dict[int, str]] = str.maketrans(
+        {"&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;"}
+    )
+
+    def __init__(
+        self,
+        infile: Path,
+        *,
+        bgcolors: str = DefaultBgColors,
+        colors: ColorPalettes = DefaultColors,
+        countname: str = DefaultCountName,
+        cp: bool = DefaultPaletteFlag,
+        encoding: str = DefaultEncoding,
+        factor: float = DefaultFactor,
+        flamechart: bool = DefaultFlameChartFlag,
+        fontsize: float = DefaultFontSize,
+        fonttype: str = DefaultFontType,
+        fontwidth: float = DefaultFontWidth,
+        hash: bool = DefaultHashFlag,
+        height: int = DefaultFrameHeight,
+        inverted: bool = DefaultInvertedFlag,
+        maxtrace: int = DefaultMaxTrace,
+        minwidth: str = DefaultMinWidth,
+        nameattr: str = DefaultNameAttrFile,
+        nametype: str = DefaultNameType,
+        negate: bool = DefaultNegateFlag,
+        notes: str = DefaultNotesText,
+        outfile: str = DefaultOutFile,
+        random: bool = DefaultRandomFlag,
+        rootnode: str = DefaultRootNode,
+        reverse: bool = DefaultStackReverseFlag,
+        subtitle: str = DefaultSubtitle,
+        total: int = DefaultTotal,
+        title: str = DefaultTitle,
+        width: int = DefaultImageWidth,
+        **_: Any,
+    ) -> None:
+        """Store normalized processing and rendering settings.
+
+        :param infile: a path to the input folded profile. May be set to
+               a dummy value ``Path()`` when using the programmatic API
+               (see ``create_flame_graph``).
+        :param bgcolors: the background color (gradient). Supports:
+               - named gradients (``yellow``, ``blue``, ``green``, ``grey``,
+                 and ``gray``),
+               - hex colors in the ``#RRGGBB`` format (will result in a flat
+                 color, not a gradient), or
+               - ``""`` for a palette-derived default gradient.
+        :param colors: the color palette for SVG frames.
+        :param countname: the counts name (e.g. ``samples``, ``cycles``).
+        :param encoding: a specific encoding to use in the XML declaration.
+        :param factor: a multiplier applied to parsed counts.
+        :param flamechart: draw a flame chart instead (sorts by time, does not
+               merge stacks).
+        :param fontsize: SVG text font size (px).
+        :param fonttype: CSS ``font-family`` name for SVG text.
+        :param fontwidth: average character width relative to ``font_size``.
+        :param height: the height of each frame (px).
+        :param hash: color frames using a deterministic hash function.
+        :param inverted: draw an icicle chart instead (deepest frames at top).
+        :param maxtrace: overrides the computation of the canvas height.
+               The height is determined by the maximum trace depth (after
+               filtering the data using ``minwidth``). This option may be used
+               to align two SVGs with possibly different data side-by-side.
+        :param minwidth: specifies the minimum width of displayed frames.
+               Narrower frames will be discarded. May be specified either as
+               a fixed pixel width (e.g., ``0.5``) or relative to the total
+               count (e.g., ``0.1%``).
+        :param nameattr: a path to the name-attribute file
+               (see ``NameAttributes``).
+        :param nametype: the name of the frames in stacks
+              (e.g., ``Function:``, ``Basic Block:``).
+        :param negate: flip the differential red/blue hues when ``True``.
+        :param notes: addition notes to embedd into the SVG comment header.
+        :param outfile: store the flamegraph in a file instead of printing it
+               to the standard output.
+        :param cp: use consistent palette that loads and stores stable colors
+               via a ``palette.map`` file.
+        :param random: use randomized frame colors within the selected palette.
+               Note that even frames with identical names will have their
+               colors chosen randomly.
+        :param rootnode: the label on the synthetic root frame.
+        :param reverse: the stacks in the folded profile are in the
+               callee-to-caller (instead of caller-to-callee) order.
+        :param subtitle: optional second title line below the main title.
+        :param total: overrides the sum of all counts, which causes the root
+               node to be wider (suitable for comparing two profiles
+               side-by-side). Must be higher or equal than the actual sum.
+        :param title: the graph title.
+        :param width: the width of the SVG canvas (px).
+
+        Extra keyword arguments are ignored so that dictionaries with possibly
+        additional keys may be unpacked directly when constructing the object.
+        """
+        self.infile: Path = infile
+        self.bg_colors: str = bgcolors
+        self.colors: ColorPalettes = colors
+        self.count_name: str = countname
+        self.encoding: str = encoding
+        self.factor: float = factor
+        self.flame_chart_flag: bool = flamechart
+        self.font_size: float = fontsize
+        self.font_type: str = fonttype
+        self.font_width: float = fontwidth
+        self.frame_height: int = height
+        self.hash_flag: bool = hash
+        self.image_width: int = width
+        self.inverted: bool = inverted
+        self.max_trace: int = maxtrace
+        self.min_width_value: float = self._init_min_width(minwidth)
+        self.min_width_relative: bool = minwidth.endswith("%")
+        self.name_attr: NameAttributes = NameAttributes(nameattr)
+        self.name_type: str = nametype
+        self.negate: bool = negate
+        self.notes_text: str = notes.translate(self.TranslationTable)
+        self.outfile: str = outfile
+        self.consistent_palette_flag: bool = cp
+        self.random_flag: bool = random
+        self.root_node: str = rootnode
+        self.stack_reverse_flag: bool = reverse
+        self.subtitle: str = subtitle
+        self.total: int = total
+        self.title: str = self._init_title(title, flamechart, inverted)
+
+    @staticmethod
+    def _init_title(title: str, is_flame_chart: bool, is_inverted: bool) -> str:
+        """Initialize the graph title.
+
+        Uses a user-supplied title if available, otherwise synthesizes
+        a default title based on the type of the graph being drawn.
+
+        :param title: the user-supplied title, or ``""``.
+        :param is_flame_chart: flame-chart mode enabled.
+        :param is_inverted: icicle mode enabled.
+
+        :return: the (synthesized) graph title.
+        """
+        if title:
+            return title
+        graph_type = "Icicle" if is_inverted else "Flame"
+        suffix = "Chart" if is_flame_chart else "Graph"
+        return f"{graph_type} {suffix}"
+
+    @staticmethod
+    def _init_min_width(min_width: str) -> float:
+        """Parse the ``minwidth`` string and obtain the numerical threshold.
+
+        In case of a malformed value, the default minwidth value is used.
+
+        :param min_width: the raw ``--minwidth`` parameter.
+
+        :return: a nonnegative float threshold.
+        """
+        min_width_match = re.match(r"^([0-9.]+)%?$", min_width)
+        if not min_width_match:
+            print(
+                f"Warning: Invalid minwidth value: '{min_width}', expected a"
+                " float with an optional '%' suffix. Using the default value"
+                f" '{Settings.DefaultMinWidth}'.'",
+                file=sys.stderr,
+            )
+            return float(Settings.DefaultMinWidth)
+        return float(min_width_match.group(1))
+
+
+class Geometry:
+    """Rendering geometry for the SVG layout.
+
+    The class wraps many constants and parameters (dimensions, paddings,
+    offset tables, etc.) used when rendering the SVG canvas, elements,
+    and frames.
+
+    :ivar y_pad_2: a bottom legend/control padding.
+    :ivar x_pad_2: a horizontal padding used for matched-percent labels.
+    :ivar width_per_count_unit: the pixel fraction corresponding to a single
+          count unit.
+    :ivar title_size: the font size of the graph title (px).
+    :ivar char_space: an approximate width of a font glyph. Used to compute the
+          available space for frame names.
+    :ivar total_factor: scales the total counts by the user-supplied factor.
+    :ivar image_width: the SVG canvas width.
+    :ivar image_height: the SVG canvas height w.r.t. maximum trace length.
+    :ivar y1_table: pre-computed Y-coordinates for frame bottom edges.
+    :ivar y2_table: pre-computed Y-coordinates for frame top edges.
+    """
+
+    __slots__ = (
+        "y_pad_2",
+        "x_pad_2",
+        "width_per_count_unit",
+        "total",
+        "title_size",
+        "char_space",
+        "total_factor",
+        "image_width",
+        "image_height",
+        "y1_table",
+        "y2_table",
+    )
+
+    XPad1: ClassVar[int] = 10
+
+    def __init__(
+        self,
+        settings: Settings,
+        total: float,
+        width_per_count_unit: float,
+        max_profile_trace: int,
+    ) -> None:
+        """Compute dimensions, pads and offset tables.
+
+        :param settings: rendering and processing options.
+        :param total: the sum of counts that determines horizontal scaling.
+        :param width_per_count_unit: pixels per a unit of count.
+        :param max_profile_trace: the depth of the longest trace found in the
+               profile (possibly overridden by the user).
+        """
+        self.y_pad_2: int = int(settings.font_size * 2 + 10)
+        self.x_pad_2: int = int(settings.font_size**2)
+        self.width_per_count_unit: float = width_per_count_unit
+        self.title_size = int(settings.font_size) + 5
+        self.char_space: float = settings.font_size * settings.font_width
+        self.total_factor: float = total * settings.factor
+        self.image_width: int = settings.image_width
+        self.image_height, self.y1_table, self.y2_table = self._init_heights(
+            settings,
+            max_profile_trace,
+            self.y_pad_2,
+        )
+
+    @staticmethod
+    def _init_heights(
+        settings: Settings,
+        max_profile_trace: int,
+        y_pad_2: int,
+    ) -> tuple[int, list[int], list[int]]:
+        """Compute the canvas height and per-frame Y-coordinate tables.
+
+        :param settings: rendering and processing options.
+        :param max_profile_trace: the depth of the longest trace found in the
+               profile (possibly overridden by the user).
+        :param y_pad_2: a bottom legend/control padding.
+
+        :return: (canvas_height,
+                  Y-coordinate table for frame bottom edges,
+                  Y-coordinate table for frame top edges).
+        """
+        y_pad_1 = int(settings.font_size * 3)  # Pad top, include title.
+        frame_pad: int = 1  # Vertical padding between frames.
+        image_height: int = y_pad_1 + y_pad_2
+        if settings.max_trace != -1:
+            image_height += (settings.max_trace + 1) * settings.frame_height
+        else:
+            image_height += (max_profile_trace + 2) * settings.frame_height
+        if settings.subtitle:
+            y_pad_3 = int(settings.font_size * 2)  # Pad top, include subtitle.
+            image_height += y_pad_3
+
+        if settings.inverted:
+            y1_table = [
+                y_pad_1 + depth * settings.frame_height for depth in range(max_profile_trace + 2)
+            ]
+            y2_table = [
+                y_pad_1 + (depth + 1) * settings.frame_height - frame_pad
+                for depth in range(max_profile_trace + 2)
+            ]
+        else:
+            y1_base: int = image_height - y_pad_2
+            y1_table = [
+                y1_base - (depth + 1) * settings.frame_height + frame_pad
+                for depth in range(max_profile_trace + 2)
+            ]
+            y2_table = [
+                y1_base - depth * settings.frame_height for depth in range(max_profile_trace + 2)
+            ]
+        return image_height, y1_table, y2_table
+
+
+class Colors:
+    """Color management for the SVG canvas and frames.
+
+    This class tries to efficiently wrap all color-related processing. Note that
+    the original Perl script supports a large range of color options and
+    variants which results in a slight code bloat when trying to implement the
+    coloring efficiently.
+
+    Concretely, the original script does a lot of unnecessary processing in each
+    ``color()`` call. The Python implementation instead splits the coloring code
+    into separate per-palette and per-mode functions (e.g., ``color_hot_hash``,
+    ``color_hot_random``, and ``color_hot``) and can thus quickly dispatch each
+    request for a new color. Furthermore, we utilize a color cache where
+    applicable (i.e., unless random coloring is requested).
+
+    :ivar color_functions: a collection of per-mode (e.g., random, hash)
+          coloring functions for each solid palette indexable by ``PaletteIdx``.
+          This collection is used mainly by the language-specific palettes to
+          quickly dispatch to the correct coloring function based on the
+          coloring mode.
+    :ivar color_fn: the coloring function selected based on the chosen palette.
+    :ivar bg_color_1: the background gradient start color.
+    :ivar bg_color_2: the background gradient end color.
+    :ivar palette_map: a ``name -> RGB`` cache.
+    :ivar consistent_palette_flag: whether persistent palette is enabled.
+    """
+
+    __slots__ = (
+        "color_functions",
+        "color_fn",
+        "bg_color_1",
+        "bg_color_2",
+        "palette_map",
+        "consistent_palette_flag",
+        "__getitem__",
+    )
+
+    class PaletteIdx(enum.IntEnum):
+        """Named indices into the ``color_functions`` collection."""
+
+        RED = 0
+        GREEN = 1
+        BLUE = 2
+        YELLOW = 3
+        PURPLE = 4
+        AQUA = 5
+        ORANGE = 6
+        HOT = 7
+        MEM = 8
+        IO = 9
+
+    PaletteFileName: ClassVar[str] = "palette.map"
+    JavaRegex: ClassVar[re.Pattern[str]] = re.compile(r"^L?(java|javax|jdk|net|org|com|io|sun)/")
+    JSRegex: ClassVar[re.Pattern[str]] = re.compile(r"/.*\.js")
+    PerlRegex: ClassVar[re.Pattern[str]] = re.compile(r"Perl|\.pl")
+    NameHashModuleSkip: ClassVar[re.Pattern[str]] = re.compile(r"^.(.*?)`")
+
+    RGBblack = "rgb(0,0,0)"
+    RGBvdgrey = "rgb(160,160,160)"
+    RGBdgrey = "rgb(200,200,200)"
+    RGBsearch = "rgb(230,0,230)"  # Search highlight fill color.
+    RGBhover = "rgb(0,230,230)"  # Hover highlight fill color.
+
+    def __init__(
+        self,
+        palette: ColorPalettes,
+        bg_colors: str,
+        has_consistent_palette: bool,
+        use_hash: bool,
+        use_random: bool,
+    ) -> None:
+        """Initializes frames and background coloring scheme.
+
+        :param palette: the requested color palette for frames.
+        :param bg_colors: the background color specification. Could be named
+               gradients, flat hex colors, or ``""`` to force automatic
+               selection based on the color palette.
+        :param has_consistent_palette: indicator whether a consistent palette
+               mode using the ``palette.map`` file is desired.
+        :param use_hash: color frames using the deterministic ``*_hash``
+               coloring functions.
+        :param use_random: color frames randomly w.r.t the selected palette.
+               Note that even frames with identical names will have different
+               colors.
+        """
+        self.color_functions: list[ColoringFn] = self._init_color_functions(use_hash, use_random)
+        self.color_fn: ColoringFn | ColoringCtxFn = self._init_color_callable(
+            palette, self.color_functions
+        )
+        self.bg_color_1, self.bg_color_2 = self._init_bg_color_gradient(palette, bg_colors)
+        self.palette_map: dict[str, str] = self._init_palette_cache(has_consistent_palette)
+        self.consistent_palette_flag: bool = has_consistent_palette
+        # Select the appropriate __getitem__ method depending on whether we can
+        # or cannot use a color cache. When random coloring is requested, even
+        # frames with identical names should compute a new color every time,
+        # hence the cache cannot be used.
+        if use_random:
+            self.__getitem__ = self._getitem_random
+        else:
+            self.__getitem__ = self._getitem_cached
+
+    @staticmethod
+    def _init_color_functions(use_hash: bool, use_random: bool) -> list[ColoringFn]:
+        """Create a mode-specific indexable collection of palette callables.
+
+        Used to quickly dispatch to the appropriate coloring function from the
+        language-specific palettes.
+
+        :param use_hash: use the ``*_hash`` coloring functions.
+        :param use_random: use the ``*_random`` coloring functions.
+
+        :return: an indexable collection of coloring callables.
+        """
+        if use_hash:
+            return [
+                Colors.color_red_hash,
+                Colors.color_green_hash,
+                Colors.color_blue_hash,
+                Colors.color_yellow_hash,
+                Colors.color_purple_hash,
+                Colors.color_aqua_hash,
+                Colors.color_orange_hash,
+                Colors.color_hot_hash,
+                Colors.color_mem_hash,
+                Colors.color_io_hash,
+            ]
+        if use_random:
+            return [
+                Colors.color_red_random,
+                Colors.color_green_random,
+                Colors.color_blue_random,
+                Colors.color_yellow_random,
+                Colors.color_purple_random,
+                Colors.color_aqua_random,
+                Colors.color_orange_random,
+                Colors.color_hot_random,
+                Colors.color_mem_random,
+                Colors.color_io_random,
+            ]
+        return [
+            Colors.color_red,
+            Colors.color_green,
+            Colors.color_blue,
+            Colors.color_yellow,
+            Colors.color_purple,
+            Colors.color_aqua,
+            Colors.color_orange,
+            Colors.color_hot,
+            Colors.color_mem,
+            Colors.color_io,
+        ]
+
+    @staticmethod
+    def _init_bg_color_gradient(palette: ColorPalettes, bg_color: str) -> tuple[str, str]:
+        """Create the start and end colors for the SVG background gradient.
+
+        :param palette: the selected palette to infer the default gradient.
+        :param bg_color: a ``#RRGGBB`` literal, gradient keyword, or ``""``.
+
+        :return: (gradient start color, gradient end color).
+        """
+        # Flat RGB hex uses one color as both gradient stops.
+        if len(bg_color) == 7 and bg_color[0] == "#":
+            return bg_color, bg_color
+        # Named presets and palette-derived defaults.
+        yellow_gradient = ("#eeeeee", "#eeeeb0")
+        blue_gradient = ("#eeeeee", "#e0e0ff")
+        green_gradient = ("#eef2ee", "#e0ffe0")
+        grey_gradient = ("#f8f8f8", "#e8e8e8")
+        # Infer gradient from ``palette`` when ``bg_color`` is empty.
+        color_key = bg_color if bg_color else palette
+        try:
+            return {
+                "yellow": yellow_gradient,
+                "blue": blue_gradient,
+                "green": green_gradient,
+                "grey": grey_gradient,
+                "gray": grey_gradient,
+                ColorPalettes.HOT: yellow_gradient,
+                ColorPalettes.MEM: green_gradient,
+                ColorPalettes.IO: blue_gradient,
+                ColorPalettes.WAKEUP: blue_gradient,
+                ColorPalettes.CHAIN: blue_gradient,
+                ColorPalettes.RED: grey_gradient,
+                ColorPalettes.GREEN: grey_gradient,
+                ColorPalettes.BLUE: grey_gradient,
+                ColorPalettes.AQUA: grey_gradient,
+                ColorPalettes.YELLOW: grey_gradient,
+                ColorPalettes.PURPLE: grey_gradient,
+                ColorPalettes.ORANGE: grey_gradient,
+            }[color_key]
+        except KeyError:
+            if bg_color:
+                print(
+                    f"WARNING: Unrecognized --bgcolors option '{bg_color}'."
+                    " Using a default yellow gradient.",
+                    file=sys.stderr,
+                )
+        return yellow_gradient
+
+    @staticmethod
+    def _init_color_callable(
+        color: ColorPalettes, color_functions: Sequence[ColoringFn]
+    ) -> ColoringFn | ColoringCtxFn:
+        """Resolve the selected palette to the corresponding coloring callable.
+
+        :param color: the palette selected by the user.
+        :param color_functions: an indexable collection of coloring functions.
+
+        :return: either a plain staticmethod ``Callable[[str], str]``, or
+                 a palette method needing ``self``. Note that despite their
+                 different type, both callable types can be called using
+                 ``self.fn()``.
+        """
+        color_map: dict[ColorPalettes, ColoringFn | ColoringCtxFn] = {
+            ColorPalettes.RED: color_functions[Colors.PaletteIdx.RED],
+            ColorPalettes.GREEN: color_functions[Colors.PaletteIdx.GREEN],
+            ColorPalettes.BLUE: color_functions[Colors.PaletteIdx.BLUE],
+            ColorPalettes.YELLOW: color_functions[Colors.PaletteIdx.YELLOW],
+            ColorPalettes.PURPLE: color_functions[Colors.PaletteIdx.PURPLE],
+            ColorPalettes.AQUA: color_functions[Colors.PaletteIdx.AQUA],
+            ColorPalettes.ORANGE: color_functions[Colors.PaletteIdx.ORANGE],
+            ColorPalettes.HOT: color_functions[Colors.PaletteIdx.HOT],
+            ColorPalettes.MEM: color_functions[Colors.PaletteIdx.MEM],
+            ColorPalettes.IO: color_functions[Colors.PaletteIdx.IO],
+            ColorPalettes.JAVA: Colors.color_java,
+            ColorPalettes.PERL: Colors.color_perl,
+            ColorPalettes.JS: Colors.color_js,
+            ColorPalettes.WAKEUP: color_functions[Colors.PaletteIdx.AQUA],
+            ColorPalettes.CHAIN: Colors.color_chain,
+        }
+        try:
+            return color_map[color]
+        except KeyError:
+            return Colors.color_unknown
+
+    @staticmethod
+    def _init_palette_cache(has_consistent_palette: bool) -> dict[str, str]:
+        """Initialize the palette cache.
+
+        If a consistent palette is requested and the palette file exists, it is
+        used to populate the cache. Otherwise, the cache is initialized with
+        two gray colors reserved for delimiter frames.
+
+        :param has_consistent_palette: populate the cache with the contents of
+               the ``palette.map`` file.
+
+        :return: an initialized color cache.
+        """
+        palette_map: dict[str, str] = {}
+        if has_consistent_palette and Path.exists(Path(Colors.PaletteFileName)):
+            try:
+                with open(Colors.PaletteFileName, "r+") as f:
+                    # Optimize dot access.
+                    str_split = str.split
+
+                    for line in f:
+                        name, color = str_split(line, "->", 1)
+                        palette_map[name] = color
+            except IOError as e:
+                print(
+                    f"ERROR: Can't open file {Colors.PaletteFileName}: {e}",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+            except ValueError:
+                print(
+                    f"ERROR: Invalid palette {Colors.PaletteFileName}",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+        # Delimiter frames use fixed grays.
+        palette_map["--"] = Colors.RGBvdgrey
+        palette_map["-"] = Colors.RGBdgrey
+        return palette_map
+
+    def store_palette(self) -> None:
+        """Save the color cache to a file if consistent palette is enabled."""
+        if self.consistent_palette_flag:
+            with open(self.PaletteFileName, "w") as f:
+                for name, color in self.palette_map.items():
+                    f.write(f"{name}->{color}\n")
+
+    @staticmethod
+    def name_hash(name: str) -> float:
+        """A pseudorandom scalar in the range ``[0, 1)`` derived from ``name``.
+
+        :param name: the frame name to hash.
+
+        :return: a scalar hash used in mixing RGB color for deterministic
+                 palettes.
+        """
+        # Weight early characters more so colors stay stable across graphs.
+        vector = 0.0
+        weight = 1.0
+        max_val = 1.0
+        mod = 10
+        # Strip optional leading module names before hashing (Perl-style names).
+        name = Colors.NameHashModuleSkip.sub("", name)
+        for c in name:
+            i = ord(c) % mod
+            vector += (i / (mod - 1)) * weight
+            max_val += 1.0 * weight
+            weight *= 0.70
+            mod += 1
+            if mod > 12:
+                break
+        return 1.0 - vector / max_val
+
+    # Here are all the solid-palette callables for each coloring mode.
+    # We deliberately omit docstrings as there is a lot of self-explanatory
+    # functions.
+    @staticmethod
+    def color_hot_hash(name: str) -> str:
+        rb_adjust = Colors.name_hash(name[::-1])
+        return (
+            f"rgb({205 + int(50 * rb_adjust)},"
+            f"{int(230 * Colors.name_hash(name))},"
+            f"{int(55 * rb_adjust)})"
+        )
+
+    @staticmethod
+    def color_hot_random(_: str) -> str:
+        val1 = random.random()
+        val2 = random.random()
+        val3 = random.random()
+        return f"rgb({205 + int(50 * val3)},{int(230 * val1)},{int(55 * val2)})"
+
+    @staticmethod
+    def color_hot(name: str) -> str:
+        random.seed(sum(ord(c) for c in name))
+        value = random.random()
+        return f"rgb({205 + int(50 * value)},{int(230 * value)},{int(55 * value)})"
+
+    @staticmethod
+    def color_mem_hash(name: str) -> str:
+        return (
+            "rgb(0,"
+            f"{190 + int(50 * Colors.name_hash(name[::-1]))},"
+            f"{int(210 * Colors.name_hash(name))})"
+        )
+
+    @staticmethod
+    def color_mem_random(_: str) -> str:
+        val1 = random.random()
+        val2 = random.random()
+        return f"rgb(0,{190 + int(50 * val2)},{int(210 * val1)})"
+
+    @staticmethod
+    def color_mem(name: str) -> str:
+        random.seed(sum(ord(c) for c in name))
+        value = random.random()
+        return f"rgb(0,{190 + int(50 * value)},{int(210 * value)})"
+
+    @staticmethod
+    def color_io_hash(name: str) -> str:
+        red_green = 80 + int(60 * Colors.name_hash(name))
+        return (
+            f"rgb({red_green}," f"{red_green}," f"{190 + int(55 * Colors.name_hash(name[::-1]))})"
+        )
+
+    @staticmethod
+    def color_io_random(_: str) -> str:
+        red_green = 80 + int(60 * random.random())
+        return f"rgb({red_green},{red_green},{190 + int(55 * random.random())})"
+
+    @staticmethod
+    def color_io(name: str) -> str:
+        random.seed(sum(ord(c) for c in name))
+        value = random.random()
+        red_green = 80 + int(60 * value)
+        return f"rgb({red_green},{red_green},{190 + int(55 * value)})"
+
+    @staticmethod
+    def color_red_hash(name: str) -> str:
+        value = Colors.name_hash(name)
+        green_blue = 50 + int(80 * value)
+        return f"rgb({200 + int(55 * value)},{green_blue},{green_blue})"
+
+    @staticmethod
+    def color_red_random(_: str) -> str:
+        value = random.random()
+        green_blue = 50 + int(80 * value)
+        return f"rgb({200 + int(55 * value)},{green_blue},{green_blue})"
+
+    @staticmethod
+    def color_red(name: str) -> str:
+        random.seed(sum(ord(c) for c in name))
+        value = random.random()
+        green_blue = 50 + int(80 * value)
+        return f"rgb({200 + int(55 * value)},{green_blue},{green_blue})"
+
+    @staticmethod
+    def color_green_hash(name: str) -> str:
+        value = Colors.name_hash(name)
+        red_blue = 50 + int(60 * value)
+        return f"rgb({red_blue},{200 + int(55 * value)},{red_blue})"
+
+    @staticmethod
+    def color_green_random(_: str) -> str:
+        value = random.random()
+        red_blue = 50 + int(60 * value)
+        return f"rgb({red_blue},{200 + int(55 * value)},{red_blue})"
+
+    @staticmethod
+    def color_green(name: str) -> str:
+        random.seed(sum(ord(c) for c in name))
+        value = random.random()
+        red_blue = 50 + int(60 * value)
+        return f"rgb({red_blue},{200 + int(55 * value)},{red_blue})"
+
+    @staticmethod
+    def color_blue_hash(name: str) -> str:
+        value = Colors.name_hash(name)
+        red_green = 80 + int(60 * value)
+        return f"rgb({red_green},{red_green},{205 + int(50 * value)})"
+
+    @staticmethod
+    def color_blue_random(_: str) -> str:
+        value = random.random()
+        red_green = 80 + int(60 * value)
+        return f"rgb({red_green},{red_green},{205 + int(50 * value)})"
+
+    @staticmethod
+    def color_blue(name: str) -> str:
+        random.seed(sum(ord(c) for c in name))
+        value = random.random()
+        red_green = 80 + int(60 * value)
+        return f"rgb({red_green},{red_green},{205 + int(50 * value)})"
+
+    @staticmethod
+    def color_yellow_hash(name: str) -> str:
+        value = Colors.name_hash(name)
+        red_green = 175 + int(55 * value)
+        return f"rgb({red_green},{red_green},{50 + int(20 * value)})"
+
+    @staticmethod
+    def color_yellow_random(_: str) -> str:
+        value = random.random()
+        red_green = 175 + int(55 * value)
+        return f"rgb({red_green},{red_green},{50 + int(20 * value)})"
+
+    @staticmethod
+    def color_yellow(name: str) -> str:
+        random.seed(sum(ord(c) for c in name))
+        value = random.random()
+        red_green = 175 + int(55 * value)
+        return f"rgb({red_green},{red_green},{50 + int(20 * value)})"
+
+    @staticmethod
+    def color_purple_hash(name: str) -> str:
+        value = Colors.name_hash(name)
+        red_blue = 190 + int(65 * value)
+        return f"rgb({red_blue},{80 + int(60 * value)},{red_blue})"
+
+    @staticmethod
+    def color_purple_random(_: str) -> str:
+        value = random.random()
+        red_blue = 190 + int(65 * value)
+        return f"rgb({red_blue},{80 + int(60 * value)},{red_blue})"
+
+    @staticmethod
+    def color_purple(name: str) -> str:
+        random.seed(sum(ord(c) for c in name))
+        value = random.random()
+        red_blue = 190 + int(65 * value)
+        return f"rgb({red_blue},{80 + int(60 * value)},{red_blue})"
+
+    @staticmethod
+    def color_aqua_hash(name: str) -> str:
+        value = Colors.name_hash(name)
+        green_blue = 165 + int(55 * value)
+        return f"rgb({50 + int(60 * value)},{green_blue},{green_blue})"
+
+    @staticmethod
+    def color_aqua_random(_: str) -> str:
+        value = random.random()
+        green_blue = 165 + int(55 * value)
+        return f"rgb({50 + int(60 * value)},{green_blue},{green_blue})"
+
+    @staticmethod
+    def color_aqua(name: str) -> str:
+        random.seed(sum(ord(c) for c in name))
+        value = random.random()
+        green_blue = 165 + int(55 * value)
+        return f"rgb({50 + int(60 * value)},{green_blue},{green_blue})"
+
+    @staticmethod
+    def color_orange_hash(name: str) -> str:
+        red_green_coeff = int(65 * Colors.name_hash(name))
+        return f"rgb({190 + red_green_coeff},{90 + red_green_coeff},0)"
+
+    @staticmethod
+    def color_orange_random(_: str) -> str:
+        red_green_coeff = int(65 * random.random())
+        return f"rgb({190 + red_green_coeff},{90 + red_green_coeff},0)"
+
+    @staticmethod
+    def color_orange(name: str) -> str:
+        random.seed(sum(ord(c) for c in name))
+        red_green_coeff = int(65 * random.random())
+        return f"rgb({190 + red_green_coeff},{90 + red_green_coeff},0)"
+
+    @staticmethod
+    def color_unknown(_: str) -> str:
+        return "rgb(0,0,0)"
+
+    def color_java(self, name: str) -> str:
+        """Color a frame related to Java programs.
+
+        This method handles both annotations (_[j], _[i], ...; which should be
+        accurate) and input that lacks any annotations. When annotations
+        are missing, we fall back to heuristics and match on java|org|com, etc.
+
+        :param name: a Java-ish frame name with optional ``_[kij]`` suffixes.
+
+        :return: an RGB color string for the given ``name``.
+        """
+        if name.endswith("_[j]"):  # JIT.
+            color_palette = Colors.PaletteIdx.GREEN
+        elif name.endswith("_[i]"):  # Inline.
+            color_palette = Colors.PaletteIdx.AQUA
+        elif ":::" in name or self.JavaRegex.search(name):  # Likely Java.
+            color_palette = Colors.PaletteIdx.GREEN
+        elif "::" in name:  # C++.
+            color_palette = Colors.PaletteIdx.YELLOW
+        elif name.endswith("_[k]"):  # Kernel.
+            color_palette = Colors.PaletteIdx.ORANGE
+        else:  # System.
+            color_palette = Colors.PaletteIdx.RED
+        return self.color_functions[color_palette](name)
+
+    def color_perl(self, name: str) -> str:
+        """Color a frame related to Perl programs.
+
+        :param name: a Perl-ish frame name with an optional ``_[k]`` suffix.
+
+        :return: an RGB color string for the given ``name``.
+        """
+        if "::" in name:  # C++.
+            color_palette = Colors.PaletteIdx.YELLOW
+        elif self.PerlRegex.search(name):  # Perl.
+            color_palette = Colors.PaletteIdx.GREEN
+        elif name.endswith("_[k]"):  # Kernel.
+            color_palette = Colors.PaletteIdx.ORANGE
+        else:  # System.
+            color_palette = Colors.PaletteIdx.RED
+        return self.color_functions[color_palette](name)
+
+    def color_js(self, name: str) -> str:
+        """Color a frame related to JavaScript programs.
+
+        This method handles both annotations (_[j], _[i], ...; which should be
+        accurate) and input that lacks any annotations. When annotations are
+        missing, we fall back to heuristics and match on "/" with a ".js", etc.
+
+        :param name: a JS-ish frame name with an optional ``_[jk]`` suffix.
+
+        :return: an RGB color string for the given ``name``.
+        """
+        if name.endswith("_[j]"):  # JIT.
+            if "/" in name:
+                color_palette = Colors.PaletteIdx.GREEN  # Source file path.
+            else:
+                color_palette = Colors.PaletteIdx.AQUA  # Built-in.
+        elif "::" in name:  # C++.
+            color_palette = Colors.PaletteIdx.YELLOW
+        elif self.JSRegex.search(name):  # Script path with extension.
+            color_palette = Colors.PaletteIdx.GREEN
+        elif ":" in name:  # Built-in label with colon.
+            color_palette = Colors.PaletteIdx.AQUA
+        elif name == " ":  # A missing symbol placeholder.
+            color_palette = Colors.PaletteIdx.GREEN
+        elif name.endswith("_[k]"):  # Kernel.
+            color_palette = Colors.PaletteIdx.ORANGE
+        else:  # System.
+            color_palette = Colors.PaletteIdx.RED
+        return self.color_functions[color_palette](name)
+
+    def color_chain(self, name: str) -> str:
+        """Color an off-CPU frame.
+
+        :param name: a frame name from an off-CPU profile.
+
+        :return: an RGB color string for the given ``name``.
+        """
+        if "_[w]" in name:  # A waker frame.
+            return self.color_functions[Colors.PaletteIdx.AQUA](name)
+        # An off-CPU stack frame.
+        return self.color_functions[Colors.PaletteIdx.BLUE](name)
+
+    @staticmethod
+    def color_scale(delta: float, max_delta: float) -> str:
+        """Color a frame using a red/blue color scale.
+
+        This method is used to color frames in differential flame graphs.
+
+        :param delta: a delta value in the interval ``[-max_delta, max_delta]``.
+        :param max_delta: the largest delta observed in the pair of profiles.
+
+        :return: an RGB color string for the given ``delta`` value.
+        """
+        r, g, b = 255, 255, 255
+        if delta > 0:
+            g = b = int(210 * (max_delta - delta) / max_delta)
+        elif delta < 0:
+            r = g = int(210 * (max_delta + delta) / max_delta)
+        return f"rgb({r},{g},{b})"
+
+    def _getitem_cached(self, name: str) -> str:
+        """Use cache to obtain/store frame color.
+
+        Do not use this directly, it is one of two __getitem__ variants that
+        are chosen programmatically during runtime.
+
+        :param name: the frame name to color.
+
+        :return: a (possibly cached) RGB color string for the given ``name``.
+        """
+        try:
+            return self.palette_map[name]
+        except KeyError:
+            # Known mypy issue: https://github.com/python/mypy/issues/17438.
+            new_color = self.color_fn(name)  # type: ignore
+            self.palette_map[name] = new_color
+            return new_color
+
+    def _getitem_random(self, name: str) -> str:
+        """Compute a new random color for the frame name.
+
+        Do not use this directly, it is one of two __getitem__ variants that
+        are chosen programmatically during runtime.
+
+        :param name: the frame name to color.
+
+        :return: a new RGB color string for the given ``name``.
+        """
+        # Handle the delimiter frames.
+        if name == "--":
+            return Colors.RGBvdgrey
+        if name == "-":
+            return Colors.RGBdgrey
+        # Known mypy issue: https://github.com/python/mypy/issues/17438.
+        return self.color_fn(name)  # type: ignore
+
+
+#### SECTION: SVG UTILITIES
+# A collection of helper functions related to constructing the flame graph SVG.
+# Strings are accumulated in a list rather than concatenated to avoid costly
+# string concatenations.
+
+
+def create_error_svg(settings: Settings) -> str:
+    """Return a minimal SVG that reports missing or invalid folded profile.
+
+    :param settings: rendering and processing options.
+
+    :return: an SVG document string containing an error message.
+    """
+    image_height = int(settings.font_size * 5)
+    # Here we concatenate the strings directly as they are quite short.
+    return (
+        create_svg_header(
+            settings.image_width,
+            image_height,
+            settings.encoding,
+            settings.notes_text,
+        )
+        + create_svg_text(
+            None,
+            int(settings.image_width / 2),
+            settings.font_size * 2,
+            "ERROR: No valid input provided to flamegraph.py.",
+        )
+        + "</svg>\n"
+    )
+
+
+def create_svg_without_frames(settings: Settings, geometry: Geometry, colors: Colors) -> list[str]:
+    """Build the SVG header, JS/CSS components, and canvas.
+
+    The resulting string is not a valid SVG document as it is missing the
+    terminating markup. It also contains no frames.
+
+    :param settings: rendering and processing options.
+    :param geometry: rendering geometry for the SVG layout.
+    :param colors: coloring options for the SVG.
+
+    :return: a collection of strings representing the incomplete SVG.
+    """
+    return [
+        create_svg_header(
+            geometry.image_width,
+            geometry.image_height,
+            settings.encoding,
+            settings.notes_text,
+        ),
+        create_svg_js_css(settings, colors.bg_color_1, colors.bg_color_2, geometry.title_size),
+        (
+            f'<rect x="0" y="0" width="{settings.image_width}"'
+            f' height="{geometry.image_height}" fill="url(#background)" />\n'
+        ),
+        create_svg_text(
+            "title",
+            int(settings.image_width / 2),
+            settings.font_size * 2,
+            settings.title,
+        ),
+        (
+            create_svg_text(
+                "subtitle",
+                int(settings.image_width / 2),
+                settings.font_size * 4,
+                settings.subtitle,
+            )
+            if settings.subtitle
+            else ""
+        ),
+        create_svg_text(
+            "details",
+            Geometry.XPad1,
+            geometry.image_height - (geometry.y_pad_2 / 2),
+            " ",
+        ),
+        create_svg_text(
+            "unzoom",
+            Geometry.XPad1,
+            settings.font_size * 2,
+            "Reset Zoom",
+            'class="hide"',
+        ),
+        create_svg_text(
+            "search",
+            settings.image_width - Geometry.XPad1 - 100,
+            settings.font_size * 2,
+            "Search",
+        ),
+        create_svg_text(
+            "ignorecase",
+            settings.image_width - Geometry.XPad1 - 16,
+            settings.font_size * 2,
+            "ic",
+        ),
+        create_svg_text(
+            "matchedhover",
+            settings.image_width - geometry.x_pad_2 - 131,
+            geometry.image_height - (geometry.y_pad_2 / 2),
+            " ",
+        ),
+        create_svg_text(
+            "matched",
+            settings.image_width - geometry.x_pad_2 - 105,
+            geometry.image_height - 4,
+            " ",
+        ),
+    ]
+
+
+def create_svg_header(img_width: int, img_height: int, encoding: str | None, notes: str) -> str:
+    """Create an SVG header string.
+
+    :param img_width: the SVG width.
+    :param img_height: the SVG height.
+    :param encoding: optional XML encoding.
+    :param notes: optional debugging notes to embed into the SVG document.
+
+    :return: an SVG header string.
+    """
+    enc_attr = f' encoding="{encoding}"' if encoding else ""
+    return f"""<?xml version="1.0"{enc_attr} standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" width="{img_width}" height="{img_height}" onload="init(evt)" viewBox="0 0 {img_width} {img_height}" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<!-- Flame graph stack visualization. See https://github.com/brendangregg/FlameGraph for latest version, and http://www.brendangregg.com/flamegraphs.html for examples. -->
+<!-- NOTES: {notes} -->
+"""
+
+
+def create_svg_text(id_attr: str | None, x: float, y: float, str_val: str, extra: str = "") -> str:
+    """Create an SVG ``<text>`` element.
+
+    :param id_attr: an optional DOM ``id`` attribute.
+    :param x: an anchor X-coordinate.
+    :param y: an anchor Y-coordinate.
+    :param str_val: the content of the ``<text>`` element.
+    :param extra: additional ``<text>`` attributes.
+
+    :return: a single ``<text>...</text>`` fragment.
+    """
+    id_str = f'id="{id_attr}"' if id_attr else ""
+    return f'<text {id_str} x="{x:.2f}" y="{y:.2f}" {extra}>{str_val}</text>\n'
+
+
+def create_svg_js_css(settings: Settings, bg_color_1: str, bg_color_2: str, title_size: int) -> str:
+    """Create an SVG stylesheet and JS scripts.
+
+    The scripts implement operations such as zoom/unzoom, search, hover, etc.
+
+    :param settings: rendering and processing options.
+    :param bg_color_1: gradient start color (top of the canvas).
+    :param bg_color_2: gradient end color (bottom of the canvas).
+    :param title_size: the title element font size.
+
+    :return: an SVG stylesheet and JS scripts.
+    """
+    return f"""<defs>
+    <linearGradient id="background" y1="0" y2="1" x1="0" x2="0" >
+        <stop stop-color="{bg_color_1}" offset="5%" />
+        <stop stop-color="{bg_color_2}" offset="95%" />
+    </linearGradient>
+</defs>
+<style type="text/css">
+    text {{ font-family:{settings.font_type}; font-size:{settings.font_size}px; fill:{Colors.RGBblack}; }}
+    #search, #ignorecase {{ opacity:0.1; cursor:pointer; }}
+    #search:hover, #search.show, #ignorecase:hover, #ignorecase.show {{ opacity:1; }}
+    #subtitle {{ text-anchor:middle; font-color:{Colors.RGBvdgrey}; }}
+    #title {{ text-anchor:middle; font-size:{title_size}px}}
+    #unzoom {{ cursor:pointer; }}
+    #frames > *:hover {{ stroke:black; stroke-width:0.5; cursor:pointer; }}
+    .hide {{ display:none; }}
+    .parent {{ opacity:0.5; }}
+</style>
+<script type="text/ecmascript">
+<![CDATA[
+    "use strict";
+    var details, searchbtn, unzoombtn, matchedtxt, svg, searching, currentSearchTerm, ignorecase, ignorecaseBtn;
+    var matchedHoverTxt, hoverSearchTerm;
+    function init(evt) {{
+        details = document.getElementById("details").firstChild;
+        searchbtn = document.getElementById("search");
+        ignorecaseBtn = document.getElementById("ignorecase");
+        unzoombtn = document.getElementById("unzoom");
+        matchedtxt = document.getElementById("matched");
+        matchedHoverTxt = document.getElementById("matchedhover");
+        svg = document.getElementsByTagName("svg")[0];
+        searching = 0;
+        currentSearchTerm = null;
+        hoverSearchTerm = null;
+    }}
+
+    // event listeners
+    window.addEventListener("click", function(e) {{
+        var target = find_group(e.target);
+        if (target) {{
+            if (target.nodeName == "a") {{
+                if (e.ctrlKey === false) return;
+                e.preventDefault();
+            }}
+            if (target.classList.contains("parent")) unzoom(true);
+            zoom(target);
+            if (!document.querySelector('.parent')) {{
+                unzoombtn.classList.add("hide");
+                return;
+            }}
+        }}
+        else if (e.target.id == "unzoom") clearzoom();
+        else if (e.target.id == "search") search_prompt();
+        else if (e.target.id == "ignorecase") toggle_ignorecase();
+    }}, false)
+
+    // mouse-over for info
+    // show
+    window.addEventListener("mouseover", function(e) {{
+        var target = find_group(e.target);
+        if (target) details.nodeValue = "{settings.name_type} " + g_to_text(target);
+    }}, false)
+
+    // clear
+    window.addEventListener("mouseout", function(e) {{
+        var target = find_group(e.target);
+        if (target) details.nodeValue = ' ';
+    }}, false)
+
+    // functions
+    function find_child(node, selector) {{
+        var children = node.querySelectorAll(selector);
+        if (children.length) return children[0];
+    }}
+    function find_group(node) {{
+        var parent = node.parentElement;
+        if (!parent) return;
+        if (parent.id == "frames") return node;
+        return find_group(parent);
+    }}
+    function orig_save(e, attr, val) {{
+        if (e.attributes["_orig_" + attr] != undefined) return;
+        if (e.attributes[attr] == undefined) return;
+        if (val == undefined) val = e.attributes[attr].value;
+        e.setAttribute("_orig_" + attr, val);
+    }}
+    function orig_load(e, attr) {{
+        if (e.attributes["_orig_"+attr] == undefined) return;
+        e.attributes[attr].value = e.attributes["_orig_" + attr].value;
+        e.removeAttribute("_orig_"+attr);
+    }}
+    function g_to_text(e) {{
+        var text = find_child(e, "title").firstChild.nodeValue;
+        return (text)
+    }}
+    function g_to_func(e) {{
+        var func = g_to_text(e);
+        // if there's any manipulation we want to do to the function
+        // name before it's searched, do it here before returning.
+        return (func);
+    }}
+    function update_text(e) {{
+        var r = find_child(e, "rect");
+        var t = find_child(e, "text");
+        var w = parseFloat(r.attributes.width.value) -3;
+        var txt = find_child(e, "title").textContent.replace(/\\([^(]*\\)$/,"");
+        t.attributes.x.value = parseFloat(r.attributes.x.value) + 3;
+
+        // Smaller than this size won't fit anything
+        if (w < 2 * {settings.font_size} * {settings.font_width}) {{
+            t.textContent = "";
+            return;
+        }}
+
+        t.textContent = txt;
+        var sl = t.getSubStringLength(0, txt.length);
+        // check if only whitespace or if we can fit the entire string into width w
+        if (/^ *$/.test(txt) || sl < w)
+            return;
+
+        // this isn't perfect, but gives a good starting point
+        // and avoids calling getSubStringLength too often
+        var start = Math.floor((w/sl) * txt.length);
+        for (var x = start; x > 0; x = x-2) {{
+            if (t.getSubStringLength(0, x + 2) <= w) {{
+                t.textContent = txt.substring(0, x) + "..";
+                return;
+            }}
+        }}
+        t.textContent = "";
+    }}
+    function formatWithSuffix(num) {{
+        const suffixes = ['', 'K', 'M', 'G', 'T', 'P', 'E'];
+        var i = 0;
+
+        while (num >= 1000 && i < suffixes.length - 1) {{
+            num /= 1000;
+            i++;
+        }}
+
+        // Format to max 3 decimal places, trimming trailing zeroes
+        var formatted = num.toFixed(3).replace(/\\.?0+$/, '');
+
+        return formatted + suffixes[i];
+    }}
+    function parseFormattedSuffix(str) {{
+        const units = {{ '': 1, K: 1e3, M: 1e6, G: 1e9, T: 1e12, P: 1e15, E: 1e18 }};
+        const suffixMatch = str.match(/\\(([\\d.]+)([KMGTPE]?) .*/);
+        return parseFloat(suffixMatch[1]) * (units[suffixMatch[2].toUpperCase()] || 1);
+    }}
+
+    // zoom
+    function zoom_reset(e) {{
+        if (e.attributes != undefined) {{
+            orig_load(e, "x");
+            orig_load(e, "width");
+        }}
+        if (e.childNodes == undefined) return;
+        for (var i = 0, c = e.childNodes; i < c.length; i++) {{
+            zoom_reset(c[i]);
+        }}
+    }}
+    function zoom_child(e, x, ratio) {{
+        if (e.attributes != undefined) {{
+            if (e.attributes.x != undefined) {{
+                orig_save(e, "x");
+                e.attributes.x.value = (parseFloat(e.attributes.x.value) - x - {Geometry.XPad1}) * ratio + {Geometry.XPad1};
+                if (e.tagName == "text")
+                    e.attributes.x.value = find_child(e.parentNode, "rect[x]").attributes.x.value + 3;
+            }}
+            if (e.attributes.width != undefined) {{
+                orig_save(e, "width");
+                e.attributes.width.value = parseFloat(e.attributes.width.value) * ratio;
+            }}
+        }}
+
+        if (e.childNodes == undefined) return;
+        for (var i = 0, c = e.childNodes; i < c.length; i++) {{
+            zoom_child(c[i], x - {Geometry.XPad1}, ratio);
+        }}
+    }}
+    function zoom_parent(e) {{
+        if (e.attributes) {{
+            if (e.attributes.x != undefined) {{
+                orig_save(e, "x");
+                e.attributes.x.value = {Geometry.XPad1};
+            }}
+            if (e.attributes.width != undefined) {{
+                orig_save(e, "width");
+                e.attributes.width.value = parseInt(svg.width.baseVal.value) - ({Geometry.XPad1} * 2);
+            }}
+        }}
+        if (e.childNodes == undefined) return;
+        for (var i = 0, c = e.childNodes; i < c.length; i++) {{
+            zoom_parent(c[i]);
+        }}
+    }}
+    function zoom(node) {{
+        var attr = find_child(node, "rect").attributes;
+        var width = parseFloat(attr.width.value);
+        var xmin = parseFloat(attr.x.value);
+        var xmax = parseFloat(xmin + width);
+        var ymin = parseFloat(attr.y.value);
+        var ratio = (svg.width.baseVal.value - 2 * {Geometry.XPad1}) / width;
+
+        // XXX: Workaround for JavaScript float issues (fix me)
+        var fudge = 0.0001;
+
+        unzoombtn.classList.remove("hide");
+
+        var el = document.getElementById("frames").children;
+        for (var i = 0; i < el.length; i++) {{
+            var e = el[i];
+            var a = find_child(e, "rect").attributes;
+            var ex = parseFloat(a.x.value);
+            var ew = parseFloat(a.width.value);
+            var upstack;
+            // Is it an ancestor
+            if ({1 if settings.inverted else 0} == 0) {{
+                upstack = parseFloat(a.y.value) > ymin;
+            }} else {{
+                upstack = parseFloat(a.y.value) < ymin;
+            }}
+            if (upstack) {{
+                // Direct ancestor
+                if (ex <= xmin && (ex+ew+fudge) >= xmax) {{
+                    e.classList.add("parent");
+                    zoom_parent(e);
+                    update_text(e);
+                }}
+                // not in current path
+                else
+                    e.classList.add("hide");
+            }}
+            // Children maybe
+            else {{
+                // no common path
+                if (ex < xmin || ex + fudge >= xmax) {{
+                    e.classList.add("hide");
+                }}
+                else {{
+                    zoom_child(e, xmin, ratio);
+                    update_text(e);
+                }}
+            }}
+        }}
+        search();
+    }}
+    function unzoom(dont_update_text) {{
+        unzoombtn.classList.add("hide");
+        var el = document.getElementById("frames").children;
+        for(var i = 0; i < el.length; i++) {{
+            el[i].classList.remove("parent");
+            el[i].classList.remove("hide");
+            zoom_reset(el[i]);
+            if(!dont_update_text) update_text(el[i]);
+        }}
+        search();
+    }}
+    function clearzoom() {{
+        unzoom();
+    }}
+
+    // search
+    function toggle_ignorecase() {{
+        ignorecase = !ignorecase;
+        if (ignorecase) {{
+            ignorecaseBtn.classList.add("show");
+        }} else {{
+            ignorecaseBtn.classList.remove("show");
+        }}
+        reset_search();
+        search();
+    }}
+    function reset_search() {{
+        var el = document.querySelectorAll("#frames rect");
+        for (var i = 0; i < el.length; i++) {{
+            orig_load(el[i], "fill")
+        }}
+        searching = 0;
+        currentSearchTerm = null;
+        searchbtn.classList.remove("show");
+        searchbtn.firstChild.nodeValue = "Search"
+        matchedtxt.classList.add("hide");
+        matchedtxt.firstChild.nodeValue = ""
+    }}
+
+    function reset_search_hover() {{
+        var el = document.getElementById("frames").children;
+        var re = new RegExp(currentSearchTerm, ignorecase ? 'i' : '');
+        for (var i = 0; i < el.length; i++) {{
+            var func = g_to_func(el[i]);
+            var rect = find_child(el[i], "rect");
+            if (rect.attributes.fill.value == "{Colors.RGBhover}") {{
+                if (func.match(re)) {{
+                    rect.attributes.fill.value = "{Colors.RGBsearch}";
+                }} else {{
+                    orig_load(rect, "fill");
+                }}
+            }}
+
+        }}
+        hoverSearchTerm = null;
+        matchedHoverTxt.classList.add("hide");
+        matchedHoverTxt.firstChild.nodeValue = ""
+    }}
+    function search_prompt() {{
+        if (!searching) {{
+            var term = prompt("Enter a search term (regexp " +
+                "allowed, eg: ^ext4_)"
+                + (ignorecase ? ", ignoring case" : "")
+                + "\\nPress Ctrl-i to toggle case sensitivity", "");
+            if (term != null) search(term);
+        }} else {{
+            reset_search();
+        }}
+    }}
+    function search(term) {{
+        if (term) currentSearchTerm = term;
+        var re = new RegExp(currentSearchTerm, ignorecase ? 'i' : '');
+
+        var res = find_frames(re, false);
+        if (!searching)
+            return;
+        searchbtn.classList.add("show");
+        searchbtn.firstChild.nodeValue = "Reset Search";
+
+        // display matched percent
+        var matched = calculate_matched(res.matches, res.maxwidth);
+        matchedtxt.classList.remove("hide");
+        matchedtxt.firstChild.nodeValue = "Matched (search): " + matched.totalSamples + " {settings.count_name}, " + matched.pct + "%";
+    }}
+    function search_hover(term) {{
+        if (term) hoverSearchTerm = term;
+
+        var res = find_frames(term, true);
+
+        // display matched percent
+        var matched = calculate_matched(res.matches, res.maxwidth);
+        matchedHoverTxt.classList.remove("hide");
+        matchedHoverTxt.firstChild.nodeValue = "Matched (mouseover): " + matched.totalSamples + " {settings.count_name}, " + matched.pct + "%";
+    }}
+    // The func_expr may be either a regex or a simple string
+    function find_frames(func_expr, is_hover) {{
+        var el = document.getElementById("frames").children;
+        var matches = new Object();
+        var maxwidth = 0;
+        for (var i = 0; i < el.length; i++) {{
+            var e = el[i];
+            var func = g_to_func(e);
+            var rect = find_child(e, "rect");
+            if (func == null || rect == null)
+                continue;
+
+            // Save max width. Only works as we have a root frame
+            var w = parseFloat(rect.attributes.width.value);
+            if (w > maxwidth)
+                maxwidth = w;
+
+            if ((is_hover && func.startsWith(func_expr)) || (!is_hover && func.match(func_expr))) {{
+                // highlight
+                var x = parseFloat(rect.attributes.x.value);
+                orig_save(rect, "fill");
+                rect.attributes.fill.value = is_hover ? "{Colors.RGBhover}" : "{Colors.RGBsearch}";
+
+                // remember matches
+                const absSamples = parseFormattedSuffix(func);
+                if (matches[x] == undefined) {{
+                    matches[x] = [w, absSamples];
+                }} else {{
+                    if (w > matches[x][0]) {{
+                        // overwrite with parent
+                        matches[x] = [w, absSamples];
+                    }}
+                }}
+                if (!is_hover) {{
+                    searching = 1;
+                }}
+            }}
+        }}
+        return {{ maxwidth: maxwidth, matches: matches }};
+    }}
+    function calculate_matched(matches, maxwidth) {{
+        // calculate absolute and percent matched, excluding vertical overlap
+        var count = 0;
+        var totalSamples = 0;
+        var lastx = -1;
+        var lastw = 0;
+        var keys = Array();
+        for (k in matches) {{
+            if (matches.hasOwnProperty(k))
+                keys.push(k);
+        }}
+        // sort the matched frames by their x location
+        // ascending, then width descending
+        keys.sort(function(a, b){{
+            return a - b;
+        }});
+        // Step through frames saving only the biggest bottom-up frames
+        // thanks to the sort order. This relies on the tree property
+        // where children are always smaller than their parents.
+        var fudge = 0.0001;	// JavaScript floating point
+        for (var k in keys) {{
+            var x = parseFloat(keys[k]);
+            var [w, samples] = matches[keys[k]];
+            if (x >= lastx + lastw - fudge) {{
+                // compute absolute matched
+                totalSamples += samples;
+                count += w;
+                lastx = x;
+                lastw = w;
+            }}
+        }}
+        // compute matched percent
+        var pct = 100 * count / maxwidth;
+        if (pct != 100) pct = pct.toFixed(1)
+        return {{ pct: pct, totalSamples: formatWithSuffix(totalSamples) }};
+    }}
+]]>
+</script>
+    """
+
+
+#### SECTION: FILE PARSING
+# To parse a folded file, use the 'parse_folded_profile' function which selects
+# the correct parsing function based on the input parameters and folded file
+# content (diff or not). The "private" parsing functions (with a leading
+# underscore) are specialized for concrete folded profile types and are not
+# expected to be used directly.
+#
+# Note that the parsing loop is one of the two hot loops in the program.
+# To optimize it as much as possible, we crafted specialized parsing functions
+# for each of the four input variants (diff/no-diff data and normal/reverse
+# stacks) to avoid unnecessary inner branches and function calls.
+
+
+class FoldedData:
+    """Parsed non-differential folded profile.
+
+    The ``data`` are intentionally stored as an Iterable to facilitate
+    compatible interface with lazy parsers.
+
+    :ivar data: an iterable of parsed ``(stack, count)`` rows.
+    :ivar total: the sum of all counts.
+    :ivar is_diff: always ``False`` for static typing discrimination.
+    """
+
+    __slots__ = "data", "total", "is_diff"
+
+    def __init__(self, data: Iterable[tuple[str, float]], total: float) -> None:
+        """Initialize an object.
+
+        :param data: an iterable of ``(stack, count)`` rows.
+        :param total: the sum of all counts.
+        """
+        self.data: Iterable[tuple[str, float]] = data
+        self.total: float = total
+        self.is_diff: Literal[False] = False
+
+
+class FoldedDiffData:
+    """Parsed differential folded profile.
+
+    The ``data`` are intentionally stored as an Iterable to facilitate
+    compatible interface with lazy parsers, e.g., the lazy parser in
+    difffolded.py.
+
+    See: https://www.brendangregg.com/blog/2014-11-09/differential-flame-graphs.html
+
+    :ivar data: an iterable of ``(stack, baseline count, target count)`` rows.
+    :ivar total: the sum of target counts (corresponds to how the Perl script
+          interprets the 'total' consumption in differential folded profiles).
+    :ivar is_diff: always ``True`` for static typing discrimination.
+    """
+
+    __slots__ = "data", "total", "is_diff"
+
+    def __init__(self, data: Iterable[tuple[str, float, float]], total: float) -> None:
+        """Initialize an object.
+
+        :param data: an iterable of ``(stack, baseline count, target count)``.
+        :param total: the sum of all counts.
+        """
+        self.data: Iterable[tuple[str, float, float]] = data
+        self.total: float = total
+        self.is_diff: Literal[True] = True
+
+
+def parse_folded_profile(
+    input_file: Path, is_flame_chart: bool, is_stack_reverse: bool
+) -> FoldedData | FoldedDiffData:
+    """Parse a folded profile file.
+
+    This is the top-level parsing function which determines the type of the
+    folded profile and selects the appropriate optimized parsing function for
+    the type, i.e., (non-)differential, forward or reversed stacks.
+
+    :param input_file: the path to the folded profile.
+    :param is_flame_chart: we are drawing a flame chart; the parsing functions
+           should preserve the order of the records instead of sorting them as
+           in the case of flame graphs.
+    :param is_stack_reverse: the stacks in the folded profile are in the
+           callee-to-caller (instead of caller-to-callee) order.
+
+    :return: the parsed (differential) folded profile.
+    """
+    result: FoldedData | FoldedDiffData
+    ignored: int = 0
+    with open(input_file, "r") as input_handle:
+        # Peek column count from the first line.
+        _, *counts = input_handle.readline().split()
+        input_handle.seek(0)
+        is_diff = len(counts) == 2
+        # Select differential vs single-column and reversed-stack parsers.
+        parse_variants: dict[
+            tuple[bool, bool],
+            Callable[[TextIO, bool], tuple[FoldedData, int]]
+            | Callable[[TextIO, bool], tuple[FoldedDiffData, int]],
+        ] = {
+            (False, False): _parse_folded,
+            (False, True): _parse_reverse_folded,
+            (True, False): _parse_differential_folded,
+            (True, True): _parse_reverse_differential_folded,
+        }
+        parse_fn = parse_variants[is_diff, is_stack_reverse]
+        result, ignored = parse_fn(input_handle, is_flame_chart)
+    # Report possible input format violations.
+    if ignored:
+        print(
+            f"WARNING: Ignored {ignored} lines with invalid format",
+            file=sys.stderr,
+        )
+    return result
+
+
+def validate_profile_total(profile: FoldedData | FoldedDiffData, settings: Settings) -> int:
+    """Validate totals, emit diagnostics, and return the effective ``total``.
+
+    The ``total`` value obtained from simply summing the counts might need
+    to be adjusted based on the input parameters.
+
+    :param profile: a parsed folded profile.
+    :param settings: rendering and processing options.
+
+    :return: the possibly adjusted ``total`` value.
+    """
+    if profile.total == 0:
+        print("ERROR: No stack counts found", file=sys.stderr)
+        print(create_error_svg(settings))
+        sys.exit(2)
+
+    if settings.count_name == "samples":
+        # Warn only while the default ``samples`` label is still in use.
+        if profile.total < 100:
+            print(
+                f"WARNING: Stack count is low ({profile.total}). Did something" " go wrong?",
+                file=sys.stderr,
+            )
+
+    if settings.total == -1:
+        return int(profile.total)
+    if -1 < settings.total < profile.total:
+        if settings.total / profile.total > 0.02:
+            # Warn only if the difference is significant.
+            print(
+                f"WARNING: Specified --total {settings.total} is less than"
+                f" actual total {profile.total}. Ignoring the --total"
+                " argument.",
+                file=sys.stderr,
+            )
+        return int(profile.total)
+    return settings.total
+
+
+def _parse_folded(input_handle: TextIO, is_flame_chart: bool) -> tuple[FoldedData, int]:
+    """Parse a standard (non-differential) folded profile.
+
+    :param input_handle: a file handle containing a folded profile.
+    :param is_flame_chart: we are drawing a flame chart; the order of the
+           records should be preserved.
+
+    :return: a pair ``(FoldedData, ignored_line_count)``.
+    """
+    data: list[tuple[str, float]] = []
+    total: float = 0.0
+    ignored: int = 0
+
+    # Optimize dot access.
+    str_rsplit = str.rsplit
+    list_append = list.append
+
+    for line in input_handle:
+        try:
+            # Using ``rsplit(..., maxsplit=1)`` is faster because the count
+            # is at the end of line.
+            stack, count_str = str_rsplit(line, maxsplit=1)
+            count = float(count_str)
+            total += count
+            list_append(data, (stack, count))
+        except ValueError:
+            ignored += 1
+
+    # Lexicographic stack order unless we are generating a flame chart.
+    if not is_flame_chart:
+        data.sort(key=itemgetter(0))
+    return FoldedData(data, total), ignored
+
+
+def _parse_reverse_folded(input_handle: TextIO, is_flame_chart: bool) -> tuple[FoldedData, int]:
+    """Parse a standard (non-differential) folded profile with reversed frames.
+
+    The parse function reverses the frames in the stacks such that they are in
+    a unified caller-to-callee order.
+
+    :param input_handle: a file handle containing a folded profile.
+    :param is_flame_chart: we are drawing a flame chart; the order of the
+           records should be preserved.
+
+    :return: a pair ``(FoldedData, ignored_line_count)``.
+    """
+    data: list[tuple[str, float]] = []
+    total: float = 0.0
+    ignored: int = 0
+
+    # Optimize dot access.
+    str_rsplit = str.rsplit
+    str_split = str.split
+    str_join = str.join
+    list_append = list.append
+
+    for line in input_handle:
+        try:
+            stack, count_str = str_rsplit(line, maxsplit=1)
+            count = float(count_str)
+            total += count
+            # TODO: We can defer the reversal until the nodes processing when
+            #  generating flame charts since we do not have to sort the stacks.
+            list_append(data, (str_join(";", reversed(str_split(stack, ";"))), count))
+        except ValueError:
+            ignored += 1
+
+    if not is_flame_chart:
+        data.sort(key=itemgetter(0))
+    return FoldedData(data, total), ignored
+
+
+def _parse_differential_folded(
+    input_handle: TextIO, is_flame_chart: bool
+) -> tuple[FoldedDiffData, int]:
+    """Parse a differential folded profile.
+
+    :param input_handle: a file handle containing a diff folded profile.
+    :param is_flame_chart: we are drawing a flame chart; the order of the
+           records should be preserved.
+
+    :return: ``(FoldedDiffData, ignored_line_count)``.
+    """
+    data: list[tuple[str, float, float]] = []
+    total: float = 0.0
+    ignored: int = 0
+
+    # Optimize dot access.
+    str_rsplit = str.rsplit
+    list_append = list.append
+
+    for line in input_handle:
+        try:
+            stack, count_str, count2_str = str_rsplit(line, maxsplit=2)
+            count = float(count_str)
+            count2 = float(count2_str)
+            total += count2
+            list_append(data, (stack, count, count2))
+        except ValueError:
+            ignored += 1
+
+    if not is_flame_chart:
+        data.sort(key=itemgetter(0))
+    return FoldedDiffData(data, total), ignored
+
+
+def _parse_reverse_differential_folded(
+    input_handle: TextIO, is_flame_chart: bool
+) -> tuple[FoldedDiffData, int]:
+    """Parse a differential folded profile with reversed frames.
+
+    The parse function reverses the frames in the stacks such that they are in
+    a unified caller-to-callee order.
+
+    :param input_handle: a file handle containing a folded diff profile.
+    :param is_flame_chart: we are drawing a flame chart; the order of the
+           records should be preserved.
+
+    :return: a pair ``(FoldedDiffData, ignored_line_count)``.
+    """
+    data: list[tuple[str, float, float]] = []
+    total: float = 0.0
+    ignored: int = 0
+
+    # Optimize dot access.
+    str_rsplit = str.rsplit
+    str_spl = str.split
+    str_join = str.join
+    list_append = list.append
+
+    for line in input_handle:
+        try:
+            stack, count_str, count2_str = str_rsplit(line, maxsplit=2)
+            count = float(count_str)
+            count2 = float(count2_str)
+            total += count2
+            # TODO: We can defer the reversal until the nodes processing when
+            #  generating flame charts since we do not have to sort the stacks.
+            list_append(
+                data,
+                (str_join(";", reversed(str_spl(stack, ";"))), count, count2),
+            )
+        except ValueError:
+            ignored += 1
+
+    if not is_flame_chart:
+        data.sort(key=itemgetter(0))
+    return FoldedDiffData(data, total), ignored
+
+
+#### SECTION: STACKS PROCESSING
+# To process (parsed) folded data, use the 'process_stacks' function which
+# selects the correct processing function based on the folded data type (diff
+# or not) and flamegraph type (CPU or off-CPU chain graphs). The "private"
+# processing functions (with a leading underscore) are not expected to be used
+# directly.
+#
+# The processing loop is the second hot loop in the program. To optimize it as
+# much as possible, we crafted a specialized processing function for each of
+# the four variants and manually inlined the 'flow' helper function found in
+# the original Perl script. This leads to some code duplication but improves
+# performance.
+#
+# Notable implementation changes compared to the Perl version:
+#
+# - The resulting processed nodes are stored in a sequential data structure
+#   (list) instead of a dictionary. An associative structure is unnecessarily
+#   expensive given that the data are later processed sequentially, anyway.
+#
+# - The min_width filtering is done during the processing instead of postponing
+#   it to a second pass through the data. This allows us to skip processing of
+#   potentially long stacks that would be discarded later.
+#
+# - The resulting nodes do not contain the artificial root node.
+#
+# - We do not pop from the 'tmp' dictionary as the number of records is
+#   generally quite low (should roughly correspond to the number of frames in
+#   the resulting flamegraph) and removing the elements incurs a small
+#   performance penalty.
+
+
+class ProcessedNodes:
+    """Stores a sequence of nodes representing non-differential graph frames.
+
+    The sequence contains only nodes that satisfy the 'min_width' threshold and
+    should be thus drawn in the flame graph.
+
+    :ivar nodes: a sequence of ``(name, depth, end_time, start_time)`` records.
+    :ivar max_trace: the length of the longest trace after filtering.
+    :ivar is_diff: always ``False`` for static typing discrimination.
+    """
+
+    __slots__ = "nodes", "max_trace", "is_diff"
+
+    def __init__(self, nodes: Sequence[tuple[str, int, float, float]], max_trace: int) -> None:
+        """Initialize an object.
+
+        :param nodes: a ``(name, depth, end_time, start_time)`` sequence.
+        :param max_trace: the length of the longest trace after filtering.
+        """
+        self.nodes: Sequence[tuple[str, int, float, float]] = nodes
+        self.max_trace: int = max_trace
+        self.is_diff: Literal[False] = False
+
+
+class ProcessedDiffNodes:
+    """Stores a sequence of nodes representing differential graph frames.
+
+    :ivar nodes: a sequence of ``(name, depth, end_time, start_time, delta)``
+          records.
+    :ivar max_trace: the length of the longest trace after filtering.
+    :ivar max_delta: the maximum observed delta between the baseline and
+          target counts of a stack (used for scaling differential hues).
+          Note that compared to ``max_trace`,` this maximum ignores the
+          ``min_width`` filtering to stay consistent with the original Perl
+          script.
+    :ivar is_diff: always ``True`` for static typing discrimination.
+    """
+
+    __slots__ = "nodes", "max_trace", "max_delta", "is_diff"
+
+    def __init__(
+        self,
+        nodes: Sequence[tuple[str, int, float, float, float]],
+        max_trace: int,
+        max_delta: float,
+    ) -> None:
+        """Initialize an object.
+
+        :param nodes: a ``(name, depth, end_time, start_time, delta)`` sequence.
+        :param max_trace: the length of the longest trace after filtering.
+        :param max_delta: the maximum observed delta between the baseline and
+               target counts of a stack (used for scaling differential hues).
+        """
+        self.nodes: Sequence[tuple[str, int, float, float, float]] = nodes
+        self.max_trace: int = max_trace
+        self.max_delta: float = max_delta
+        self.is_diff: Literal[True] = True
+
+
+def process_stacks(
+    profile: FoldedData | FoldedDiffData, settings: Settings
+) -> tuple[ProcessedNodes | ProcessedDiffNodes, Geometry]:
+    """Processes folded stacks into drawable frames.
+
+    This is the top-level processing function which selects the appropriate
+    optimized processing function for the stacks type. Also note that the
+    resulting nodes are already filtered w.r.t. the ``min_width`` parameter.
+
+    :param profile: a parsed folded profile (single or differential).
+    :param settings: rendering and processing options.
+
+    :return: the processed nodes and a matching ``Geometry`` instance.
+    """
+    # Compute the width threshold so stacks can be filtered during traversal.
+    width_per_count_unit = (settings.image_width - 2 * Geometry.XPad1) / profile.total
+    if settings.min_width_relative:
+        min_width_threshold: float = settings.min_width_value * profile.total / 100
+    else:
+        min_width_threshold = settings.min_width_value / width_per_count_unit
+    # Dispatch to the correct specialized function by profile type. The explicit
+    # branches (in contrast to a dictionary dispatch, e.g., in the
+    # ``parse_folded_profile``) preserve narrowed types for mypy.
+    nodes: ProcessedNodes | ProcessedDiffNodes
+    if profile.is_diff:
+        if settings.colors == ColorPalettes.CHAIN:
+            nodes = _process_differential_waker_stacks(profile, min_width_threshold)
+        else:
+            nodes = _process_differential_stacks(profile, min_width_threshold)
+    else:
+        if settings.colors == ColorPalettes.CHAIN:
+            nodes = _process_waker_stacks(profile, min_width_threshold)
+        else:
+            nodes = _process_stacks(profile, min_width_threshold)
+    # Create a geometry object that computes many parameters for rendering
+    # the SVG.
+    geometry = Geometry(
+        settings,
+        profile.total,
+        width_per_count_unit,
+        nodes.max_trace,
+    )
+    return nodes, geometry
+
+
+def _process_stacks(profile: FoldedData, min_width: float) -> ProcessedNodes:
+    """Processes non-differential non-waker folded stacks into drawable frames.
+
+    :param profile: a parsed folded profile.
+    :param min_width: a filtering threshold.
+
+    :return: processed nodes that should be drawn as frames.
+    """
+    prev_stack: list[str] = []
+    time: float = 0.0
+    max_trace: int = 0
+    nodes: list[tuple[str, int, float, float]] = []
+    tmp: dict[tuple[str, int], float] = {}
+
+    # Optimize dot access.
+    str_split = str.split
+    list_append = list.append
+
+    for stack, count in profile.data:
+        this_stack = str_split(stack, ";")
+        # -- BEGIN: inlined 'flow'.
+        prev_stack_len, this_stack_len = len(prev_stack), len(this_stack)
+        max_common_len = min(prev_stack_len, this_stack_len)
+        len_same = 0
+        # Consecutive stacks usually share a common initial sub-sequences of
+        # frames. We must skip these frames now as they will be processed later.
+        while len_same < max_common_len and prev_stack[len_same] == this_stack[len_same]:
+            len_same += 1
+
+        # First process the remaining differing frames in the old stack and
+        # create the actual nodes that should be drawn.
+        for depth in range(len_same, prev_stack_len):
+            stime = tmp[(prev_stack[depth], depth)]
+            if (time - stime) < min_width:
+                # All the callee nodes must have lower or equal time consumption
+                # than (time - stime), and thus will fail the check as well.
+                break
+            list_append(nodes, (prev_stack[depth], depth, time, stime))
+            max_trace = max(depth, max_trace)
+
+        # The remaining differing frames in the current stack must be stored
+        # for processing in the next iteration.
+        for depth in range(len_same, this_stack_len):
+            tmp[(this_stack[depth], depth)] = time
+        # -- END: inlined 'flow'.
+        prev_stack = this_stack
+        time += count
+
+    # Finish processing the last stack.
+    for idx, frame in enumerate(prev_stack):
+        stime = tmp[(frame, idx)]
+        if (time - stime) < min_width:
+            break
+        list_append(nodes, (frame, idx, time, stime))
+        max_trace = max(idx, max_trace)
+    return ProcessedNodes(nodes, max_trace)
+
+
+def _process_waker_stacks(profile: FoldedData, min_width: float) -> ProcessedNodes:
+    """Processes non-differential waker folded stacks into drawable frames.
+
+    See: https://www.brendangregg.com/FlameGraphs/offcpuflamegraphs.html#Chain
+
+    :param profile: a parsed folded profile.
+    :param min_width: a filtering threshold.
+
+    :return: processed nodes that should be drawn as frames.
+    """
+    prev_stack: list[str] = []
+    time: float = 0.0
+    max_trace: int = 0
+    nodes: list[tuple[str, int, float, float]] = []
+    tmp: dict[tuple[str, int], float] = {}
+
+    # Optimize dot access.
+    str_split = str.split
+    list_append = list.append
+
+    # See ``_process_stacks`` for the shared unwinding logic.
+    for stack, count in profile.data:
+        this_stack = str_split(stack, ";")
+        prev_stack_len, this_stack_len = len(prev_stack), len(this_stack)
+        # Annotate frames after ``--`` with ``_[w]`` for coloring purposes.
+        try:
+            waker_start = this_stack.index("--") + 1
+            for depth in range(waker_start + 1, this_stack_len):
+                if this_stack[depth] != "--":
+                    this_stack[depth] += "_[w]"
+        except ValueError:
+            pass
+        # -- BEGIN: inlined 'flow'.
+        max_common_len = min(prev_stack_len, this_stack_len)
+        len_same = 0
+        while len_same < max_common_len and prev_stack[len_same] == this_stack[len_same]:
+            len_same += 1
+
+        for depth in range(len_same, prev_stack_len):
+            stime = tmp[(prev_stack[depth], depth)]
+            if (time - stime) < min_width:
+                break
+            list_append(nodes, (prev_stack[depth], depth, time, stime))
+            max_trace = max(depth, max_trace)
+
+        for depth in range(len_same, this_stack_len):
+            tmp[(this_stack[depth], depth)] = time
+        # -- END: inlined 'flow'.
+        prev_stack = this_stack
+        time += count
+
+    for idx, frame in enumerate(prev_stack):
+        stime = tmp[(frame, idx)]
+        if (time - stime) < min_width:
+            break
+        list_append(nodes, (frame, idx, time, stime))
+        max_trace = max(idx, max_trace)
+    return ProcessedNodes(nodes, max_trace)
+
+
+def _process_differential_stacks(profile: FoldedDiffData, min_width: float) -> ProcessedDiffNodes:
+    """Processes differential non-waker folded stacks into drawable frames.
+
+    :param profile: a parsed folded profile.
+    :param min_width: a filtering threshold.
+
+    :return: processed nodes that should be drawn as frames.
+    """
+    prev_stack: list[str] = []
+    time: float = 0.0
+    max_trace: int = 0
+    max_delta: float = 1.0
+    nodes: list[tuple[str, int, float, float, float]] = []
+    tmp: dict[tuple[str, int], tuple[float, float]] = {}
+
+    # Optimize dot access.
+    str_split = str.split
+    list_append = list.append
+
+    # See ``_process_stacks`` for the shared unwinding logic.
+    for stack, count, count2 in profile.data:
+        this_stack = str_split(stack, ";")
+        prev_stack_len, this_stack_len = len(prev_stack), len(this_stack)
+        delta = count2 - count
+        max_delta = max(max_delta, abs(delta))
+        # -- BEGIN: inlined 'flow'.
+        max_common_len = min(prev_stack_len, this_stack_len)
+        len_same = 0
+        while len_same < max_common_len and prev_stack[len_same] == this_stack[len_same]:
+            len_same += 1
+
+        for depth in range(len_same, prev_stack_len):
+            stime, tmp_delta = tmp[(prev_stack[depth], depth)]
+            if (time - stime) < min_width:
+                break
+            list_append(nodes, (prev_stack[depth], depth, time, stime, tmp_delta))
+            max_trace = max(depth, max_trace)
+
+        # The delta belongs to the leaf frame of this stack.
+        for depth in range(len_same, this_stack_len - 1):
+            tmp[(this_stack[depth], depth)] = (time, 0.0)
+        if this_stack_len > len_same:
+            tmp[(this_stack[-1], this_stack_len - 1)] = (time, delta)
+        # -- END: inlined 'flow'.
+        prev_stack = this_stack
+        time += count2
+
+    for idx, frame in enumerate(prev_stack):
+        stime, delta = tmp[(frame, idx)]
+        if (time - stime) < min_width:
+            break
+        list_append(nodes, (frame, idx, time, stime, delta))
+        max_trace = max(idx, max_trace)
+
+    return ProcessedDiffNodes(nodes, max_trace, max_delta)
+
+
+def _process_differential_waker_stacks(
+    profile: FoldedDiffData, min_width: float
+) -> ProcessedDiffNodes:
+    """Processes differential waker folded stacks into drawable frames.
+
+    See: https://www.brendangregg.com/FlameGraphs/offcpuflamegraphs.html#Chain
+
+    :param profile: a parsed folded profile.
+    :param min_width: a filtering threshold.
+
+    :return: processed nodes that should be drawn as frames.
+    """
+    prev_stack: list[str] = []
+    time: float = 0.0
+    max_trace: int = 0
+    max_delta: float = 1.0
+    nodes: list[tuple[str, int, float, float, float]] = []
+    tmp: dict[tuple[str, int], tuple[float, float]] = {}
+    str_split = str.split
+    list_append = list.append
+
+    # See ``_process_stacks`` for the shared unwinding logic.
+    # See ``_process_differential_stacks`` for handling deltas.
+    for stack, count, count2 in profile.data:
+        this_stack = str_split(stack, ";")
+        prev_stack_len, this_stack_len = len(prev_stack), len(this_stack)
+        # Annotate frames after ``--`` with ``_[w]`` for coloring purposes.
+        try:
+            waker_start = this_stack.index("--") + 1
+            for depth in range(waker_start + 1, this_stack_len):
+                if this_stack[depth] != "--":
+                    this_stack[depth] += "_[w]"
+        except ValueError:
+            pass
+        delta = count2 - count
+        max_delta = max(max_delta, abs(delta))
+        # -- BEGIN: inlined 'flow'.
+
+        max_common_len = min(prev_stack_len, this_stack_len)
+        len_same = 0
+        while len_same < max_common_len and prev_stack[len_same] == this_stack[len_same]:
+            len_same += 1
+
+        for depth in range(len_same, prev_stack_len):
+            stime, tmp_delta = tmp[(prev_stack[depth], depth)]
+            if (time - stime) < min_width:
+                break
+            list_append(nodes, (prev_stack[depth], depth, time, stime, tmp_delta))
+            max_trace = max(depth, max_trace)
+
+        for depth in range(len_same, this_stack_len - 1):
+            tmp[(this_stack[depth], depth)] = (time, 0.0)
+        if this_stack_len > len_same:
+            tmp[(this_stack[-1], this_stack_len - 1)] = (time, delta)
+        # -- END: inlined 'flow'.
+        prev_stack = this_stack
+        time += count2
+
+    for idx, frame in enumerate(prev_stack):
+        stime, delta = tmp[(frame, idx)]
+        if (time - stime) < min_width:
+            break
+        list_append(nodes, (frame, idx, time, stime, delta))
+        max_trace = max(idx, max_trace)
+
+    return ProcessedDiffNodes(nodes, max_trace, max_delta)
+
+
+#### SECTION: FRAMES CONSTRUCTION
+# To transform the processed nodes into flame graph frames, use the
+# 'construct_frames' function which selects the correct specialized function
+# based on the data type (diff or not) and the presence or absence of a
+# name-attribute file.
+#
+# Constructing the frames is *usually* not a hot spot since the nodes have
+# already been pre-filtered in the previous step. However, this depends on the
+# 'min_width' parameter which might have been set such that (almost) no
+# filtering was done. In such cases, the frames construction could become a new
+# hot loop. As a precaution, we optimized the construction as well by providing
+# optimized variants that attempt to remove as many unnecessary branches and
+# user function calls as possible. This leads to some code duplication but
+# improves performance in case of insufficient filtering.
+
+
+def construct_frames(
+    nodes: ProcessedNodes | ProcessedDiffNodes,
+    total: float,
+    geometry: Geometry,
+    settings: Settings,
+    colors: Colors,
+) -> list[str]:
+    """Translates the processed nodes into SVG ``<g>`` or ``<a>`` frames.
+
+    This function creates the initial root frame and then calls the appropriate
+    function to generate the nested frames, which is optimized for the
+    particular input type, i.e., (non-)differential profile with(out) custom
+    name attributes.
+
+    :param nodes: graph nodes obtained from ``process_stacks``.
+    :param total: the (possibly user-adjusted) sum of all counts used for
+           horizontal scale.
+    :param geometry: rendering geometry for the SVG layout.
+    :param settings: rendering and processing options.
+    :param colors: coloring options for the SVG.
+
+    :return: a list of SVG frame strings forming the flame graph content.
+    """
+    # Create the auxiliary full-width root frame.
+    frames: list[str] = ['<g id="frames">\n']
+    x1 = Geometry.XPad1
+    x2 = Geometry.XPad1 + total * geometry.width_per_count_unit
+    y1 = geometry.y1_table[0]
+    y2 = geometry.y2_table[0]
+    samples = int(geometry.total_factor)
+    samples_txt = _format_with_suffix(samples)
+    info = f"{settings.root_node} ({samples_txt} {settings.count_name}, 100%)"
+    escaped_func = settings.root_node
+
+    if nodes.is_diff:
+        color_val = colors.color_scale(0.0, nodes.max_delta)
+    else:
+        color_val = colors[""]
+
+    chars = int((x2 - x1) / geometry.char_space)
+    text = ""  # Show no text in too narrow frames.
+    if chars >= 3:  # Enough room for one visible character plus an ellipsis.
+        text = escaped_func[:chars]
+        if chars < len(escaped_func):
+            # Truncate with a two-character ellipsis when the label is too long.
+            text = text[:-2] + ".."
+
+    frame_rectangle = (
+        f'<rect x="{x1:.1f}" y="{y1:.1f}" width="{x2 - x1:.1f}"'
+        f' height="{y2 - y1:.1f}" fill="{color_val}" rx="2" ry="2" />\n'
+    )
+    frame_text = f'<text x="{x1 + 3:.2f}" y="{3 + (y1 + y2) / 2:.2f}">{text}</text>\n'
+    frame_begin, frame_end = settings.name_attr.get_frame("", info)
+    frames.append(f"{frame_begin}{frame_rectangle}{frame_text}{frame_end}")
+
+    # Dispatch to the correct specialized function. Similarly to the
+    # ``process_stacks`` function, we intentionally keep the explicit
+    # branches (in contrast to a dictionary dispatch, e.g., in the
+    # ``parse_folded_profile``) to preserve narrowed types for mypy.
+    if nodes.is_diff:
+        if settings.name_attr.attr_cache:
+            _construct_node_diff_frames_with_attrs(nodes, frames, geometry, settings, colors)
+        else:
+            _construct_node_diff_frames(nodes, frames, geometry, settings, colors)
+    else:
+        if settings.name_attr.attr_cache:
+            _construct_node_frames_with_attrs(nodes, frames, geometry, settings, colors)
+        else:
+            _construct_node_frames(nodes, frames, geometry, settings, colors)
+
+    frames.append("</g>")
+    return frames
+
+
+def _construct_node_frames(
+    nodes: ProcessedNodes,
+    frames: list[str],
+    geometry: Geometry,
+    settings: Settings,
+    colors: Colors,
+) -> None:
+    """Construct frames without name attributes from non-differential nodes.
+
+    The nodes are appended to the ``frames`` input list, which may already
+    contain some frames (e.g., the root frame).
+
+    :param nodes: graph nodes obtained from ``process_stacks``.
+    :param frames[in,out]: a (non-empty) list of frames to append new frames to.
+    :param geometry: rendering geometry for the SVG layout.
+    :param settings: rendering and processing options.
+    :param colors: coloring options for the SVG.
+    """
+    suffixes: list[str] = ["", "K", "M", "G", "T", "P", "E"]
+    suffix_regex: re.Pattern[str] = re.compile(r"_\[[kwij]]$")
+
+    # Optimize dot access.
+    str_translate = str.translate
+    list_append = list.append
+    re_sub = re.sub
+    x_pad_1: int = Geometry.XPad1
+    width_per_count_unit: float = geometry.width_per_count_unit
+    y1_table: list[int] = geometry.y1_table
+    y2_table: list[int] = geometry.y2_table
+    total_factor: float = geometry.total_factor
+    char_space: float = geometry.char_space
+    factor: float = settings.factor
+    count_name: str = settings.count_name
+    translation_table: dict[int, str] = Settings.TranslationTable
+
+    for func, depth, etime, stime in nodes.nodes:
+        x1 = x_pad_1 + stime * width_per_count_unit
+        x2 = x_pad_1 + etime * width_per_count_unit
+        y1 = y1_table[depth + 1]
+        y2 = y2_table[depth + 1]
+
+        samples = int((etime - stime) * factor)
+        # -- BEGIN: inlined '_format_with_suffix'.
+        step = 0
+        samples_copy: float = samples
+        while samples_copy >= 1000.0 and step < len(suffixes) - 1:
+            samples_copy /= 1000.0
+            step += 1
+        samples_txt = f"{samples_copy:.3f}".rstrip("0").rstrip(".") + suffixes[step]
+        # -- END: inlined '_format_with_suffix'.
+
+        pct = (100 * samples) / total_factor
+        # Strip stack annotations and SVG-breaking characters.
+        escaped_func = re_sub(suffix_regex, "", str_translate(func, translation_table))
+        info = f"{escaped_func} ({samples_txt} {count_name}, {pct:.2f}%)"
+        color_val = colors[func]
+
+        chars = int((x2 - x1) / char_space)
+        text = ""
+        if chars >= 3:
+            text = escaped_func[:chars]
+            if chars < len(escaped_func):
+                text = text[:-2] + ".."
+
+        frame_rectangle = (
+            f'<rect x="{x1:.1f}" y="{y1:.1f}" width="{x2 - x1:.1f}"'
+            f' height="{y2 - y1:.1f}" fill="{color_val}" rx="2" ry="2" />\n'
+        )
+        frame_text = f'<text x="{x1 + 3:.2f}"' f' y="{3 + (y1 + y2) / 2:.2f}">{text}</text>\n'
+        list_append(
+            frames,
+            f"<g>\n<title>{info}</title>\n{frame_rectangle}{frame_text}</g>\n",
+        )
+
+
+def _construct_node_frames_with_attrs(
+    nodes: ProcessedNodes,
+    frames: list[str],
+    geometry: Geometry,
+    settings: Settings,
+    colors: Colors,
+) -> None:
+    """Construct frames with custom name attributes from non-differential nodes.
+
+    The nodes are appended to the ``frames`` input list, which may already
+    contain some frames (e.g., the root frame).
+
+    :param nodes: graph nodes obtained from ``process_stacks``.
+    :param frames[in,out]: a (non-empty) list of frames to append new frames to.
+    :param geometry: rendering geometry for the SVG layout.
+    :param settings: rendering and processing options.
+    :param colors: coloring options for the SVG.
+    """
+    suffixes: list[str] = ["", "K", "M", "G", "T", "P", "E"]
+    suffix_regex: re.Pattern[str] = re.compile(r"_\[[kwij]]$")
+
+    # Optimize dot access.
+    str_translate = str.translate
+    list_append = list.append
+    re_sub = re.sub
+    x_pad_1: int = Geometry.XPad1
+    width_per_count_unit: float = geometry.width_per_count_unit
+    y1_table: list[int] = geometry.y1_table
+    y2_table: list[int] = geometry.y2_table
+    total_factor: float = geometry.total_factor
+    char_space: float = geometry.char_space
+    factor: float = settings.factor
+    count_name: str = settings.count_name
+    name_attr_cache = settings.name_attr.attr_cache
+    translation_table: dict[int, str] = Settings.TranslationTable
+
+    for func, depth, etime, stime in nodes.nodes:
+        x1 = x_pad_1 + stime * width_per_count_unit
+        x2 = x_pad_1 + etime * width_per_count_unit
+        y1 = y1_table[depth + 1]
+        y2 = y2_table[depth + 1]
+
+        samples = int((etime - stime) * factor)
+        # -- BEGIN: inlined '_format_with_suffix'.
+        step = 0
+        samples_copy: float = samples
+        while samples_copy >= 1000.0 and step < len(suffixes) - 1:
+            samples_copy /= 1000.0
+            step += 1
+        samples_txt = f"{samples_copy:.3f}".rstrip("0").rstrip(".") + suffixes[step]
+        # -- END: inlined '_format_with_suffix'.
+
+        pct = (100 * samples) / total_factor
+        # Strip stack annotations and SVG-breaking characters.
+        escaped_func = re_sub(suffix_regex, "", str_translate(func, translation_table))
+        info = f"{escaped_func} ({samples_txt} {count_name}, {pct:.2f}%)"
+        color_val = colors[func]
+
+        chars = int((x2 - x1) / char_space)
+        text = ""
+        if chars >= 3:
+            text = escaped_func[:chars]
+            if chars < len(escaped_func):
+                text = text[:-2] + ".."
+
+        frame_rectangle = (
+            f'<rect x="{x1:.1f}" y="{y1:.1f}" width="{x2 - x1:.1f}"'
+            f' height="{y2 - y1:.1f}" fill="{color_val}" rx="2" ry="2" />\n'
+        )
+        frame_text = f'<text x="{x1 + 3:.2f}"' f' y="{3 + (y1 + y2) / 2:.2f}">{text}</text>\n'
+        # -- BEGIN: inlined 'settings.name_attr.get_frame'.
+        try:
+            frame_begin, frame_end = name_attr_cache[func]
+        except KeyError:
+            frame_begin, frame_end = ("<g>\n<title>", "</g>\n")
+        # -- END: inlined 'settings.name_attr.get_frame'.
+        list_append(
+            frames,
+            f"{frame_begin}{info}</title>\n{frame_rectangle}" f"{frame_text}{frame_end}",
+        )
+
+
+def _construct_node_diff_frames(
+    nodes: ProcessedDiffNodes,
+    frames: list[str],
+    geometry: Geometry,
+    settings: Settings,
+    colors: Colors,
+) -> None:
+    """Construct frames without name attributes from differential nodes.
+
+    The nodes are appended to the ``frames`` input list, which may already
+    contain some frames (e.g., the root frame).
+
+    :param nodes: graph nodes obtained from ``process_stacks``.
+    :param frames[in,out]: a (non-empty) list of frames to append new frames to.
+    :param geometry: rendering geometry for the SVG layout.
+    :param settings: rendering and processing options.
+    :param colors: coloring options for the SVG.
+    """
+    suffixes: list[str] = ["", "K", "M", "G", "T", "P", "E"]
+    suffix_regex: re.Pattern[str] = re.compile(r"_\[[kwij]]$")
+
+    # Optimize dot access.
+    str_translate = str.translate
+    list_append = list.append
+    re_sub = re.sub
+    color_scale = colors.color_scale
+    x_pad_1: int = Geometry.XPad1
+    width_per_count_unit: float = geometry.width_per_count_unit
+    y1_table: list[int] = geometry.y1_table
+    y2_table: list[int] = geometry.y2_table
+    total_factor: float = geometry.total_factor
+    char_space: float = geometry.char_space
+    factor: float = settings.factor
+    count_name: str = settings.count_name
+    translation_table: dict[int, str] = Settings.TranslationTable
+    max_delta: float = nodes.max_delta
+
+    negate_coeff: int = -1 if settings.negate else 1
+    for func, depth, etime, stime, delta in nodes.nodes:
+        x1 = x_pad_1 + stime * width_per_count_unit
+        x2 = x_pad_1 + etime * width_per_count_unit
+        y1 = y1_table[depth + 1]
+        y2 = y2_table[depth + 1]
+
+        samples = int((etime - stime) * factor)
+        # -- BEGIN: inlined '_format_with_suffix'.
+        step = 0
+        samples_copy: float = samples
+        while samples_copy >= 1000.0 and step < len(suffixes) - 1:
+            samples_copy /= 1000.0
+            step += 1
+        samples_txt = f"{samples_copy:.3f}".rstrip("0").rstrip(".") + suffixes[step]
+        # -- END: inlined '_format_with_suffix'.
+
+        pct = (100 * samples) / total_factor
+        # Strip stack annotations and SVG-breaking characters.
+        escaped_func = re_sub(suffix_regex, "", str_translate(func, translation_table))
+        d = delta * negate_coeff
+        info = (
+            f"{escaped_func} ({samples_txt} {count_name}, {pct:.2f}%;"
+            f" {(100 * d) / total_factor:+.2f}%)"
+        )
+
+        chars = int((x2 - x1) / char_space)
+        text = ""
+        if chars >= 3:
+            text = escaped_func[:chars]
+            if chars < len(escaped_func):
+                text = text[:-2] + ".."
+
+        frame_rectangle = (
+            f'<rect x="{x1:.1f}" y="{y1:.1f}" width="{x2 - x1:.1f}"'
+            f' height="{y2 - y1:.1f}" fill="{color_scale(d, max_delta)}" rx="2"'
+            ' ry="2" />\n'
+        )
+        frame_text = f'<text x="{x1 + 3:.2f}"' f' y="{3 + (y1 + y2) / 2:.2f}">{text}</text>\n'
+        list_append(
+            frames,
+            f"<g>\n<title>{info}</title>\n{frame_rectangle}{frame_text}</g>\n",
+        )
+
+
+def _construct_node_diff_frames_with_attrs(
+    nodes: ProcessedDiffNodes,
+    frames: list[str],
+    geometry: Geometry,
+    settings: Settings,
+    colors: Colors,
+) -> None:
+    """Construct frames with custom name attributes from differential nodes.
+
+    The nodes are appended to the ``frames`` input list, which may already
+    contain some frames (e.g., the root frame).
+
+    :param nodes: graph nodes obtained from ``process_stacks``.
+    :param frames[in,out]: a (non-empty) list of frames to append new frames to.
+    :param geometry: rendering geometry for the SVG layout.
+    :param settings: rendering and processing options.
+    :param colors: coloring options for the SVG.
+    """
+    suffixes: list[str] = ["", "K", "M", "G", "T", "P", "E"]
+    suffix_regex: re.Pattern[str] = re.compile(r"_\[[kwij]]$")
+
+    # Optimize dot access.
+    str_translate = str.translate
+    list_append = list.append
+    re_sub = re.sub
+    color_scale = colors.color_scale
+    x_pad_1: int = Geometry.XPad1
+    width_per_count_unit: float = geometry.width_per_count_unit
+    y1_table: list[int] = geometry.y1_table
+    y2_table: list[int] = geometry.y2_table
+    total_factor: float = geometry.total_factor
+    char_space: float = geometry.char_space
+    factor: float = settings.factor
+    count_name: str = settings.count_name
+    translation_table: dict[int, str] = Settings.TranslationTable
+    name_attr_cache = settings.name_attr.attr_cache
+    max_delta: float = nodes.max_delta
+
+    negate_coeff: int = -1 if settings.negate else 1
+    for func, depth, etime, stime, delta in nodes.nodes:
+        x1 = x_pad_1 + stime * width_per_count_unit
+        x2 = x_pad_1 + etime * width_per_count_unit
+        y1 = y1_table[depth + 1]
+        y2 = y2_table[depth + 1]
+
+        samples = int((etime - stime) * factor)
+        # -- BEGIN: inlined '_format_with_suffix'.
+        step = 0
+        samples_copy: float = samples
+        while samples_copy >= 1000.0 and step < len(suffixes) - 1:
+            samples_copy /= 1000.0
+            step += 1
+        samples_txt = f"{samples_copy:.3f}".rstrip("0").rstrip(".") + suffixes[step]
+        # -- END: inlined '_format_with_suffix'.
+
+        pct = (100 * samples) / total_factor
+        # Strip stack annotations and SVG-breaking characters.
+        escaped_func = re_sub(suffix_regex, "", str_translate(func, translation_table))
+        d = delta * negate_coeff
+        info = (
+            f"{escaped_func} ({samples_txt} {count_name}, {pct:.2f}%;"
+            f" {(100 * d) / total_factor:+.2f}%)"
+        )
+
+        chars = int((x2 - x1) / char_space)
+        text = ""
+        if chars >= 3:
+            text = escaped_func[:chars]
+            if chars < len(escaped_func):
+                text = text[:-2] + ".."
+
+        frame_rectangle = (
+            f'<rect x="{x1:.1f}" y="{y1:.1f}" width="{x2 - x1:.1f}"'
+            f' height="{y2 - y1:.1f}" fill="{color_scale(d, max_delta)}" rx="2"'
+            ' ry="2" />\n'
+        )
+        frame_text = f'<text x="{x1 + 3:.2f}"' f' y="{3 + (y1 + y2) / 2:.2f}">{text}</text>\n'
+        # -- BEGIN: inlined 'settings.name_attr.get_frame'.
+        try:
+            frame_begin, frame_end = name_attr_cache[func]
+        except KeyError:
+            frame_begin, frame_end = ("<g>\n<title>", "</g>\n")
+        # -- END: inlined 'settings.name_attr.get_frame'.
+        list_append(
+            frames,
+            f"{frame_begin}{info}</title>\n{frame_rectangle}" f"{frame_text}{frame_end}",
+        )
+
+
+def _format_with_suffix(num: float) -> str:
+    """Format a number with SI suffixes (``K``, ``M``, ...).
+
+    :param num: a number to format.
+
+    :return: a number with an optional SI suffix.
+    """
+    suffixes = ["", "K", "M", "G", "T", "P", "E"]
+    i = 0
+    while num >= 1000.0 and i < len(suffixes) - 1:
+        num /= 1000.0
+        i += 1
+    # Format to at most three decimal places, trimming trailing zeros.
+    formatted = f"{num:.3f}".rstrip("0").rstrip(".")
+    return formatted + suffixes[i]
+
+
+### SECTION: TOP-LEVEL FUNCTIONS
+# CLI and programmatic (``create_flame_graph``) entrypoints + helper functions.
+
+
+@overload
+def create_flame_graph(
+    profile: Path | FoldedData | FoldedDiffData,
+    *,
+    bgcolors: str = ...,
+    colors: ColorPalettes = ...,
+    countname: str = ...,
+    cp: bool = ...,
+    encoding: str = ...,
+    factor: float = ...,
+    flamechart: bool = ...,
+    fontsize: float = ...,
+    fonttype: str = ...,
+    fontwidth: float = ...,
+    hash: bool = ...,
+    height: int = ...,
+    inverted: bool = ...,
+    maxtrace: int = ...,
+    minwidth: str = ...,
+    nametype: str = ...,
+    nameattr: str = ...,
+    negate: bool = ...,
+    notes: str = ...,
+    outfile: None = ...,
+    random: bool = ...,
+    rootnode: str = ...,
+    reverse: bool = ...,
+    subtitle: str = ...,
+    total: int = ...,
+    title: str = ...,
+    width: int = ...,
+    **_: Any,
+) -> str: ...
+
+
+@overload
+def create_flame_graph(
+    profile: Path | FoldedData | FoldedDiffData,
+    *,
+    bgcolors: str = ...,
+    colors: ColorPalettes = ...,
+    countname: str = ...,
+    cp: bool = ...,
+    encoding: str = ...,
+    factor: float = ...,
+    flamechart: bool = ...,
+    fontsize: float = ...,
+    fonttype: str = ...,
+    fontwidth: float = ...,
+    hash: bool = ...,
+    height: int = ...,
+    inverted: bool = ...,
+    maxtrace: int = ...,
+    minwidth: str = ...,
+    nametype: str = ...,
+    nameattr: str = ...,
+    negate: bool = ...,
+    notes: str = ...,
+    outfile: str = ...,
+    random: bool = ...,
+    rootnode: str = ...,
+    reverse: bool = ...,
+    subtitle: str = ...,
+    total: int = ...,
+    title: str = ...,
+    width: int = ...,
+    **_: Any,
+) -> str: ...
+
+
+def create_flame_graph(
+    profile: Path | FoldedData | FoldedDiffData,
+    *,
+    bgcolors: str = Settings.DefaultBgColors,
+    colors: ColorPalettes = Settings.DefaultColors,
+    countname: str = Settings.DefaultCountName,
+    cp: bool = Settings.DefaultPaletteFlag,
+    encoding: str = Settings.DefaultEncoding,
+    factor: float = Settings.DefaultFactor,
+    flamechart: bool = Settings.DefaultFlameChartFlag,
+    fontsize: float = Settings.DefaultFontSize,
+    fonttype: str = Settings.DefaultFontType,
+    fontwidth: float = Settings.DefaultFontWidth,
+    hash: bool = Settings.DefaultHashFlag,
+    height: int = Settings.DefaultFrameHeight,
+    inverted: bool = Settings.DefaultInvertedFlag,
+    maxtrace: int = Settings.DefaultMaxTrace,
+    minwidth: str = Settings.DefaultMinWidth,
+    nametype: str = Settings.DefaultNameType,
+    nameattr: str = Settings.DefaultNameAttrFile,
+    negate: bool = Settings.DefaultNegateFlag,
+    notes: str = Settings.DefaultNotesText,
+    outfile: str | None = None,
+    random: bool = Settings.DefaultRandomFlag,
+    rootnode: str = Settings.DefaultRootNode,
+    reverse: bool = Settings.DefaultStackReverseFlag,
+    subtitle: str = Settings.DefaultSubtitle,
+    total: int = Settings.DefaultTotal,
+    title: str = Settings.DefaultTitle,
+    width: int = Settings.DefaultImageWidth,
+    **_: Any,
+) -> str | None:
+    """Renders an SVG from the provided profile.
+
+    The input profile can either be an (already parsed) in-memory profile, or
+    a path to a file containing a folded profile that will be parsed.
+
+    Based on the ``outfile`` parameter, the created SVG can be written to
+    a file or returned directly:
+     - if ``outfile`` is ``None``, then the SVG is returned as a string;
+     - if ``outfile`` is either an empty string or ``stdout``, then the SVG
+       is written to the standard output; otherwise
+     - the SVG is written to the ``outfile``.
+
+    :param profile: a path to the input profile, or already parsed folded data.
+    :param bgcolors: the background color (gradient). Supports:
+           - named gradients (``yellow``, ``blue``, ``green``, ``grey``,
+             and ``gray``),
+           - hex colors in the ``#RRGGBB`` format (will result in a flat
+             color, not a gradient), or
+           - ``""`` for a palette-derived default gradient.
+    :param colors: the color palette for SVG frames.
+    :param countname: the counts name (e.g. ``samples``, ``cycles``).
+    :param encoding: a specific encoding to use in the XML declaration.
+    :param factor: a multiplier applied to parsed counts.
+    :param flamechart: draw a flame chart instead (sorts by time, does not
+           merge stacks).
+    :param fontsize: SVG text font size (px).
+    :param fonttype: CSS ``font-family`` name for SVG text.
+    :param fontwidth: average character width relative to ``font_size``.
+    :param height: the height of each frame (px).
+    :param hash: color frames using a deterministic hash function.
+    :param inverted: draw an icicle chart instead (deepest frames at top).
+    :param maxtrace: overrides the computation of the canvas height.
+           The height is determined by the maximum trace depth (after
+           filtering the data using ``minwidth``). This option may be used
+           to align two SVGs with possibly different data side-by-side.
+    :param minwidth: specifies the minimum width of displayed frames.
+           Narrower frames will be discarded. May be specified either as
+           a fixed pixel width (e.g., ``0.5``) or relative to the total
+           count (e.g., ``0.1%``).
+    :param nameattr: a path to the name-attribute file
+           (see ``NameAttributes``).
+    :param nametype: the name of the frames in stacks
+          (e.g., ``Function:``, ``Basic Block:``).
+    :param negate: flip the differential red/blue hues when ``True``.
+    :param notes: addition notes to embedd into the SVG comment header.
+    :param outfile: store the flamegraph in a file or write it to the standard
+           output instead of returning it as a string.
+    :param cp: use consistent palette that loads and stores stable colors
+           via a ``palette.map`` file.
+    :param random: use randomized frame colors within the selected palette.
+           Note that even frames with identical names will have their
+           colors chosen randomly.
+    :param rootnode: the label on the synthetic root frame.
+    :param reverse: the stacks in the folded profile are in the
+           callee-to-caller (instead of caller-to-callee) order.
+    :param subtitle: optional second title line below the main title.
+    :param total: overrides the sum of all counts, which causes the root
+           node to be wider (suitable for comparing two profiles
+           side-by-side). Must be higher or equal than the actual sum.
+    :param title: the graph title.
+    :param width: the width of the SVG canvas (px).
+
+    :return: the SVG content unless an output file was specified.
+
+    Extra keyword arguments are ignored so that dictionaries with possibly
+    additional keys may be unpacked directly when calling the function.
+    """
+    settings: Settings = Settings(
+        Path(),
+        bgcolors=bgcolors,
+        colors=colors,
+        countname=countname,
+        cp=cp,
+        encoding=encoding,
+        factor=factor,
+        flamechart=flamechart,
+        fontsize=fontsize,
+        fonttype=fonttype,
+        fontwidth=fontwidth,
+        hash=hash,
+        height=height,
+        inverted=inverted,
+        maxtrace=maxtrace,
+        minwidth=minwidth,
+        nametype=nametype,
+        nameattr=nameattr,
+        negate=negate,
+        notes=notes,
+        random=random,
+        rootnode=rootnode,
+        reverse=reverse,
+        subtitle=subtitle,
+        total=total,
+        title=title,
+        width=width,
+    )
+    svg_header, svg_frames = _build_flame_graph(profile, settings)
+    # We write the SVG to a file (including stdout) if specified.
+    # Otherwise, we join the SVG fragments into a single string and return it.
+    if outfile is not None:
+        write_flame_graph(outfile, svg_header, svg_frames)
+        return None
+    return "".join(svg_header + svg_frames)
+
+
+def initialize_cli_options(cli_parser: argparse.ArgumentParser) -> None:
+    """Initializes the CLI options that may be reused by composite scripts.
+
+    When importing the flamegraph.py script by other Python scripts, it might
+    be helpful to extend their CLI options with the options and arguments used
+    by this script.
+
+    Note that the ``infile`` positional parameter is skipped.
+
+    :param cli_parser: a CLI parser to extend.
+    """
+    cli_parser.add_argument(
+        "--bgcolors",
+        type=str,
+        default=Settings.DefaultBgColors,
+        help=(
+            "Set color for the background. Pre-defined gradient choices are"
+            " yellow, blue, green, grey, and gray. Flat colors may be specified"
+            "as '#rrggbb' (default: selected automatically w.r.t. --colors)."
+        ),
+    )
+    cli_parser.add_argument(
+        "--colors",
+        type=ColorPalettes,
+        default=Settings.DefaultColors.value,
+        choices=ColorPalettes.supported(),
+        help="Set color palette for frames (default: %(default)s).",
+    )
+    cli_parser.add_argument(
+        "--countname",
+        type=str,
+        default=Settings.DefaultCountName,
+        help="The count type label (default: %(default)s).",
+    )
+    cli_parser.add_argument(
+        "--cp",
+        action="store_true",
+        help=(
+            "Frame colors use consistent palette from the"
+            f" {Colors.PaletteFileName} file (default: False)."
+        ),
+    )
+    cli_parser.add_argument(
+        "--encoding",
+        type=str,
+        default=Settings.DefaultEncoding,
+        help="The xml encoding (default: omitted).",
+    )
+    cli_parser.add_argument(
+        "--factor",
+        type=float,
+        default=Settings.DefaultFactor,
+        help="A factor to scale the counts by (default: %(default)s).",
+    )
+    cli_parser.add_argument(
+        "--flamechart",
+        action="store_true",
+        help=(
+            "Generate flame chart which sorts by time and does not merge"
+            " stacks (default: False)."
+        ),
+    )
+    cli_parser.add_argument(
+        "--fontsize",
+        type=float,
+        default=Settings.DefaultFontSize,
+        help="The font size (default: %(default)s).",
+    )
+    cli_parser.add_argument(
+        "--fonttype",
+        type=str,
+        default=Settings.DefaultFontType,
+        help="The font type (default: %(default)s).",
+    )
+    cli_parser.add_argument(
+        "--fontwidth",
+        type=float,
+        default=Settings.DefaultFontWidth,
+        help=("The average font width relative to font size" " (default: %(default)s)."),
+    )
+    cli_parser.add_argument(
+        "--hash",
+        action="store_true",
+        help=("Frame colors are generated using function name hash" " (default: False)."),
+    )
+    cli_parser.add_argument(
+        "--height",
+        type=int,
+        default=Settings.DefaultFrameHeight,
+        help="The height of each frame (default: %(default)s).",
+    )
+    cli_parser.add_argument(
+        "--inverted",
+        action="store_true",
+        help="Generate icicle graph (default: False).",
+    )
+    cli_parser.add_argument(
+        "--maxtrace",
+        type=int,
+        default=Settings.DefaultMaxTrace,
+        help=(
+            "The maximal seen height of a trace used to compute the offsets"
+            " and image height; this may be used to align two flamegraphs"
+            " (default: computed automatically)."
+        ),
+    )
+    cli_parser.add_argument(
+        "--minwidth",
+        type=str,
+        default=Settings.DefaultMinWidth,
+        help=(
+            "Omit cheap functions. Width in (fractions of) pixels or"
+            " percentage of time, e.g., '0.5%%'"
+            " (default: %(default)s pixels)."
+        ),
+    )
+    cli_parser.add_argument(
+        "--nameattr",
+        type=str,
+        default=Settings.DefaultNameAttrFile,
+        help=(
+            "A path to file holding function attributes, e.g., id, class, or"
+            " href (default: ignored)."
+        ),
+    )
+    cli_parser.add_argument(
+        "--nametype",
+        type=str,
+        default=Settings.DefaultNameType,
+        help="The name type label (default: %(default)s).",
+    )
+    cli_parser.add_argument(
+        "--negate",
+        action="store_true",
+        help=("Switch differential hues when generating diff flamegraphs" " (default: False)."),
+    )
+    cli_parser.add_argument(
+        "--notes",
+        type=str,
+        default=Settings.DefaultNotesText,
+        help="Add debugging notes to the SVG (default: omitted).",
+    )
+    cli_parser.add_argument(
+        "--outfile",
+        type=str,
+        default=Settings.DefaultOutFile,
+        help=(
+            "Specify the SVG output file. If unspecified, the SVG is printed"
+            " to the standard output (default: %(default)s)."
+        ),
+    )
+    cli_parser.add_argument(
+        "--random",
+        action="store_true",
+        help="Frame colors are generated randomly (default: False).",
+    )
+    cli_parser.add_argument(
+        "--reverse",
+        action="store_true",
+        help=(
+            "Indicates whether stack traces in the input file are reversed;"
+            " note that this introduces a performance penalty"
+            " (default: False)."
+        ),
+    )
+    cli_parser.add_argument(
+        "--rootnode",
+        type=str,
+        default=Settings.DefaultRootNode,
+        help="Set the name of the root node (default: %(default)s).",
+    )
+    cli_parser.add_argument(
+        "--subtitle",
+        type=str,
+        default=Settings.DefaultSubtitle,
+        help="A subtitle of the image (default: omitted).",
+    )
+    cli_parser.add_argument(
+        "--title",
+        type=str,
+        default=Settings.DefaultTitle,
+        help="The title of the image (default: generated automatically).",
+    )
+    cli_parser.add_argument(
+        "--total",
+        type=int,
+        default=Settings.DefaultTotal,
+        help=(
+            "Override the sum of the total counts; the value must be larger"
+            " or equal than the actual sum (default: ignored)."
+        ),
+    )
+    cli_parser.add_argument(
+        "--width",
+        type=int,
+        default=Settings.DefaultImageWidth,
+        help="The width of the image (default: %(default)s).",
+    )
+
+
+def _build_flame_graph(
+    profile: Path | FoldedData | FoldedDiffData, settings: Settings
+) -> tuple[list[str], list[str]]:
+    """Build the flame graph SVG.
+
+    A convenience wrapper over (optional) profile parsing, validation, stack
+    processing and SVG rendering.
+
+    :param profile: a path to the input profile, or already parsed folded data.
+    :param settings: rendering and processing options.
+
+    :return: a tuple of SVG header and SVG frames.
+    """
+    # If a path was given, we need to parse the profile first. Otherwise, we
+    # were given an already parsed profile.
+    if isinstance(profile, Path):
+        parsed_profile = parse_folded_profile(
+            profile, settings.flame_chart_flag, settings.stack_reverse_flag
+        )
+    else:
+        parsed_profile = profile
+    parsed_profile.total = validate_profile_total(parsed_profile, settings)
+    colors: Colors = Colors(
+        settings.colors,
+        settings.bg_colors,
+        settings.consistent_palette_flag,
+        settings.hash_flag,
+        settings.random_flag,
+    )
+    nodes, geometry = process_stacks(parsed_profile, settings)
+
+    # Construct the SVG.
+    svg_setup = create_svg_without_frames(settings, geometry, colors)
+    svg_frames: list[str] = construct_frames(
+        nodes, parsed_profile.total, geometry, settings, colors
+    )
+    svg_frames.append("</svg>\n")
+    colors.store_palette()
+    return svg_setup, svg_frames
+
+
+def write_flame_graph(outfile: str, *svg_fragments: Iterable[str]) -> None:
+    """Write the SVG content to a file or standard output.
+
+    :param outfile: ``""``, ``stdout``, or a path to the output file.
+    :param svg_fragments: SVG contents (stored as possibly multiple collections
+           of strings).
+    """
+    # This could be made more elegant using nullcontext from contextlib,
+    # however, it would result in an unnecessary import.
+    if outfile in ("", "stdout"):
+        # Write the flamegraph to the stdout.
+        for fragment in svg_fragments:
+            sys.stdout.writelines(fragment)
+    else:
+        # Write the flamegraph to an output file.
+        with open(outfile, "w+") as out_handle:
+            for fragment in svg_fragments:
+                out_handle.writelines(fragment)
+
+
+if __name__ == "__main__":
+    # Creates a flamegraph SVG using CLI.
+    # Based on the ``outfile`` option, the flame graph will be written to
+    # either the standard output or the specified output file.
+    _cli_parser = argparse.ArgumentParser(
+        description="Generate flame graph SVG.",
+        usage="%(prog)s [options] infile > outfile.svg",
+    )
+    _cli_parser.add_argument(
+        "infile",
+        type=Path,
+        metavar="infile",
+        help="The input folded stack file.",
+    )
+    initialize_cli_options(_cli_parser)
+
+    _args = _cli_parser.parse_args()
+    _settings: Settings = Settings(**vars(_args))
+    _profile = parse_folded_profile(
+        _settings.infile,
+        _settings.flame_chart_flag,
+        _settings.stack_reverse_flag,
+    )
+    write_flame_graph(_settings.outfile, *_build_flame_graph(_profile, _settings))

--- a/perun/scripts/flamegraph.py
+++ b/perun/scripts/flamegraph.py
@@ -144,7 +144,11 @@ from pathlib import Path
 import random
 import re
 import sys
-from typing import Any, TextIO, ClassVar, Literal, TypeAlias, overload
+from typing import Any, TextIO, ClassVar, Literal, TypeAlias, overload, Type, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from types import TracebackType
+    from _typeshed import OpenTextModeReading
 
 ColoringFn: TypeAlias = Callable[[str], str]
 ColoringCtxFn: TypeAlias = Callable[["Colors", str], str]
@@ -265,7 +269,6 @@ class NameAttributes:
 
     @staticmethod
     def _construct_name_attrs(
-        id: str | None = None,
         g_extra: str | None = None,
         href: str | None = None,
         target: str | None = None,
@@ -274,19 +277,18 @@ class NameAttributes:
     ) -> tuple[str, str]:
         """Build the opening and closing SVG fragments for the given attributes.
 
-        :param id: an ``id=`` value.
         :param g_extra: extra attributes to use in ``<g>``.
         :param href: if set, emit ``<a xlink:href=...>`` instead of ``<g>``.
         :param target: link target (defaults to ``_top`` when ``href`` is set).
         :param a_extra: extra attributes to use in ``<a>`` when ``href`` is set.
-        :param rest: remaining ``name=value`` pairs (e.g. ``class``).
+        :param rest: remaining ``name=value`` pairs (e.g. ``class``, ``id``).
 
         :return: (opening markup, closing markup).
         """
         # Process the ``<g>`` attributes.
         g_attrs = []
-        if id is not None:
-            g_attrs.append(f'id="{id}"')
+        if (g_id := rest.get("id")) is not None:
+            g_attrs.append(f'id="{g_id}"')
         if (g_class := rest.get("class")) is not None:
             # Cannot name the parameter ``class`` (reserved keyword).
             g_attrs.append(f'class="{g_class}"')
@@ -1675,7 +1677,9 @@ def create_svg_js_css(settings: Settings, bg_color_1: str, bg_color_2: str, titl
             }}
             if (upstack) {{
                 // Direct ancestor
-                if (ex <= xmin && (ex+ew+fudge) >= xmax) {{
+                // The ex + ew + fudge could sometimes end up being higher than
+                // xmax due to rounding error.
+                if (ex <= xmin && (ex+ew+fudge) >= xmin) {{
                     e.classList.add("parent");
                     zoom_parent(e);
                     update_text(e);
@@ -1938,8 +1942,57 @@ class FoldedDiffData:
         self.is_diff: Literal[True] = True
 
 
+class InputTextFile:
+    """A helper context manager for reading from a file or stdin correctly.
+
+    There is no easy built-in way to read from both an external file that
+    needs to be opened and closed, and the standard input which is already
+    opened and should not be closed. This simple wrapper handles both cases
+    and exposes interface to interact with both input types identically.
+
+    Note that this wrapper works only for text files in read mode.
+    """
+
+    def __init__(self, input_file: Path | None, mode: OpenTextModeReading) -> None:
+        """Initialize the CM object.
+
+        :param input_file: a path to the input file, or ``None`` for stdin.
+        :param mode: a read-only file opening mode.
+        """
+        # We cannot simply assign the grids as it would not propagate outside the object.
+        self.input_file: Path | None = input_file
+        self.mode: OpenTextModeReading = mode
+        self.handle: TextIO = sys.stdin
+
+    def __enter__(self) -> TextIO:
+        """Opens the input file if it is supplied.
+
+        :return: a handle to the opened file or stdin.
+        """
+        if self.input_file is not None:
+            self.handle = open(self.input_file, self.mode)
+        return self.handle
+
+    def __exit__(
+        self,
+        _: Type[BaseException] | None,
+        __: BaseException | None,
+        ___: TracebackType | None,
+    ) -> None:
+        """Closes the input file but not the stdin.
+
+        Any unhandled exceptions should be propagated outside the CM.
+
+        :param _: the type of the exception that occurred, if any
+        :param __: the actual exception object, if any
+        :param ___: the traceback of the error, if any
+        """
+        if self.input_file is not None:
+            self.handle.close()
+
+
 def parse_folded_profile(
-    input_file: Path, is_flame_chart: bool, is_stack_reverse: bool
+    input_file: Path | None, is_flame_chart: bool, is_stack_reverse: bool
 ) -> FoldedData | FoldedDiffData:
     """Parse a folded profile file.
 
@@ -1947,7 +2000,7 @@ def parse_folded_profile(
     folded profile and selects the appropriate optimized parsing function for
     the type, i.e., (non-)differential, forward or reversed stacks.
 
-    :param input_file: the path to the folded profile.
+    :param input_file: a path to the folded profile, or ``None`` for stdin.
     :param is_flame_chart: we are drawing a flame chart; the parsing functions
            should preserve the order of the records instead of sorting them as
            in the case of flame graphs.
@@ -1958,16 +2011,18 @@ def parse_folded_profile(
     """
     result: FoldedData | FoldedDiffData
     ignored: int = 0
-    with open(input_file, "r") as input_handle:
+    with InputTextFile(input_file, "r") as input_handle:
         # Peek column count from the first line.
-        _, *counts = input_handle.readline().split()
-        input_handle.seek(0)
+        # We sadly cannot use seek(0) as we might be working with the stdin, so
+        # we need to pass that line for processing to the specialized functions.
+        first_line = input_handle.readline()
+        _, *counts = first_line.split()
         is_diff = len(counts) == 2
         # Select differential vs single-column and reversed-stack parsers.
         parse_variants: dict[
             tuple[bool, bool],
-            Callable[[TextIO, bool], tuple[FoldedData, int]]
-            | Callable[[TextIO, bool], tuple[FoldedDiffData, int]],
+            Callable[[TextIO, str, bool], tuple[FoldedData, int]]
+            | Callable[[TextIO, str, bool], tuple[FoldedDiffData, int]],
         ] = {
             (False, False): _parse_folded,
             (False, True): _parse_reverse_folded,
@@ -1975,7 +2030,7 @@ def parse_folded_profile(
             (True, True): _parse_reverse_differential_folded,
         }
         parse_fn = parse_variants[is_diff, is_stack_reverse]
-        result, ignored = parse_fn(input_handle, is_flame_chart)
+        result, ignored = parse_fn(input_handle, first_line, is_flame_chart)
     # Report possible input format violations.
     if ignored:
         print(
@@ -2024,10 +2079,13 @@ def validate_profile_total(profile: FoldedData | FoldedDiffData, settings: Setti
     return settings.total
 
 
-def _parse_folded(input_handle: TextIO, is_flame_chart: bool) -> tuple[FoldedData, int]:
+def _parse_folded(
+    input_handle: TextIO, first_line: str, is_flame_chart: bool
+) -> tuple[FoldedData, int]:
     """Parse a standard (non-differential) folded profile.
 
     :param input_handle: a file handle containing a folded profile.
+    :param first_line: an already read line used to determine the profile type.
     :param is_flame_chart: we are drawing a flame chart; the order of the
            records should be preserved.
 
@@ -2041,16 +2099,19 @@ def _parse_folded(input_handle: TextIO, is_flame_chart: bool) -> tuple[FoldedDat
     str_rsplit = str.rsplit
     list_append = list.append
 
-    for line in input_handle:
-        try:
-            # Using ``rsplit(..., maxsplit=1)`` is faster because the count
-            # is at the end of line.
-            stack, count_str = str_rsplit(line, maxsplit=1)
-            count = float(count_str)
-            total += count
-            list_append(data, (stack, count))
-        except ValueError:
-            ignored += 1
+    # This is a bit of a hack to not duplicate the processing code for both the
+    # already read line and the file handle.
+    for source in ([first_line], input_handle):
+        for line in source:
+            try:
+                # Using ``rsplit(..., maxsplit=1)`` is faster because the count
+                # is at the end of line.
+                stack, count_str = str_rsplit(line, maxsplit=1)
+                count = float(count_str)
+                total += count
+                list_append(data, (stack, count))
+            except ValueError:
+                ignored += 1
 
     # Lexicographic stack order unless we are generating a flame chart.
     if not is_flame_chart:
@@ -2058,13 +2119,16 @@ def _parse_folded(input_handle: TextIO, is_flame_chart: bool) -> tuple[FoldedDat
     return FoldedData(data, total), ignored
 
 
-def _parse_reverse_folded(input_handle: TextIO, is_flame_chart: bool) -> tuple[FoldedData, int]:
+def _parse_reverse_folded(
+    input_handle: TextIO, first_line: str, is_flame_chart: bool
+) -> tuple[FoldedData, int]:
     """Parse a standard (non-differential) folded profile with reversed frames.
 
     The parse function reverses the frames in the stacks such that they are in
     a unified caller-to-callee order.
 
     :param input_handle: a file handle containing a folded profile.
+    :param first_line: an already read line used to determine the profile type.
     :param is_flame_chart: we are drawing a flame chart; the order of the
            records should be preserved.
 
@@ -2080,16 +2144,17 @@ def _parse_reverse_folded(input_handle: TextIO, is_flame_chart: bool) -> tuple[F
     str_join = str.join
     list_append = list.append
 
-    for line in input_handle:
-        try:
-            stack, count_str = str_rsplit(line, maxsplit=1)
-            count = float(count_str)
-            total += count
-            # TODO: We can defer the reversal until the nodes processing when
-            #  generating flame charts since we do not have to sort the stacks.
-            list_append(data, (str_join(";", reversed(str_split(stack, ";"))), count))
-        except ValueError:
-            ignored += 1
+    for source in ([first_line], input_handle):
+        for line in source:
+            try:
+                stack, count_str = str_rsplit(line, maxsplit=1)
+                count = float(count_str)
+                total += count
+                # TODO: We can defer the reversal until the nodes processing when
+                #  generating flame charts since we do not have to sort the stacks.
+                list_append(data, (str_join(";", reversed(str_split(stack, ";"))), count))
+            except ValueError:
+                ignored += 1
 
     if not is_flame_chart:
         data.sort(key=itemgetter(0))
@@ -2097,11 +2162,12 @@ def _parse_reverse_folded(input_handle: TextIO, is_flame_chart: bool) -> tuple[F
 
 
 def _parse_differential_folded(
-    input_handle: TextIO, is_flame_chart: bool
+    input_handle: TextIO, first_line: str, is_flame_chart: bool
 ) -> tuple[FoldedDiffData, int]:
     """Parse a differential folded profile.
 
     :param input_handle: a file handle containing a diff folded profile.
+    :param first_line: an already read line used to determine the profile type.
     :param is_flame_chart: we are drawing a flame chart; the order of the
            records should be preserved.
 
@@ -2115,15 +2181,16 @@ def _parse_differential_folded(
     str_rsplit = str.rsplit
     list_append = list.append
 
-    for line in input_handle:
-        try:
-            stack, count_str, count2_str = str_rsplit(line, maxsplit=2)
-            count = float(count_str)
-            count2 = float(count2_str)
-            total += count2
-            list_append(data, (stack, count, count2))
-        except ValueError:
-            ignored += 1
+    for source in ([first_line], input_handle):
+        for line in source:
+            try:
+                stack, count_str, count2_str = str_rsplit(line, maxsplit=2)
+                count = float(count_str)
+                count2 = float(count2_str)
+                total += count2
+                list_append(data, (stack, count, count2))
+            except ValueError:
+                ignored += 1
 
     if not is_flame_chart:
         data.sort(key=itemgetter(0))
@@ -2131,7 +2198,7 @@ def _parse_differential_folded(
 
 
 def _parse_reverse_differential_folded(
-    input_handle: TextIO, is_flame_chart: bool
+    input_handle: TextIO, first_line: str, is_flame_chart: bool
 ) -> tuple[FoldedDiffData, int]:
     """Parse a differential folded profile with reversed frames.
 
@@ -2139,6 +2206,7 @@ def _parse_reverse_differential_folded(
     a unified caller-to-callee order.
 
     :param input_handle: a file handle containing a folded diff profile.
+    :param first_line: an already read line used to determine the profile type.
     :param is_flame_chart: we are drawing a flame chart; the order of the
            records should be preserved.
 
@@ -2154,20 +2222,21 @@ def _parse_reverse_differential_folded(
     str_join = str.join
     list_append = list.append
 
-    for line in input_handle:
-        try:
-            stack, count_str, count2_str = str_rsplit(line, maxsplit=2)
-            count = float(count_str)
-            count2 = float(count2_str)
-            total += count2
-            # TODO: We can defer the reversal until the nodes processing when
-            #  generating flame charts since we do not have to sort the stacks.
-            list_append(
-                data,
-                (str_join(";", reversed(str_spl(stack, ";"))), count, count2),
-            )
-        except ValueError:
-            ignored += 1
+    for source in ([first_line], input_handle):
+        for line in source:
+            try:
+                stack, count_str, count2_str = str_rsplit(line, maxsplit=2)
+                count = float(count_str)
+                count2 = float(count2_str)
+                total += count2
+                # TODO: We can defer the reversal until the nodes processing when
+                #  generating flame charts since we do not have to sort the stacks.
+                list_append(
+                    data,
+                    (str_join(";", reversed(str_spl(stack, ";"))), count, count2),
+                )
+            except ValueError:
+                ignored += 1
 
     if not is_flame_chart:
         data.sort(key=itemgetter(0))
@@ -3470,6 +3539,8 @@ if __name__ == "__main__":
     _cli_parser.add_argument(
         "infile",
         type=Path,
+        nargs="?",
+        default=None,
         metavar="infile",
         help="The input folded stack file.",
     )

--- a/perun/scripts/meson.build
+++ b/perun/scripts/meson.build
@@ -2,7 +2,10 @@ perun_scripts_dir = perun_dir / 'scripts'
 
 perun_scripts_files = files(
     'difffolded.pl',
+    'difffolded.py',
+    'diff_flamegraph.py',
     'flamegraph.pl',
+    'flamegraph.py',
     'stackcollapse-perf.pl',
 )
 

--- a/perun/view_diff/report_folded.py
+++ b/perun/view_diff/report_folded.py
@@ -501,9 +501,12 @@ class FlameGraphSettings:
     :ivar inverted: whether an icicle graph should be rendered instead
     :ivar rootnode: the root node name
     :ivar total: the total amount of consumed resources
+    :ivar normalize: normalize the sample counts in differential graphs
+    :ivar parallelize: parallelize the creation of flamegraph grids
+    :ivar use_perl: use the Perl variants of flame graph scripts
     :ivar fg_script_path: the path to the flamegraph script
     :ivar difffolded_path: the path to the difffolded script
-    :ivar parallelize: parallelize the creation of flamegraph grids
+    :ivar difffolded_path: the path to the diff_flamegraph script
     """
 
     __slots__ = (
@@ -519,9 +522,12 @@ class FlameGraphSettings:
         "inverted",
         "rootnode",
         "total",
+        "normalize",
+        "parallelize",
+        "use_perl",
         "fg_script_path",
         "difffolded_path",
-        "parallelize",
+        "diff_fg_path",
     )
 
     # Default flamegraph parameters reconstructed from the flamegraph.pl script.
@@ -568,7 +574,9 @@ class FlameGraphSettings:
         inverted: bool = DefaultInverted,
         rootnode: str = DefaultRootNode,
         total: int = DefaultTotal,
+        normalize: bool = False,
         parallelize: bool = True,
+        use_perl_scripts: bool = False,
         **_: Any,
     ) -> None:
         """
@@ -585,6 +593,7 @@ class FlameGraphSettings:
         :param rootnode: the root node name
         :param total: the total amount of consumed resources
         :param parallelize: parallelize the creation of flamegraph grids
+        :param use_perl_scripts: use the Perl variants of flame graph scripts
         """
         # We call the type conversion functions since the parameters may be supplied from CLI
         # where the types do not necessarily have to match.
@@ -600,10 +609,14 @@ class FlameGraphSettings:
         self.inverted: bool = bool(inverted)
         self.rootnode: str = str(rootnode)
         self.total: int = int(total)
+        self.normalize: bool = bool(normalize)
 
-        self.fg_script_path: Path = Path(script_kit.get_script("flamegraph.pl"))
-        self.difffolded_path: Path = Path(script_kit.get_script("difffolded.pl"))
         self.parallelize: bool = parallelize
+        self.use_perl = use_perl_scripts
+        suffix: str = ".pl" if use_perl_scripts else ".py"
+        self.fg_script_path: Path = Path(script_kit.get_script(f"flamegraph{suffix}"))
+        self.difffolded_path: Path = Path(script_kit.get_script(f"difffolded.pl"))
+        self.diff_fg_path: Path = Path(script_kit.get_script(f"diff_flamegraph.py"))
 
     @classmethod
     def from_cli(cls, **cli_kwargs: Any) -> FlameGraphSettings:
@@ -836,8 +849,9 @@ class FlameGraphGridParallelBuilder(contextlib.ExitStack):
     :ivar fg_handles: handles to temporary output files for the created flamegraphs; pipes have
           limited buffer sizes and we do not want to periodically scan for output or use blocking
           methods for reading the output
-    :ivar diff_processes: handles of difffolded.pl processes that generate data for diff flamegraphs
-    :ivar fg_processes: handles of flamegraph.pl processes
+    :ivar diff_processes: handles of difffolded.pl (.py) processes that generate data for diff
+          flamegraphs
+    :ivar fg_processes: handles of flamegraph.pl (.py) processes
     :ivar grid: a reference to the grid object for the generated flamegraphs; context managers
           cannot explicitly return values, hence we use an output parameter
     """
@@ -867,21 +881,28 @@ class FlameGraphGridParallelBuilder(contextlib.ExitStack):
             self.enter_context(tempfile.NamedTemporaryFile(mode="w+")) for _ in range(4)
         ]
         # Spawn two difffolded processes: one for each diff flamegraph.
-        # Note: PyCharm incorrectly shows typing errors related to the context manager return types.
-        #  However, everything is typed correctly according to mypy.
-        self.diff_processes = [
-            self.enter_context(
-                processes.nonblocking_subprocess(
-                    grid_commands.baseline_target_difffolded, {"stdout": PIPE}
-                )
-            ),
-            self.enter_context(
-                processes.nonblocking_subprocess(
-                    grid_commands.target_baseline_difffolded, {"stdout": PIPE}
-                )
-            ),
-        ]
-        # Spawn four flamegraph.pl processes: one for each flamegraph in the grid.
+        # The processes should be spawned only if we are using the original Perl scripts and not
+        # the optimized Python ones, which is indicated by empty difffolded commands.
+        if grid_commands.baseline_target_difffolded:
+            self.diff_processes = [
+                self.enter_context(
+                    processes.nonblocking_subprocess(
+                        grid_commands.baseline_target_difffolded, {"stdout": PIPE}
+                    )
+                ),
+                self.enter_context(
+                    processes.nonblocking_subprocess(
+                        grid_commands.target_baseline_difffolded, {"stdout": PIPE}
+                    )
+                ),
+            ]
+        # Spawn four flamegraph processes: one for each flamegraph in the grid.
+        base_tar_kwargs: dict[str, Any] = {"stdout": self.fg_handles[2]}
+        tar_base_kwargs: dict[str, Any] = {"stdout": self.fg_handles[3]}
+        # Handle both Perl and Python versions.
+        if grid_commands.baseline_target_difffolded:
+            base_tar_kwargs["stdin"] = self.diff_processes[0].stdout
+            tar_base_kwargs["stdin"] = self.diff_processes[1].stdout
         self.fg_processes = [
             self.enter_context(
                 processes.nonblocking_subprocess(
@@ -896,13 +917,13 @@ class FlameGraphGridParallelBuilder(contextlib.ExitStack):
             self.enter_context(
                 processes.nonblocking_subprocess(
                     grid_commands.baseline_target_fg_diff,
-                    {"stdin": self.diff_processes[0].stdout, "stdout": self.fg_handles[2]},
+                    base_tar_kwargs,
                 )
             ),
             self.enter_context(
                 processes.nonblocking_subprocess(
                     grid_commands.target_baseline_fg_diff,
-                    {"stdin": self.diff_processes[1].stdout, "stdout": self.fg_handles[3]},
+                    tar_base_kwargs,
                 )
             ),
         ]
@@ -1714,13 +1735,13 @@ def build_flamegraph_command(
     *new_flags: str,
     **override_kwargs: Any,
 ) -> str:
-    """Create a flamegraph.pl command to generate a flame graph.
+    """Create a command to generate a flame graph.
 
     :param input_path: a path to the file with folded flame graph data; may be omitted in which case
-           the input data should be supplied to the flamegraph.pl process via stdin
+           the input data should be supplied to the flamegraph process via stdin
     :param settings: flamegraph configuration parameters and flags
     :param title: the title of the flame graph
-    :param new_flags: additional flags that should be passed to the flamegraph.pl script
+    :param new_flags: additional flags that should be passed to the flamegraph script
     :param override_kwargs: additional parameters that should extend or override the parameter
            values stored in the settings object
 
@@ -1732,11 +1753,63 @@ def build_flamegraph_command(
         "--title",
         f"'{title}'",
     ]
+    # Extend the command with parameters.
+    cmd.extend(_add_flamegraph_params(settings, *new_flags, **override_kwargs))
+    return " ".join(cmd)
+
+
+def build_diff_flamegraph_py_command(
+    baseline_path: Path,
+    target_path: Path,
+    settings: FlameGraphSettings,
+    title: str,
+    *new_flags: str,
+    **override_kwargs: Any,
+) -> str:
+    """Create a command to generate a diff flame graph using our helper script.
+
+    :param baseline_path: a path to the file with baseline folded flame graph data
+    :param target_path: a path to the file with target folded flame graph data
+    :param settings: flamegraph configuration parameters and flags
+    :param title: the title of the flame graph
+    :param new_flags: additional flags that should be passed to the flamegraph script
+    :param override_kwargs: additional parameters that should extend or override the parameter
+           values stored in the settings object
+
+    :return: the command for generating a flame graph
+    """
+    cmd = [
+        str(settings.diff_fg_path),
+        str(baseline_path),
+        str(target_path),
+        "--title",
+        f"'{title}'",
+    ]
+    # Extend the command with parameters.
+    cmd.extend(_add_flamegraph_params(settings, *new_flags, **override_kwargs))
+    return " ".join(cmd)
+
+
+def _add_flamegraph_params(
+    settings: FlameGraphSettings,
+    *new_flags: str,
+    **override_kwargs: Any,
+) -> list[str]:
+    """Construct a collection of flags and keyword arguments for a flamegraph script.
+
+    :param settings: flamegraph configuration parameters and flags
+    :param new_flags: additional flags that should be passed to the flamegraph script
+    :param override_kwargs: additional parameters that should extend or override the parameter
+           values stored in the settings object
+
+    :return: a list of flags and parameters
+    """
+    params: list[str] = []
     # Extend the command with flags.
     flags: set[str] = set(new_flags)
     if settings.inverted and "inverted" not in new_flags:
         flags.add("inverted")
-    cmd.extend(f"--{flag}" for flag in flags)
+    params.extend(f"--{flag}" for flag in flags)
 
     # Extend the command with flamegraph parameters that have non-default values.
     # Although we could supply the parameters with default values as well, it would needlessly
@@ -1746,9 +1819,9 @@ def build_flamegraph_command(
     kw_params.update(override_kwargs)
     for key, val in kw_params.items():
         if val is not None:
-            cmd.append(f"--{key}")
-            cmd.append(f"'{val}'")
-    return " ".join(cmd)
+            params.append(f"--{key}")
+            params.append(f"'{val}'")
+    return params
 
 
 def build_differential_flamegraph_commands(
@@ -1759,20 +1832,32 @@ def build_differential_flamegraph_commands(
     *new_flags: str,
     **override_kwargs: Any,
 ) -> tuple[str, str]:
-    """Create difffolded.pl and flamegraph.pl commands to generate a differential flame graph.
+    """Create diffing and flamegraph commands to generate a differential flame graph.
 
     :param baseline: a path to the file with baseline folded flame graph data
     :param target: a path to the file with target folded flame graph data
     :param settings: flamegraph configuration parameters and flags
     :param title: the title of the flame graph
-    :param new_flags: additional flags that should be passed to the flamegraph.pl script
+    :param new_flags: additional flags that should be passed to the flamegraph script
     :param override_kwargs: additional parameters that should extend or override the parameter
            values stored in the settings object
 
-    :return: the difffolded.pl and flamegraph.pl commands for generating a differential flame graph
+    :return: the difffolded and flamegraph commands for generating a differential flame graph
     """
-    diff_cmd = f"{settings.difffolded_path} -n {baseline} {target}"
-    fg_cmd = build_flamegraph_command(None, settings, title, *new_flags, **override_kwargs)
+    if settings.use_perl:
+        normalize_flag = ""
+        if settings.normalize or "normalize" in new_flags:
+            normalize_flag = "-n"
+        diff_cmd = f"{settings.difffolded_path} {normalize_flag} {baseline} {target}"
+        fg_cmd = build_flamegraph_command(None, settings, title, *new_flags, **override_kwargs)
+    else:
+        diff_cmd = ""
+        extended_flags = list(new_flags)
+        if settings.normalize and "normalize" not in new_flags:
+            extended_flags.append("normalize")
+        fg_cmd = build_diff_flamegraph_py_command(
+            baseline, target, settings, title, *extended_flags, **override_kwargs
+        )
     return diff_cmd, fg_cmd
 
 
@@ -1789,7 +1874,7 @@ def build_flamegraph_grid_commands(
     :param baseline: a path to the file with baseline folded flame graph data
     :param target: a path to the file with target folded flame graph data
     :param settings: flamegraph configuration parameters and flags
-    :param new_flags: additional flags that should be passed to the flamegraph.pl script
+    :param new_flags: additional flags that should be passed to the flamegraph script
     :param titles: the titles of the respective flamegraphs
     :param override_kwargs: additional parameters that should extend or override the parameter
            values stored in the settings object
@@ -1808,22 +1893,32 @@ def build_flamegraph_grid_commands(
     )
 
 
-def build_flamegraph_grid_serially(grid_commands: FlameGraphGridCommands) -> FlameGraphGrid:
+def build_flamegraph_grid_serially(grid_cmds: FlameGraphGridCommands) -> FlameGraphGrid:
     """Create a flamegraph grid serially in this process.
 
-    :param grid_commands: the commands for generating a flamegraph grid
+    :param grid_cmds: the commands for generating a flamegraph grid
 
     :return: the generated flamegraph grid
     """
     log.major_info("Creating Flame Graph Grid (Serially)")
 
     # Transform the commands into a tuple that we can index in a loop.
-    cmds: tuple[str, str, str, str] = (
-        grid_commands.baseline,
-        grid_commands.target,
-        f"{grid_commands.baseline_target_difffolded} | {grid_commands.baseline_target_fg_diff}",
-        f"{grid_commands.target_baseline_difffolded} | {grid_commands.target_baseline_fg_diff}",
-    )
+    if grid_cmds.baseline_target_difffolded:
+        # Perl variant.
+        cmds: tuple[str, str, str, str] = (
+            grid_cmds.baseline,
+            grid_cmds.target,
+            f"{grid_cmds.baseline_target_difffolded} | {grid_cmds.baseline_target_fg_diff}",
+            f"{grid_cmds.target_baseline_difffolded} | {grid_cmds.target_baseline_fg_diff}",
+        )
+    else:
+        # Python variant.
+        cmds = (
+            grid_cmds.baseline,
+            grid_cmds.target,
+            grid_cmds.baseline_target_fg_diff,
+            grid_cmds.target_baseline_fg_diff,
+        )
 
     grid: FlameGraphGrid = FlameGraphGrid()
     for idx, (fg_cmd, tag) in enumerate(zip(cmds, FlameGraphGrid.EscapeTags)):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -194,7 +194,8 @@ source = [
 omit = [
     "tests/*",
     "perun/collect/trace/*",
-    "perun/thirdparty/*"
+    "perun/thirdparty/*",
+    "perun/scripts/"  # FIXME: The Python scripts are only temporary.
 ]
 
 [tool.coverage.report]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -80,11 +80,11 @@ def test_regressogram_incorrect(pcs_single_prof):
     """
     incorrect_tests = [
         # Test non-existing argument
-        {"params": ["-a"], "output": "No such option: -a"},
+        {"params": ["-a"], "output": "No such option '-a'"},
         # Test malformed bucket_number argument
         {
             "params": ["--buckets_numbers"],
-            "output": "No such option: --buckets_numbers",
+            "output": "No such option '--buckets_numbers'",
         },
         # Test missing bucket_number value
         {"params": ["-bn"], "output": "Option '-bn' requires an argument."},
@@ -93,7 +93,7 @@ def test_regressogram_incorrect(pcs_single_prof):
         # Test malformed bucket_method argument
         {
             "params": ["--buckets_methods"],
-            "output": "No such option: --buckets_methods",
+            "output": "No such option '--buckets_methods'",
         },
         # Test missing bucket_method value
         {
@@ -105,7 +105,7 @@ def test_regressogram_incorrect(pcs_single_prof):
         # Test malformed statistic_function argument
         {
             "params": ["--statistic_functions"],
-            "output": "No such option: --statistic_functions",
+            "output": "No such option '--statistic_functions'",
         },
         # Test invalid model name
         {"params": ["-sf", "max"], "output": "Invalid value"},
@@ -224,13 +224,13 @@ def test_moving_average_incorrect(pcs_single_prof):
     incorrect_tests = [
         # TESTS MOVING AVERAGE COMMAND AND OPTIONS
         # 1. Test non-existing argument
-        {"params": ["--abcd"], "output": "No such option: --abcd"},
+        {"params": ["--abcd"], "output": "No such option '--abcd'"},
         # 2. Test non-existing command
         {"params": ["cma"], "output": "No such command"},
         # 3. Test non-existing argument
-        {"params": ["-b"], "output": "No such option: -b"},
+        {"params": ["-b"], "output": "No such option '-b'"},
         # 4. Test malformed min_periods argument
-        {"params": ["--min_period"], "output": "No such option: --min_period"},
+        {"params": ["--min_period"], "output": "No such option '--min_period'"},
         # 5. Test missing min_period value
         {"params": ["-mp"], "output": "Option '-mp' requires an argument."},
         # 6. Test invalid range min_periods value
@@ -238,20 +238,20 @@ def test_moving_average_incorrect(pcs_single_prof):
         # 7. Test invalid value type min_periods value
         {"params": ["-mp", "A"], "output": "Invalid value"},
         # 8. Test malformed per_key argument
-        {"params": ["--per-keys"], "output": "No such option: --per-keys"},
+        {"params": ["--per-keys"], "output": "No such option '--per-keys'"},
         # 9. Test missing per_key value
         {"params": ["-per"], "output": "Option '-per' requires an argument."},
         # 10. Test invalid value per_key arguments
         {"params": ["--per-key", "unknown"], "output": "Invalid value"},
         # 11. Test malformed of_key argument
-        {"params": ["--off"], "output": "No such option: --off"},
+        {"params": ["--off"], "output": "No such option '--off'"},
         # 12. Test missing of_key value
         {"params": ["--of-key"], "output": "Option '--of-key' requires an argument."},
         # 13. Test invalid value of_key arguments
         {"params": ["-of", "unknown"], "output": "Invalid value"},
         # TESTS SIMPLE MOVING AVERAGE COMMAND AND SIMPLE MOVING MEDIAN COMMAND
         # 14. Test malformed window-width argument
-        {"params": ["--window_widh"], "output": "No such option: --window_widh"},
+        {"params": ["--window_widh"], "output": "No such option '--window_widh'"},
         # 15. Test missing window-width value
         {"params": ["-ww"], "output": "Option '-ww' requires an argument."},
         # 16. Test invalid range window-width argument
@@ -259,9 +259,9 @@ def test_moving_average_incorrect(pcs_single_prof):
         # 17. Test invalid value type window-width argument
         {"params": ["--window_width", 0.5], "output": "Invalid value"},
         # 18. Test malformed center argument
-        {"params": ["--centers"], "output": "No such option: --centers"},
+        {"params": ["--centers"], "output": "No such option '--centers'"},
         # 19. Test malformed no-center argument
-        {"params": ["--mo-center"], "output": "No such option: --mo-center"},
+        {"params": ["--mo-center"], "output": "No such option '--mo-center'"},
         # 20. Test value for center argument
         {
             "params": ["--center", "True"],
@@ -274,7 +274,7 @@ def test_moving_average_incorrect(pcs_single_prof):
         },
         # TESTS SIMPLE MOVING AVERAGE COMMAND
         # 22. Test malformed window-type argument
-        {"params": ["--windov_type"], "output": "No such option: --windov_type"},
+        {"params": ["--windov_type"], "output": "No such option '--windov_type'"},
         # 23. Test missing window-type value
         {
             "params": ["--window_type"],
@@ -284,7 +284,7 @@ def test_moving_average_incorrect(pcs_single_prof):
         {"params": ["-wt", "boxcars"], "output": "Invalid value"},
         # TESTS EXPONENTIAL MOVING AVERAGE COMMAND
         # 25. Test malformed decay argument
-        {"params": ["--decays"], "output": "No such option: --decays"},
+        {"params": ["--decays"], "output": "No such option '--decays'"},
         # 26. Test missing decay value
         {"params": ["-d"], "output": "Option '-d' requires 2 arguments."},
         # 27. Test invalid type of first value in decay argument
@@ -463,19 +463,19 @@ def test_kernel_regression_incorrect(pcs_single_prof):
     incorrect_tests = [
         # TEST COMMON OPTIONS OF KERNEL-REGRESSION CLI AND IT COMMANDS
         # 1. Test non-existing argument
-        {"params": ["--ajax"], "output": "No such option: --ajax"},
+        {"params": ["--ajax"], "output": "No such option '--ajax'"},
         # 2. Test non-existing command
         {"params": ["my-selection"], "output": "No such command"},
         # 3. Test non-existing argument
-        {"params": ["-c"], "output": "No such option: -c"},
+        {"params": ["-c"], "output": "No such option '-c'"},
         # 4. Test malformed per-key argument
-        {"params": ["--per-keys"], "output": "No such option: --per-keys"},
+        {"params": ["--per-keys"], "output": "No such option '--per-keys'"},
         # 5. Test missing per-key value
         {"params": ["-per"], "output": "Option '-per' requires an argument."},
         # 6. Test invalid value for per-key argument
         {"params": ["--per-key", "randomize"], "output": "Invalid value"},
         # 7. Test malformed of-key argument
-        {"params": ["--off-key"], "output": "No such option: --off-key"},
+        {"params": ["--off-key"], "output": "No such option '--off-key'"},
         # 8. Test missing of-key value
         {"params": ["-of"], "output": "Option '-of' requires an argument."},
         # 9. Test invalid value for per-key argument
@@ -492,7 +492,7 @@ def test_kernel_regression_incorrect(pcs_single_prof):
         {"params": ["kernel-rigde"], "output": "No such command"},
         # TEST OPTIONS OF ESTIMATOR-SETTINGS MODES IN KERNEL-REGRESSION CLI
         # 15. Test malformed reg-type argument
-        {"params": ["--reg-types"], "output": "No such option: --reg-types"},
+        {"params": ["--reg-types"], "output": "No such option '--reg-types'"},
         # 16. Test missing reg-type value
         {"params": ["-rt"], "output": "Option '-rt' requires an argument."},
         # 17. Test invalid value for reg-type argument
@@ -500,28 +500,28 @@ def test_kernel_regression_incorrect(pcs_single_prof):
         # 18. Test malformed bandwidth-method argument
         {
             "params": ["--bandwidht-method"],
-            "output": "No such option: --bandwidht-method",
+            "output": "No such option '--bandwidht-method'",
         },
         # 19. Test missing bandwidth-value value
         {"params": ["-bw"], "output": "Option '-bw' requires an argument."},
         # 20. Test invalid value for bandwidth-value argument
         {"params": ["-bw", "cv-ls"], "output": "Invalid value"},
         # 21. Test malformed n-sub argument
-        {"params": ["--n-sub-sample"], "output": "No such option: --n-sub-sample"},
+        {"params": ["--n-sub-sample"], "output": "No such option '--n-sub-sample'"},
         # 22. Test missing n-sub argument
         {"params": ["-nsub"], "output": "Option '-nsub' requires an argument."},
         # 23. Test invalid value for n-sub argument
         {"params": ["-nsub", 0], "output": "Invalid value"},
         # 24. Test malformed n-res argument
-        {"params": ["--n-re-sample"], "output": "No such option: --n-re-sample"},
+        {"params": ["--n-re-sample"], "output": "No such option '--n-re-sample'"},
         # 25. Test missing n-sub argument
         {"params": ["-nres"], "output": "Option '-nres' requires an argument."},
         # 26. Test invalid value for n-sub argument
         {"params": ["--n-re-samples", 0], "output": "Invalid value"},
         # 27. Test malformed efficient argument
-        {"params": ["--eficient"], "output": "No such option: --eficient"},
+        {"params": ["--eficient"], "output": "No such option '--eficient'"},
         # 28. Test malformed no-uniformly argument
-        {"params": ["--uniformlys"], "output": "No such option: --uniformlys"},
+        {"params": ["--uniformlys"], "output": "No such option '--uniformlys'"},
         # 29. Test value for efficient argument
         {
             "params": ["--efficient", "True"],
@@ -533,9 +533,9 @@ def test_kernel_regression_incorrect(pcs_single_prof):
             "output": "Got unexpected extra argument (False)",
         },
         # 31. Test malformed randomize argument
-        {"params": ["--randomized"], "output": "No such option: --randomized"},
+        {"params": ["--randomized"], "output": "No such option '--randomized'"},
         # 32. Test malformed no-randomize argument
-        {"params": ["--no-randomized"], "output": "No such option: --no-randomized"},
+        {"params": ["--no-randomized"], "output": "No such option '--no-randomized'"},
         # 33. Test value for randomize argument
         {
             "params": ["--randomize", "False"],
@@ -547,9 +547,9 @@ def test_kernel_regression_incorrect(pcs_single_prof):
             "output": "Got unexpected extra argument (True)",
         },
         # 35. Test malformed return-median argument
-        {"params": ["--returns-median"], "output": "No such option: --returns-median"},
+        {"params": ["--returns-median"], "output": "No such option '--returns-median'"},
         # 36. Test malformed return-mean argument
-        {"params": ["--returns-mean"], "output": "No such option: --returns-mean"},
+        {"params": ["--returns-mean"], "output": "No such option '--returns-mean'"},
         # 37. Test value for return-median argument
         {
             "params": ["--return-median", "True"],
@@ -562,7 +562,7 @@ def test_kernel_regression_incorrect(pcs_single_prof):
         },
         # TEST OPTIONS OF METHOD-SELECTION MODES IN KERNEL-REGRESSION CLI
         # 39. Test malformed reg-type argument
-        {"params": ["--reg-types"], "output": "No such option: --reg-types"},
+        {"params": ["--reg-types"], "output": "No such option '--reg-types'"},
         # 40. Test missing reg-type value
         {"params": ["-rt"], "output": "Option '-rt' requires an argument."},
         # 41. Test invalid value for reg-type argument
@@ -570,7 +570,7 @@ def test_kernel_regression_incorrect(pcs_single_prof):
         # 42. Test malformed bandwidth-method argument
         {
             "params": ["--bandwidth-methods"],
-            "output": "No such option: --bandwidth-methods",
+            "output": "No such option '--bandwidth-methods'",
         },
         # 43. Test missing bandwidth-method value
         {"params": ["-bm"], "output": "Option '-bm' requires an argument."},
@@ -578,7 +578,7 @@ def test_kernel_regression_incorrect(pcs_single_prof):
         {"params": ["-bm", "goldman"], "output": "Invalid value"},
         # TEST OPTIONS OF USER-SELECTION MODES IN KERNEL-REGRESSION CLI
         # 45. Test malformed reg-type argument
-        {"params": ["--reg-types"], "output": "No such option: --reg-types"},
+        {"params": ["--reg-types"], "output": "No such option '--reg-types'"},
         # 46. Test missing reg-type value
         {"params": ["-rt"], "output": "Option '-rt' requires an argument."},
         # 47. Test invalid value for reg-type argument
@@ -586,7 +586,7 @@ def test_kernel_regression_incorrect(pcs_single_prof):
         # 48. Test malformed bandwidth-value argument
         {
             "params": ["--bandwidth-values"],
-            "output": "No such option: --bandwidth-values",
+            "output": "No such option '--bandwidth-values'",
         },
         # 49. Test missing bandwidth-value value
         {"params": ["-bv"], "output": "Option '-bv' requires an argument."},
@@ -594,7 +594,7 @@ def test_kernel_regression_incorrect(pcs_single_prof):
         {"params": ["--bandwidth-value", -2], "output": "Invalid value"},
         # TEST OPTIONS OF KERNEL-RIDGE MODES IN KERNEL-REGRESSION CLI
         # 51. Test malformed gamma-range argument
-        {"params": ["--gama-range"], "output": "No such option: --gama-range"},
+        {"params": ["--gama-range"], "output": "No such option '--gama-range'"},
         # 52. Test missing gamma-range value
         {"params": ["-gr"], "output": "Option '-gr' requires 2 arguments."},
         # 53. Test wrong count of value gamma-range argument
@@ -610,7 +610,7 @@ def test_kernel_regression_incorrect(pcs_single_prof):
             "output": "Invalid values: 1.value must be < then the 2.value",
         },
         # 56. Test malformed gamma-step argument
-        {"params": ["--gamma-steps"], "output": "No such option: --gamma-steps"},
+        {"params": ["--gamma-steps"], "output": "No such option '--gamma-steps'"},
         # 57. Test missing gamma-step value
         {"params": ["-gs"], "output": "Option '-gs' requires an argument."},
         # 58. Test invalid value gamma-step argument no.1
@@ -622,7 +622,7 @@ def test_kernel_regression_incorrect(pcs_single_prof):
         },
         # TEST OPTIONS OF KERNEL-SMOOTHING MODES IN KERNEL-REGRESSION CLI
         # 60. Test malformed kernel-type argument
-        {"params": ["--kernel-typse"], "output": "No such option: --kernel-typse"},
+        {"params": ["--kernel-typse"], "output": "No such option '--kernel-typse'"},
         # 61. Test missing kernel-type value
         {"params": ["-kt"], "output": "Option '-kt' requires an argument."},
         # 62. Test invalid value of kernel-type argument
@@ -630,14 +630,14 @@ def test_kernel_regression_incorrect(pcs_single_prof):
         # 63. Test malformed smoothing-method argument
         {
             "params": ["--smothing-method"],
-            "output": "No such option: --smothing-method",
+            "output": "No such option '--smothing-method'",
         },
         # 64. Test missing smoothing-method value
         {"params": ["-sm"], "output": "Option '-sm' requires an argument."},
         # 65. Test invalid value of smoothing method argument
         {"params": ["-sm", "local-constant"], "output": "Invalid value"},
         # 66. Test malformed bandwidth-value argument
-        {"params": ["--bandwith-value"], "output": "No such option: --bandwith-value"},
+        {"params": ["--bandwith-value"], "output": "No such option '--bandwith-value'"},
         # 67. Test missing bandwidth-value value
         {"params": ["-bv"], "output": "Option '-bv' requires an argument."},
         # 68. Test invalid value for bandwidth-value argument
@@ -645,7 +645,7 @@ def test_kernel_regression_incorrect(pcs_single_prof):
         # 69. Test malformed bandwidth-method argument
         {
             "params": ["--bandwidht-method"],
-            "output": "No such option: --bandwidht-method",
+            "output": "No such option '--bandwidht-method'",
         },
         # 70. Test missing bandwidth-method value
         {"params": ["-bm"], "output": "Option '-bm' requires an argument."},
@@ -654,7 +654,7 @@ def test_kernel_regression_incorrect(pcs_single_prof):
         # 72. Test malformed polynomial-order argument
         {
             "params": ["--polynomila-order"],
-            "output": "No such option: --polynomila-order",
+            "output": "No such option '--polynomila-order'",
         },
         # 73. Test missing value for polynomial-order argument
         {"params": ["-q"], "output": "Option '-q' requires an argument."},
@@ -915,12 +915,12 @@ def test_reg_analysis_incorrect(pcs_single_prof):
     # Test non-existing argument
     result = runner.invoke(cli.postprocessby, ["0@i", "regression-analysis", "-f"])
     asserts.predicate_from_cli(result, result.exit_code == 2)
-    asserts.predicate_from_cli(result, "No such option: -f" in result.output)
+    asserts.predicate_from_cli(result, "No such option '-f'" in result.output)
 
     # Test malformed method argument
     result = runner.invoke(cli.postprocessby, ["0@i", "regression-analysis", "--metod", "full"])
     asserts.predicate_from_cli(result, result.exit_code == 2)
-    asserts.predicate_from_cli(result, "No such option: --metod" in result.output)
+    asserts.predicate_from_cli(result, "No such option '--metod'" in result.output)
 
     # Test missing method value
     result = runner.invoke(cli.postprocessby, ["0@i", "regression-analysis", "-m"])
@@ -938,7 +938,7 @@ def test_reg_analysis_incorrect(pcs_single_prof):
         ["0@i", "regression-analysis", "--method", "full", "--regresion_models"],
     )
     asserts.predicate_from_cli(result, result.exit_code == 2)
-    asserts.predicate_from_cli(result, "No such option: --regresion_models" in result.output)
+    asserts.predicate_from_cli(result, "No such option '--regresion_models'" in result.output)
 
     # Test missing model value
     result = runner.invoke(
@@ -969,7 +969,7 @@ def test_reg_analysis_incorrect(pcs_single_prof):
         ["0@i", "regression-analysis", "-m", "full", "-r", "all", "--seps"],
     )
     asserts.predicate_from_cli(result, result.exit_code == 2)
-    asserts.predicate_from_cli(result, " No such option: --seps" in result.output)
+    asserts.predicate_from_cli(result, " No such option '--seps'" in result.output)
 
     # Test missing steps value
     result = runner.invoke(

--- a/tests/test_diff_views.py
+++ b/tests/test_diff_views.py
@@ -153,8 +153,11 @@ def test_diff_flamegraph_invalid_param(pcs_with_root):
         ],
     )
     assert result.exit_code == 0
-    assert 'Unrecognized bgcolor option "invalid_color"' in result.output
-    assert Path.cwd() / "flamegraph_warn.html" in Path.cwd().iterdir()
+    # Test both Perl and Python variants of the error message.
+    assert (
+        'Unrecognized bgcolor option "invalid_color"' in result.output
+        or "Unrecognized --bgcolors option 'invalid_color'"
+    )
 
 
 def test_diff_report_native(pcs_with_root):


### PR DESCRIPTION
# Overview

This PR adds Python translations of the original Perl scripts `difffolded.pl` and `flamegraph.pl`. The Python versions offer better performance than the original Perl versions and are easier to integrate directly into Python code if needed.

It also adds a helper script that combines both `difffolded.py` and `flamegraph.py` to draw a differential flame graph directly from two profiles. For large profiles, this is even faster than piping the two python scripts together. 

Finally, the Python versions extend the original Perl scripts with new CLI options and fixes some bugs, e.g., missing frames in differential flame graphs.

The Python scripts are now used by default when generating folded reports. It is possible to revert to the Perl versions via a flag `--flamegraph-use-perl-scripts`.

# Performance measurements

Similarly to #343, I did a crude local performance measurements using profiles from two `stress-ng` benchmarks, `mmapmany` and `fio`, as representatives of small and large inputs. I have measured the performance of both the individual scripts and generating a folded report.

| Input | Profile Size (MB) |
|--------- | ----------------------- |
| `mmapmany-base` | ~ 0.26 |
| `mmapmany-tar`  | ~ 0.71 |
| `fio-base`  | ~ 158 |
| `fio-tar`   | ~ 74 |

**Summary**

Overall, the Python scripts are slower and consume more memory for small folded profiles. This is caused mostly by the Python VM overhead, which accounts for ~40-50ms startup time and ~3.7 MB heap memory usage. However, this additional cost is mostly insignificant when constructing reports.

For large profiles, the new Python versions show significant improvements both in execution time and memory consumption. For example, generating a `fio` folded report shows a 2x speedup.

Despite the lackluster performance for small profiles, the Python version will help us integrate flame graph generation directly into our code (instead of creating `subprocess`es and passing data through files), which will lead to performance gains in the future. It will also make it easier to extend the flame graphs with new features that had to be written in Perl before.

**Individual scripts**

| Command | Peak Memory Usage (MB) | Elapsed Time (s) |
| ------------------------- | ------------------------------------- | ----------------------- |
| `difffolded.py fio-base fio-tar` | 114  | 1.33 |
| `difffolded.pl fio-base fio-tar`  | 334  | 2.8 |
| `difffolded.py mmapmany-base mmapmany-tar` | 4.4  | 0.067 |
| `difffolded.pl mmapmany-base mmapmany-tar`  | 1.5  | 0.014 |
| `flamegraph.py fio-base` | 101  | 1.38 |
| `flamegraph.pl fio-base`  | 544  | 10.8 |
| `flamegraph.py mmapmany-base` | 7.7  | 0.087 |
| `flamegraph.pl mmapmany-base`  | 3.7  | 0.051 |
| `difffolded.py fio-base fio-tar \| flamegraph.py` | 114 + 101  | 2.44 |
| `difffolded.pl fio-base fio-tar \| flamegraph.pl`  | 334 + 593  | 11.82 |
| `diff_flamegraph.py fio-base fio-tar` | 114  | 1.99 |
| `difffolded.py mmapmany-base mmapmany-tar \| flamegraph.py` | 4.4 + 7.7  | 0.104 |
| `difffolded.pl mmapmany-base mmapmany-tar \| flamegraph.pl`  | 1.5 + 3.9  | 0.049 |
| `diff_flamegraph.py mmapmany-base mmapmany-tar` | 8.5 | 0.114 |


**Folded Reports**

| Command |  Elapsed Time (s) |
| ----------------| ------------------------ |
| `report --parallel --python fio-base fio-tar` | 18.1 |
| `report --parallel --perl fio-base fio-tar` | 33.4 |
| `report  --serial --python fio-base fio-tar`  | 24.2 |
| `report  --serial --perl fio-base fio-tar`   | 63.2 |
| `report --parallel --python mmapmany-base mmapmany-tar` | 1.18 |
| `report --parallel --perl mmapmany-base mmapmany-tar`   | 1.1 |
| `report  --serial --python mmapmany-base mmapmany-tar`   | 1.4 |
| `report  --serial --perl mmapmany-base mmapmany-tar`   | 1.2 |


This PR resolves #344.