### PR TITLE
Release version 0.27.3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@ Changelog
 =========
 
 
+0.27.3 (2026-06-03)
+-------------------
+
+  - Perun reports now have a per-function tree map grid complementing the flame graph grid.
+  - Fixed flame graph and tree map flickering in Google Chrome.
+
+
 0.27.2 (2026-05-23)
 -------------------
 

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
     'perun',
     'c',
-    version: '0.27.2',
+    version: '0.27.3',
     license: 'GPL-3',
     meson_version: '>=1.0.0',
     default_options: [


### PR DESCRIPTION
Changelog:

- Perun reports now have a per-function tree map grid complementing the flame graph grid.
- Fixed flame graph and tree map flickering in Google Chrome.