### PR TITLE
Fix flame graph and tree map grid flicker in Chrome

### DIFF
--- a/perun/scripts/flamegraph.py
+++ b/perun/scripts/flamegraph.py
@@ -1574,6 +1574,7 @@ def create_svg_js_css(
 </defs>
 <style type="text/css">
     text {{ font-family:{settings.font_type}; font-size:{settings.font_size}px; fill:{Colors.RGBblack}; }}
+    #frames > g > text {{ pointer-events:none; }}
     #search, #ignorecase, #excToggle {{ opacity:0.5; cursor:pointer; }}
     #search:hover, #search.show, #ignorecase:hover, #ignorecase.show, #excToggle:hover {{ opacity:1; }}
     #subtitle {{ text-anchor:middle; font-color:{Colors.RGBvdgrey}; }}
@@ -1592,6 +1593,7 @@ def create_svg_js_css(
     var nameTypeLabel, inclusiveLabel, exclusiveLabel;
     var detailsName, detailsExcl, detailsIncl;
     var exclusiveMode;
+    var detailsGroup = null;
     var isDiff = {'true' if is_diff else 'false'};
     function init(evt) {{
         nameTypeLabel = document.getElementById("nameTypeLabel");
@@ -1650,6 +1652,8 @@ def create_svg_js_css(
     window.addEventListener("mouseover", function(e) {{
         var target = find_group(e.target);
         if (!target) return;
+        if (target === detailsGroup) return;
+        detailsGroup = target;
 
         nameTypeLabel.classList.remove("hide");
         inclusiveLabel.classList.remove("hide");
@@ -1669,6 +1673,8 @@ def create_svg_js_css(
     window.addEventListener("mouseout", function(e) {{
         var target = find_group(e.target);
         if (!target) return;
+        if (is_event_still_in_group(e, target)) return;
+        detailsGroup = null;
 
         nameTypeLabel.classList.add("hide");
         if (!searching) {{
@@ -1691,6 +1697,56 @@ def create_svg_js_css(
         if (!parent) return;
         if (parent.id == "frames") return node;
         return find_group(parent);
+    }}
+    function is_event_still_in_group(evt, group) {{
+        var related = evt.relatedTarget;
+        if (!related) return false;
+        return group === related || group.contains(related);
+    }}
+    function is_hover_highlighted(rect, overlay) {{
+        if (rect.getAttribute("fill") == "{Colors.RGBhover}") return true;
+        if (!overlay) return false;
+        var fill = overlay.getAttribute("fill");
+        return fill == "{Colors.RGBhover}" || fill == "{Colors.RGBhoverOverlay}";
+    }}
+    function restore_frame_after_hover(frameEl) {{
+        var func = g_to_func(frameEl);
+        var {{ rect, overlay }} = getGroupRectangles(frameEl);
+        var re = currentSearchTerm ? new RegExp(currentSearchTerm, ignorecase ? 'i' : '') : null;
+        if (re && func.match(re)) {{
+            if (isDiff) {{
+                if (overlay) {{
+                    overlay.attributes.fill.value = "{Colors.RGBsearch}";
+                }} else {{
+                    rect.attributes.fill.value = "{Colors.RGBsearch}";
+                }}
+            }} else {{
+                rect.attributes.fill.value = "{Colors.RGBsearch}";
+                if (overlay) {{
+                    overlay.attributes.fill.value = "{Colors.RGBsearchOverlay}";
+                }}
+            }}
+        }} else {{
+            if (overlay) {{
+                orig_load(overlay, "fill");
+                if (!isDiff) {{
+                    rect.setAttribute("fill", "white");
+                }} else {{
+                    orig_load(rect, "fill");
+                }}
+            }} else {{
+                orig_load(rect, "fill");
+            }}
+        }}
+    }}
+    function clear_hover_highlights() {{
+        var el = document.getElementById("frames").children;
+        for (var i = 0; i < el.length; i++) {{
+            var {{ rect, overlay }} = getGroupRectangles(el[i]);
+            if (is_hover_highlighted(rect, overlay)) {{
+                restore_frame_after_hover(el[i]);
+            }}
+        }}
     }}
     function orig_save(e, attr, val) {{
         if (e.attributes["_orig_" + attr] != undefined) return;
@@ -1947,37 +2003,7 @@ def create_svg_js_css(
     }}
 
     function reset_search_hover() {{
-        var el = document.getElementById("frames").children;
-        var re = new RegExp(currentSearchTerm, ignorecase ? 'i' : '');
-        for (var i = 0; i < el.length; i++) {{
-            var func = g_to_func(el[i]);
-            var {{ rect, overlay }} = getGroupRectangles(el[i]);
-            if (rect.getAttribute("fill") != "{Colors.RGBhover}" && (!overlay || overlay.getAttribute("fill") != "{Colors.RGBhover}")) continue;
-
-            if (func.match(re)) {{
-                if (isDiff) {{
-                    if (overlay) {{
-                        overlay.attributes.fill.value = "{Colors.RGBsearch}";
-                    }} else {{
-                        rect.attributes.fill.value = "{Colors.RGBsearch}";
-                    }}
-                }} else {{
-                    rect.attributes.fill.value = "{Colors.RGBsearch}";
-                    if (overlay) {{
-                        overlay.attributes.fill.value = "{Colors.RGBsearchOverlay}";
-                    }}
-                }}
-            }} else {{
-                if (overlay) {{
-                    orig_load(overlay, "fill");
-                    if (!isDiff) {{
-                        rect.setAttribute("fill", "white");
-                    }}
-                }} else {{
-                    orig_load(rect, "fill");
-                }}
-            }}
-        }}
+        clear_hover_highlights();
         hoverSearchTerm = null;
         if (!searching) {{
             inclusiveLabel.classList.add("hide");
@@ -2019,12 +2045,12 @@ def create_svg_js_css(
         matchedSearchIncl.nodeValue = matched.totalInclSamples + " {settings.count_name}, " + matched.pct + "%";
         matchedSearchExcl.nodeValue = matched.totalExclSamples + " {settings.count_name}, " + matched.pct_excl + "%";
     }}
-    function search_hover(term) {{
+    function apply_hover_highlight(term) {{
         if (term) hoverSearchTerm = term;
-
-        var res = find_frames(term, true);
-
-        // display matched percent
+        return find_frames(term, true);
+    }}
+    function search_hover_show_stats(res) {{
+        if (!res) return;
         var matched = calculate_matched(res.matches, res.maxwidth);
         inclusiveLabel.classList.remove("hide");
         exclusiveLabel.classList.remove("hide");
@@ -2032,6 +2058,10 @@ def create_svg_js_css(
         matchedHoverCount.nodeValue = matched.count;
         matchedHoverIncl.nodeValue = matched.totalInclSamples + " {settings.count_name}, " + matched.pct + "%";
         matchedHoverExcl.nodeValue = matched.totalExclSamples + " {settings.count_name}, " + matched.pct_excl + "%";
+    }}
+    function search_hover(term) {{
+        clear_hover_highlights();
+        search_hover_show_stats(apply_hover_highlight(term));
     }}
     // The func_expr may be either a regex or a simple string
     function find_frames(func_expr, is_hover) {{

--- a/perun/templates/scripts/flame_graph_js.html.jinja2
+++ b/perun/templates/scripts/flame_graph_js.html.jinja2
@@ -43,33 +43,140 @@
                     }});
             }
 
-            ["lhs", "rhs", "lhs_diff", "rhs_diff"].forEach(type => {
-                document.querySelectorAll(`#${type}_{{ index }}_frames g`).forEach(node => {
-                    node.addEventListener("mouseenter", function () {
-                        const textElement = node.querySelector("title");
+            const LINKED_FLAMEGRAPH_TYPES = ["lhs", "rhs", "lhs_diff", "rhs_diff"];
+            const linkedHoverState = {
+                term: null,
+                sourceType: null,
+                leaveTimer: null,
+            };
 
-                        if (textElement && textElement.innerHTML) {
-                            {% if use_perl %}
-                            let searchTerm = cleanTitlePerl(textElement.innerHTML);
-                            {% else %}
-                            let searchTerm = cleanTitlePython(textElement.innerHTML);
-                            {% endif %}
-
-                            window[`lhs_{{index}}_search_hover`](searchTerm);
-                            window[`rhs_{{index}}_search_hover`](searchTerm);
-                            window[`lhs_diff_{{index}}_search_hover`](searchTerm);
-                            window[`rhs_diff_{{index}}_search_hover`](searchTerm);
+            function findLinkedFlamegraphHit(target) {
+                let node = target;
+                while (node && node.parentElement) {
+                    for (const type of LINKED_FLAMEGRAPH_TYPES) {
+                        if (node.parentElement.id === `${type}_0_frames`) {
+                            const title = node.querySelector("title");
+                            if (!title || !title.innerHTML) {
+                                return null;
+                            }
+                            return { type, group: node, title };
                         }
-                    });
+                    }
+                    node = node.parentElement;
+                }
+                return null;
+            }
 
-                    node.addEventListener("mouseleave", function () {
-                        window[`lhs_{{index}}_reset_search_hover`]();
-                        window[`rhs_{{index}}_reset_search_hover`]();
-                        window[`lhs_diff_{{index}}_reset_search_hover`]();
-                        window[`rhs_diff_{{index}}_reset_search_hover`]();
+            function linkedResetSearchHoverAll() {
+                LINKED_FLAMEGRAPH_TYPES.forEach(function (type) {
+                    const fn = window[`${type}_0_reset_search_hover`];
+                    if (typeof fn === "function") {
+                        fn();
+                    }
+                });
+                linkedHoverState.term = null;
+                linkedHoverState.sourceType = null;
+            }
+
+            function linkedApplyHover(searchTerm, sourceType) {
+                if (
+                    searchTerm === linkedHoverState.term &&
+                    sourceType === linkedHoverState.sourceType
+                ) {
+                    return;
+                }
+
+                LINKED_FLAMEGRAPH_TYPES.forEach(function (type) {
+                    const fn = window[`${type}_0_reset_search_hover`];
+                    if (typeof fn === "function") {
+                        fn();
+                    }
+                });
+
+                if (!searchTerm) {
+                    linkedHoverState.term = null;
+                    linkedHoverState.sourceType = null;
+                    return;
+                }
+
+                linkedHoverState.term = searchTerm;
+                linkedHoverState.sourceType = sourceType;
+
+                LINKED_FLAMEGRAPH_TYPES.forEach(function (type) {
+                    const highlightFn = window[`${type}_0_apply_hover_highlight`];
+                    const statsFn = window[`${type}_0_search_hover_show_stats`];
+                    if (typeof highlightFn !== "function") {
+                        return;
+                    }
+                    const res = highlightFn(searchTerm);
+                    if (typeof statsFn === "function") {
+                        statsFn(res);
+                    }
+                });
+            }
+
+            function cancelLinkedHoverLeave() {
+                if (linkedHoverState.leaveTimer !== null) {
+                    clearTimeout(linkedHoverState.leaveTimer);
+                    linkedHoverState.leaveTimer = null;
+                }
+            }
+
+            function isPointerOverLinkedFrame(clientX, clientY) {
+                const el = document.elementFromPoint(clientX, clientY);
+                if (!el) {
+                    return false;
+                }
+                return findLinkedFlamegraphHit(el) !== null;
+            }
+
+            function scheduleLinkedHoverLeave(clientX, clientY) {
+                cancelLinkedHoverLeave();
+                linkedHoverState.leaveTimer = setTimeout(function () {
+                    linkedHoverState.leaveTimer = null;
+                    if (!isPointerOverLinkedFrame(clientX, clientY)) {
+                        linkedResetSearchHoverAll();
+                    }
+                }, 0);
+            }
+
+            const flameSection = document.getElementById("flame");
+            if (flameSection) {
+                flameSection.addEventListener("mouseover", function (e) {
+                    const hit = findLinkedFlamegraphHit(e.target);
+                    cancelLinkedHoverLeave();
+                    if (!hit) {
+                        if (linkedHoverState.term !== null) {
+                            linkedResetSearchHoverAll();
+                        }
+                        return;
+                    }
+                    linkedApplyHover(
+                        cleanTitlePython(hit.title.innerHTML),
+                        hit.type
+                    );
+                });
+
+                flameSection.addEventListener("mouseout", function (e) {
+                    if (e.relatedTarget && flameSection.contains(e.relatedTarget)) {
+                        return;
+                    }
+                    scheduleLinkedHoverLeave(e.clientX, e.clientY);
+                });
+
+                LINKED_FLAMEGRAPH_TYPES.forEach(function (type) {
+                    const framesEl = document.getElementById(`${type}_0_frames`);
+                    if (!framesEl) {
+                        return;
+                    }
+                    framesEl.addEventListener("mouseleave", function (e) {
+                        if (e.relatedTarget && framesEl.contains(e.relatedTarget)) {
+                            return;
+                        }
+                        scheduleLinkedHoverLeave(e.clientX, e.clientY);
                     });
                 });
-            });
+            }
 
         {% endfor%}
 

--- a/perun/templates/scripts/tree_map_js.html.jinja2
+++ b/perun/templates/scripts/tree_map_js.html.jinja2
@@ -71,7 +71,7 @@
     const panelLeavesRegistry = new Map();
     let parsedDataCache = null;
     let activeHoverUid = null;
-    let hoverClearFrame = null;
+    let treemapHoverLeaveTimer = null;
     let globalHighlight = "none";
 
     // --- Shared helpers ---
@@ -129,10 +129,10 @@
         return GRID_PANELS.every(({ panelId }) => getPanel(panelId).metric === metric);
     }
 
-    function cancelPendingHoverClear() {
-        if (hoverClearFrame !== null) {
-            cancelAnimationFrame(hoverClearFrame);
-            hoverClearFrame = null;
+    function cancelTreemapHoverLeave() {
+        if (treemapHoverLeaveTimer !== null) {
+            clearTimeout(treemapHoverLeaveTimer);
+            treemapHoverLeaveTimer = null;
         }
     }
 
@@ -143,7 +143,7 @@
         panelLeavesRegistry.clear();
         parsedDataCache = null;
         activeHoverUid = null;
-        cancelPendingHoverClear();
+        cancelTreemapHoverLeave();
     }
 
     function buildPanelRegex(panelId) {
@@ -435,11 +435,63 @@
         }
     }
 
-    function isAnyRectHoveredForUid(uid) {
-        return [...document.querySelectorAll(".leaf rect:hover")].some(
-            (el) => el.getAttribute("data-uid") === uid
-        );
+    function findTreemapLeafUid(target) {
+        const chartGrid = document.getElementById("treemaps");
+        let node = target;
+        while (node && node !== chartGrid) {
+            if (node.nodeName === "rect" && node.hasAttribute("data-uid")) {
+                return node.getAttribute("data-uid");
+            }
+            if (node.classList && node.classList.contains("leaf")) {
+                const rect = node.querySelector("rect[data-uid]");
+                if (rect) {
+                    return rect.getAttribute("data-uid");
+                }
+            }
+            node = node.parentElement;
+        }
+        return null;
     }
+    function uidUnderPointer(clientX, clientY) {
+        const el = document.elementFromPoint(clientX, clientY);
+        if (!el) {
+            return null;
+        }
+        return findTreemapLeafUid(el);
+    }
+    function scheduleTreemapHoverLeave(clientX, clientY) {
+        cancelTreemapHoverLeave();
+        treemapHoverLeaveTimer = setTimeout(function () {
+            treemapHoverLeaveTimer = null;
+            if (activeHoverUid === null) {
+                return;
+            }
+            if (uidUnderPointer(clientX, clientY) === activeHoverUid) {
+                return;
+            }
+            flushActiveHover();
+        }, 0);
+    }
+    function initTreemapHoverDelegation(chartGrid) {
+        chartGrid.addEventListener("mouseover", function (e) {
+            const uid = findTreemapLeafUid(e.target);
+            cancelTreemapHoverLeave();
+            if (uid) {
+                enterHover(uid);
+                return;
+            }
+            if (activeHoverUid !== null) {
+                scheduleTreemapHoverLeave(e.clientX, e.clientY);
+            }
+        });
+        chartGrid.addEventListener("mouseout", function (e) {
+            if (e.relatedTarget && chartGrid.contains(e.relatedTarget)) {
+                return;
+            }
+            scheduleTreemapHoverLeave(e.clientX, e.clientY);
+        });
+    }
+
 
     function onHoverEnd() {
         if (!anyPanelSearchActive() && !anyPanelHighlightActive()) {
@@ -458,35 +510,25 @@
         });
     }
 
-    function enterHover(uid) {
-        cancelPendingHoverClear();
+    function applyLinkedHover(uid) {
         if (activeHoverUid !== null && activeHoverUid !== uid) {
             setLinkedHover(activeHoverUid, false);
         }
         activeHoverUid = uid;
         setLinkedHover(uid, true);
+    }
+
+    function enterHover(uid) {
+        cancelTreemapHoverLeave();
+        if (activeHoverUid === uid) {
+            return;
+        }
+        applyLinkedHover(uid);
         showStatusForUid(uid);
     }
 
-    function leaveHover(uid) {
-        cancelPendingHoverClear();
-        const leavingUid = uid;
-        hoverClearFrame = requestAnimationFrame(() => {
-            hoverClearFrame = null;
-            if (activeHoverUid !== leavingUid) {
-                return;
-            }
-            if (isAnyRectHoveredForUid(leavingUid)) {
-                return;
-            }
-            activeHoverUid = null;
-            setLinkedHover(leavingUid, false);
-            onHoverEnd();
-        });
-    }
-
     function flushActiveHover() {
-        cancelPendingHoverClear();
+        cancelTreemapHoverLeave();
         if (activeHoverUid === null) {
             return;
         }
@@ -662,9 +704,13 @@
             setStatusLabelsVisible(panelId, true);
             const titleText = findLeafTitle(panelId, uid);
             if (titleText) {
+                setStatusLabelsVisible(panelId, true);
                 updatePanelDetails(panelId, titleText);
             } else {
                 clearPanelDetails(panelId);
+                if (!isPanelSearchActive(panelId) && !isPanelHighlightActive(panelId)) {
+                    setStatusLabelsVisible(panelId, false);
+                }
             }
         });
     }
@@ -910,14 +956,6 @@
             appendCenteredTileLabels(g, w, h, lines, fontSize);
         });
 
-        leaves.select("rect")
-            .on("mouseenter", function (event, d) {
-                enterHover(d.data.uid);
-            })
-            .on("mouseleave", function (event, d) {
-                leaveHover(d.data.uid);
-            });
-
         panelLeavesRegistry.set(
             panelId,
             root.leaves().map((d) => {
@@ -1159,12 +1197,7 @@
             handlePanelControlClick(e.target.id || "");
         });
 
-        chartGrid.addEventListener("mouseleave", (e) => {
-            const related = e.relatedTarget;
-            if (!related || !chartGrid.contains(related)) {
-                flushActiveHover();
-            }
-        });
+        initTreemapHoverDelegation(chartGrid);
 
         document.getElementById("treemap_search_reset_all").addEventListener("click", globalSearchReset);
         {% if is_folded %}

--- a/perun/templates/style/graph_grids.css
+++ b/perun/templates/style/graph_grids.css
@@ -95,3 +95,12 @@
 .panel-drag-active .grid-svg-container svg {
     pointer-events: none;
 }
+
+#flame,
+#flame .comparison_container,
+#flame .grid-svg-container,
+#treemaps,
+#treemaps .comparison_container,
+#treemaps .grid-svg-container {
+    overflow-anchor: none;
+}

--- a/perun/view_diff/flamegraph.py
+++ b/perun/view_diff/flamegraph.py
@@ -85,6 +85,12 @@ def escape_content(tag: str, content: str) -> str:
         r"(?<!\w)(toggleExclusive)\(",
         r"(?<!\w)(removeExclusiveView)\(",
         r"(?<!\w)(updateExclusiveView)\(",
+        r"(?<!\w)(is_event_still_in_group)\(",
+        r"(?<!\w)(is_hover_highlighted)\(",
+        r"(?<!\w)(restore_frame_after_hover)\(",
+        r"(?<!\w)(clear_hover_highlights)\(",
+        r"(?<!\w)(apply_hover_highlight)\(",
+        r"(?<!\w)(search_hover_show_stats)\(",
     ]
     other = [
         (r"\"search\"", f'"{tag}_search"'),


### PR DESCRIPTION
Both flame graph and tree map grids caused window scroll flicker in Google Chrome due to incorrect handling of simultaneous hover events over all 4 panels in grids.

This PR fixes the issue.