### PR TITLE
Release Perun v0.27.4

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,14 @@ Changelog
 =========
 
 
+0.27.4 (2026-07-04)
+-------------------
+
+  - Added a static favicon to HTML reports.
+  - The traces detail pop-up now visualizes the call stack.
+  - The top function names in overview are now clickable and show a traces detail.
+
+
 0.27.3 (2026-06-03)
 -------------------
 

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
     'perun',
     'c',
-    version: '0.27.3',
+    version: '0.27.4',
     license: 'GPL-3',
     meson_version: '>=1.0.0',
     default_options: [


### PR DESCRIPTION
Changelog:

  - Added a static favicon to HTML reports.
  - The traces detail pop-up now visualizes the call stack.
  - The top function names in overview are now clickable and show a traces detail.