### PR TITLE
Release version 0.27.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,15 @@ Changelog
 =========
 
 
+0.27.2 (2026-05-23)
+-------------------
+
+  - The flamegraphs are now by default generated using native Python scripts.
+  - Flamegraphs in reports now have an additional sub-root node that can be zoomed to unscale the graph w.r.t. the compared one.
+  - Flamegraphs in reports now support exclusive consumption view.
+  - Tabular view in reports now also renders a table with exclusive resource consumption.
+
+
 0.27.1 (2026-04-22)
 -------------------
 

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
     'perun',
     'c',
-    version: '0.27.1',
+    version: '0.27.2',
     license: 'GPL-3',
     meson_version: '>=1.0.0',
     default_options: [


### PR DESCRIPTION
Changelog:

  - The flamegraphs are now by default generated using native Python scripts.
  - Flamegraphs in reports now have an additional sub-root node that can be zoomed to unscale the graph w.r.t. the compared one.
  - Flamegraphs in reports now support exclusive consumption view.
  - Tabular view in reports now also renders a table with exclusive resource consumption.